### PR TITLE
Support custom logging via TOML

### DIFF
--- a/.changes/unreleased/Added-20230625-180350.yaml
+++ b/.changes/unreleased/Added-20230625-180350.yaml
@@ -1,0 +1,4 @@
+kind: Added
+body: Support for setting logging level from TOML input. error, warn, info, debug
+  are supported
+time: 2023-06-25T18:03:50.670251-04:00

--- a/artemis-core/src/artifacts/applications/artifacts.rs
+++ b/artemis-core/src/artifacts/applications/artifacts.rs
@@ -263,6 +263,7 @@ mod tests {
             output: output.to_string(),
             filter_name: Some(String::new()),
             filter_script: Some(String::new()),
+            logging: Some(String::new()),
         }
     }
 

--- a/artemis-core/src/artifacts/os/files/filelisting.rs
+++ b/artemis-core/src/artifacts/os/files/filelisting.rs
@@ -354,6 +354,7 @@ mod tests {
             output: output.to_string(),
             filter_name: Some(String::new()),
             filter_script: Some(String::new()),
+            logging: Some(String::new()),
         }
     }
 

--- a/artemis-core/src/artifacts/os/linux/artifacts.rs
+++ b/artemis-core/src/artifacts/os/linux/artifacts.rs
@@ -175,6 +175,7 @@ mod tests {
             output: output.to_string(),
             filter_name: Some(String::new()),
             filter_script: Some(String::new()),
+            logging: Some(String::new()),
         }
     }
 

--- a/artemis-core/src/artifacts/os/macos/artifacts.rs
+++ b/artemis-core/src/artifacts/os/macos/artifacts.rs
@@ -377,6 +377,7 @@ mod tests {
             output: output.to_string(),
             filter_name: Some(String::new()),
             filter_script: Some(String::new()),
+            logging: Some(String::new()),
         }
     }
 

--- a/artemis-core/src/artifacts/os/macos/unified_logs/logs.rs
+++ b/artemis-core/src/artifacts/os/macos/unified_logs/logs.rs
@@ -212,6 +212,7 @@ mod tests {
             output: output.to_string(),
             filter_name: Some(String::new()),
             filter_script: Some(String::new()),
+            logging: Some(String::new()),
         }
     }
 

--- a/artemis-core/src/artifacts/os/unix/artifacts.rs
+++ b/artemis-core/src/artifacts/os/unix/artifacts.rs
@@ -195,6 +195,7 @@ mod tests {
             output: output.to_string(),
             filter_name: Some(String::new()),
             filter_script: Some(String::new()),
+            logging: Some(String::new()),
         }
     }
 

--- a/artemis-core/src/core.rs
+++ b/artemis-core/src/core.rs
@@ -51,8 +51,8 @@ pub fn parse_toml_data(data: &[u8]) -> Result<(), TomlError> {
 
 /// Based on target system collect data based on TOML config
 fn toml_data(os_target: &ArtemisToml, toml_data: &[u8]) -> Result<(), TomlError> {
-    if let Ok(log_file) = create_log_file(&os_target.output) {
-        let _ = WriteLogger::init(log::LevelFilter::Warn, Config::default(), log_file);
+    if let Ok((log_file, level)) = create_log_file(&os_target.output) {
+        let _ = WriteLogger::init(level, Config::default(), log_file);
     }
 
     if os_target.system == "macos" {
@@ -169,6 +169,7 @@ mod tests {
                 output: String::from("local"),
                 filter_name: Some(String::new()),
                 filter_script: Some(String::new()),
+                logging: Some(String::new()),
             },
             artifacts: Vec::new(),
         };

--- a/artemis-core/src/output/formats/json.rs
+++ b/artemis-core/src/output/formats/json.rs
@@ -99,6 +99,7 @@ mod tests {
             output: String::from("json"),
             filter_name: Some(String::new()),
             filter_script: Some(String::new()),
+            logging: Some(String::new()),
         };
         let start_time = time_now();
 

--- a/artemis-core/src/output/formats/jsonl.rs
+++ b/artemis-core/src/output/formats/jsonl.rs
@@ -196,6 +196,7 @@ mod tests {
             output: String::from("json"),
             filter_name: Some(String::new()),
             filter_script: Some(String::new()),
+            logging: Some(String::new()),
         };
         let start_time = time_now();
 
@@ -227,6 +228,7 @@ mod tests {
             output: String::from("json"),
             filter_name: Some(String::new()),
             filter_script: Some(String::new()),
+            logging: Some(String::new()),
         };
 
         let uuid = generate_uuid();
@@ -261,6 +263,7 @@ mod tests {
             output: String::from("json"),
             filter_name: Some(String::new()),
             filter_script: Some(String::new()),
+            logging: Some(String::new()),
         };
 
         let uuid = generate_uuid();
@@ -297,6 +300,7 @@ mod tests {
             output: String::from("json"),
             filter_name: Some(String::new()),
             filter_script: Some(String::new()),
+            logging: Some(String::new()),
         };
 
         let name = "test";

--- a/artemis-core/src/output/local/output.rs
+++ b/artemis-core/src/output/local/output.rs
@@ -66,6 +66,7 @@ mod tests {
             output: String::from("local"),
             filter_name: Some(String::new()),
             filter_script: Some(String::new()),
+            logging: Some(String::new()),
         };
 
         let test = "A rust program";
@@ -89,6 +90,7 @@ mod tests {
             output: String::from("local"),
             filter_name: Some(String::new()),
             filter_script: Some(String::new()),
+            logging: Some(String::new()),
         };
 
         let test = "A rust program";

--- a/artemis-core/src/output/remote/aws.rs
+++ b/artemis-core/src/output/remote/aws.rs
@@ -474,6 +474,7 @@ mod tests {
             output: output.to_string(),
             filter_name: Some(String::new()),
             filter_script: Some(String::new()),
+logging: Some(String::new())
         }
     }
 

--- a/artemis-core/src/output/remote/azure.rs
+++ b/artemis-core/src/output/remote/azure.rs
@@ -113,6 +113,7 @@ mod tests {
             output: output.to_string(),
             filter_name: Some(String::new()),
             filter_script: Some(String::new()),
+            logging: Some(String::new()),
         }
     }
 

--- a/artemis-core/src/output/remote/gcp.rs
+++ b/artemis-core/src/output/remote/gcp.rs
@@ -363,6 +363,7 @@ mod tests {
             output: output.to_string(),
             filter_name: Some(String::new()),
             filter_script: Some(String::new()),
+logging: Some(String::new())
         }
     }
 
@@ -544,6 +545,7 @@ mod tests {
             output: String::from("local"),
             filter_name: Some(String::new()),
             filter_script: Some(String::new()),
+logging: Some(String::new())
         };
 
         let test = "A rust program";

--- a/artemis-core/src/runtime/applications/chromium.rs
+++ b/artemis-core/src/runtime/applications/chromium.rs
@@ -85,6 +85,7 @@ mod tests {
             output: output.to_string(),
             filter_name: Some(String::new()),
             filter_script: Some(String::new()),
+            logging: Some(String::new()),
         }
     }
 

--- a/artemis-core/src/runtime/applications/firefox.rs
+++ b/artemis-core/src/runtime/applications/firefox.rs
@@ -85,6 +85,7 @@ mod tests {
             output: output.to_string(),
             filter_name: Some(String::new()),
             filter_script: Some(String::new()),
+            logging: Some(String::new()),
         }
     }
 

--- a/artemis-core/src/runtime/deno.rs
+++ b/artemis-core/src/runtime/deno.rs
@@ -112,6 +112,7 @@ mod tests {
             output: output.to_string(),
             filter_name: Some(String::new()),
             filter_script: Some(String::new()),
+            logging: Some(String::new()),
         }
     }
 

--- a/artemis-core/src/runtime/macos/accounts.rs
+++ b/artemis-core/src/runtime/macos/accounts.rs
@@ -39,6 +39,7 @@ mod tests {
             output: output.to_string(),
             filter_name: Some(String::new()),
             filter_script: Some(String::new()),
+            logging: Some(String::new()),
         }
     }
 

--- a/artemis-core/src/runtime/macos/emond.rs
+++ b/artemis-core/src/runtime/macos/emond.rs
@@ -39,6 +39,7 @@ mod tests {
             output: output.to_string(),
             filter_name: Some(String::new()),
             filter_script: Some(String::new()),
+            logging: Some(String::new()),
         }
     }
 

--- a/artemis-core/src/runtime/macos/fsevents.rs
+++ b/artemis-core/src/runtime/macos/fsevents.rs
@@ -39,6 +39,7 @@ mod tests {
             output: output.to_string(),
             filter_name: Some(String::new()),
             filter_script: Some(String::new()),
+            logging: Some(String::new()),
         }
     }
 

--- a/artemis-core/src/runtime/macos/launchd.rs
+++ b/artemis-core/src/runtime/macos/launchd.rs
@@ -57,6 +57,7 @@ mod tests {
             output: output.to_string(),
             filter_name: Some(String::new()),
             filter_script: Some(String::new()),
+            logging: Some(String::new()),
         }
     }
 

--- a/artemis-core/src/runtime/macos/loginitems.rs
+++ b/artemis-core/src/runtime/macos/loginitems.rs
@@ -41,6 +41,7 @@ mod tests {
             output: output.to_string(),
             filter_name: Some(String::new()),
             filter_script: Some(String::new()),
+            logging: Some(String::new()),
         }
     }
 

--- a/artemis-core/src/runtime/macos/macho.rs
+++ b/artemis-core/src/runtime/macos/macho.rs
@@ -41,6 +41,7 @@ mod tests {
             output: output.to_string(),
             filter_name: Some(String::new()),
             filter_script: Some(String::new()),
+            logging: Some(String::new()),
         }
     }
 

--- a/artemis-core/src/runtime/macos/plist.rs
+++ b/artemis-core/src/runtime/macos/plist.rs
@@ -42,6 +42,7 @@ mod tests {
             output: output.to_string(),
             filter_name: Some(String::new()),
             filter_script: Some(String::new()),
+            logging: Some(String::new()),
         }
     }
 

--- a/artemis-core/src/runtime/macos/processes.rs
+++ b/artemis-core/src/runtime/macos/processes.rs
@@ -40,14 +40,13 @@ mod tests {
             format: String::from("json"),
             compress,
             url: Some(String::new()),
-
             api_key: Some(String::new()),
-
             endpoint_id: String::from("abcd"),
             collection_id: 0,
             output: output.to_string(),
             filter_name: None,
             filter_script: None,
+            logging: None,
         }
     }
 

--- a/artemis-core/src/runtime/macos/safari.rs
+++ b/artemis-core/src/runtime/macos/safari.rs
@@ -87,6 +87,7 @@ mod tests {
             output: output.to_string(),
             filter_name: Some(String::new()),
             filter_script: Some(String::new()),
+            logging: Some(String::new()),
         }
     }
 

--- a/artemis-core/src/runtime/macos/unifiedlogs.rs
+++ b/artemis-core/src/runtime/macos/unifiedlogs.rs
@@ -104,6 +104,7 @@ mod tests {
             output: output.to_string(),
             filter_name: Some(String::new()),
             filter_script: Some(String::new()),
+            logging: Some(String::new()),
         }
     }
 

--- a/artemis-core/src/runtime/unix/cron.rs
+++ b/artemis-core/src/runtime/unix/cron.rs
@@ -37,6 +37,7 @@ mod tests {
             output: output.to_string(),
             filter_name: Some(String::new()),
             filter_script: Some(String::new()),
+            logging: Some(String::new()),
         }
     }
 

--- a/artemis-core/src/runtime/unix/shellhistory.rs
+++ b/artemis-core/src/runtime/unix/shellhistory.rs
@@ -74,6 +74,7 @@ mod tests {
             output: output.to_string(),
             filter_name: Some(String::new()),
             filter_script: Some(String::new()),
+            logging: Some(String::new()),
         }
     }
     #[test]

--- a/artemis-core/src/utils/artemis_toml.rs
+++ b/artemis-core/src/utils/artemis_toml.rs
@@ -38,6 +38,7 @@ pub(crate) struct Output {
     pub(crate) filter_script: Option<String>,
     pub(crate) url: Option<String>,
     pub(crate) api_key: Option<String>,
+    pub(crate) logging: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/artemis-core/src/utils/output.rs
+++ b/artemis-core/src/utils/output.rs
@@ -135,6 +135,7 @@ mod tests {
             output: String::from("local"),
             filter_name: Some(String::new()),
             filter_script: Some(String::new()),
+            logging: Some(String::new()),
         };
 
         let test = "A rust program";
@@ -160,6 +161,7 @@ mod tests {
             output: String::from("local"),
             filter_name: Some(String::new()),
             filter_script: Some(String::new()),
+            logging: Some(String::new()),
         };
 
         let _ = compress_final_output(&output);


### PR DESCRIPTION
This PR adds support for allowing a user to set the logging level via TOML. 
The supported log types are:

- warn
- error
- info
- debug

The default is warn. If an unsupported log type is provided then warn is used.