### PR TITLE
Registry fixes and JavaScript file support

### DIFF
--- a/.changes/unreleased/Added-20230805-213422.yaml
+++ b/.changes/unreleased/Added-20230805-213422.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Support for executing JavaScript file directly
+time: 2023-08-05T21:34:22.815465-04:00

--- a/.changes/unreleased/Fixed-20230804-222815.yaml
+++ b/.changes/unreleased/Fixed-20230804-222815.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: String extraction on UTF16 vs UTF8 (ASCII) Registry values
+time: 2023-08-04T22:28:15.6459331-04:00

--- a/.changes/unreleased/Fixed-20230804-222940.yaml
+++ b/.changes/unreleased/Fixed-20230804-222940.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Bug when extracting BigData cells and multiString value data from Regsitry
+time: 2023-08-04T22:29:40.397284-04:00

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,7 +329,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -594,7 +594,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -771,7 +771,7 @@ checksum = "3c65c2ffdafc1564565200967edc4851c7b55422d3913466688907efd05ea26f"
 dependencies = [
  "deno-proc-macro-rules-macros",
  "proc-macro2",
- "syn 2.0.18",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -783,14 +783,14 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.28",
 ]
 
 [[package]]
 name = "deno_core"
-version = "0.197.0"
+version = "0.200.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efdf066ffb540f889e481c4f1cdbb7bc202a7af937e7c435234586395e533976"
+checksum = "a8ba264b90ceb6e95b39d82e674d8ecae86ca012f900338ea50d1a077d9d75fd"
 dependencies = [
  "anyhow",
  "bytes",
@@ -814,9 +814,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.75.0"
+version = "0.78.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba2d2ca95637f48ba885bfa78cf3b962aa6752e4bb0bacda438e024a4b6b3b69"
+checksum = "ffd1c83b1fd465ee0156f2917c9af9ca09fe2bf54052a2cae1a8dcbc7b89aefc"
 dependencies = [
  "deno-proc-macro-rules",
  "lazy-regex",
@@ -829,9 +829,8 @@ dependencies = [
  "strum",
  "strum_macros 0.25.1",
  "syn 1.0.109",
- "syn 2.0.18",
+ "syn 2.0.28",
  "thiserror",
- "v8",
 ]
 
 [[package]]
@@ -899,7 +898,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1004,7 +1003,7 @@ checksum = "48016319042fb7c87b78d2993084a831793a897a5cd1a2a67cab9d1eeb4b7d76"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1231,7 +1230,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2121,7 +2120,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2241,7 +2240,7 @@ checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2284,7 +2283,7 @@ checksum = "52a40bc70c2c58040d2d8b167ba9a5ff59fc9dab7ad44771cfde3dcfde7a09c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2321,9 +2320,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.59"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
@@ -2460,9 +2459,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.1"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
+checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2472,9 +2471,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310"
+checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2718,9 +2717,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.164"
+version = "1.0.181"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
+checksum = "6d3e73c93c3240c0bda063c239298e633114c69a888c3e37ca8bb33f343e9890"
 dependencies = [
  "serde_derive",
 ]
@@ -2736,20 +2735,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.164"
+version = "1.0.181"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
+checksum = "be02f6cb0cd3a5ec20bbcfbcbd749f57daddb1a0882dc2e46a6c236c90b977ed"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.28",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.99"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46266871c240a00b8f503b877622fe33430b3c7d963bdc0f2adc511e54a1eae3"
+checksum = "076066c5f1078eac5b722a31827a8832fe108bed65dfa75e233c89f8206e976c"
 dependencies = [
  "indexmap 2.0.0",
  "itoa",
@@ -2790,9 +2789,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.108.0"
+version = "0.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1a26c89d56d8607d220c639e971e3e3901138fcc5dd0f619cee0868e1cc89e"
+checksum = "309b3060a9627882514f3a3ce3cc08ceb347a76aeeadc58f138c3f189cf88b71"
 dependencies = [
  "bytes",
  "derive_more",
@@ -2806,9 +2805,9 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -3009,7 +3008,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.18",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -3031,9 +3030,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.18"
+version = "2.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3042,9 +3041,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.29.6"
+version = "0.29.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7cb97a5a85a136d84e75d5c3cf89655090602efb1be0d8d5337b7e386af2908"
+checksum = "165d6d8539689e3d3bc8b98ac59541e1f21c7de7c85d60dc80e43ae0ed2113db"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -3125,7 +3124,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -3220,7 +3219,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -3308,7 +3307,7 @@ checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -3516,7 +3515,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.28",
  "wasm-bindgen-shared",
 ]
 
@@ -3550,7 +3549,7 @@ checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.28",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -564,9 +564,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.1"
+version = "4.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ed2379f8603fa2b7509891660e802b88c70a79a6427a70abb5968054de2c28"
+checksum = "5fd304a20bff958a57f04c4e96a2e7594cc4490a0e809cbd48bb6437edaa452d"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -575,22 +575,21 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.1"
+version = "4.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72394f3339a76daf211e57d4bcb374410f3965dcc606dd0e03738c7888766980"
+checksum = "01c6a3f08f1fe5662a35cfe393aec09c4df95f60ee93b7556505260f75eee9e1"
 dependencies = [
  "anstream",
  "anstyle",
- "bitflags 1.3.2",
  "clap_lex",
  "strsim",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.3.1"
+version = "4.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e9ef9a08ee1c0e1f2e162121665ac45ac3783b0f897db7244ae75ad9a8f65b"
+checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/artemis-core/Cargo.toml
+++ b/artemis-core/Cargo.toml
@@ -6,20 +6,20 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = {version="1.0.164", features = ["derive"]}
+serde = {version="1.0.181", features = ["derive"]}
 log = "0.4.19"
-serde_json = "1.0.99"
+serde_json = "1.0.104"
 toml = "0.7.6"
 base64 = "0.21.2"
 nom = "7.1.3"
 rusqlite = {version = "0.29.0", features = ["bundled"]}
 md-5 = "0.10.5"
-sha-1 = "0.10.0"
+sha-1 = "0.10.1"
 sha2 = "0.10.7"
-regex = "1.9.1"
+regex = "1.9.3"
 byteorder = "1.4.3"
 walkdir = "2.3.3"
-sysinfo = "0.29.6"
+sysinfo = "0.29.7"
 home = "0.5.5"
 uuid = {version = "1.4.1", features = ["v4"]}
 chrono = "0.4.26"
@@ -33,7 +33,7 @@ glob = "0.3.1"
 quick-xml = {version ="0.30.0", default-features = false, features = ["serialize"]}
 
 # Deno Runtime integration
-deno_core = {version = "0.197.0"}
+deno_core = {version = "0.200.0"}
 tokio = {version = "1.29.1"}
 
 # Windows Dependencies
@@ -57,7 +57,7 @@ plist = "1.5.0"
 
 # Dependencies at compile time
 [build-dependencies]
-deno_core = {version = "0.197.0"}
+deno_core = {version = "0.200.0"}
 
 # Dependencies for tests
 [dev-dependencies]

--- a/artemis-core/build.rs
+++ b/artemis-core/build.rs
@@ -6,15 +6,19 @@ use std::{env, path::PathBuf};
 
 /// Create a SnapShot at build time to help speed up our JavaScript Runtime
 fn main() {
-    let extensions = Extension::builder("artemis")
-        .esm(include_js_files!(artemis 
-            "javascript/console.js",
-            "javascript/filesystem.js",
-            "javascript/environment.js",
-            "javascript/encoding.js",
-            "javascript/main.js",))
-        .esm_entry_point("ext:artemis/javascript/main.js")
-        .build();
+    let extensions = Extension {
+        esm_files: include_js_files!(artemis 
+        "javascript/console.js",
+        "javascript/filesystem.js",
+        "javascript/environment.js",
+        "javascript/encoding.js",
+        "javascript/main.js",)
+        .to_vec()
+        .into(),
+        esm_entry_point: Some("ext:artemis/javascript/main.js"),
+        ..Default::default()
+    };
+
     // Build the file path to the snapshot.
     let out = PathBuf::from(env::var_os("OUT_DIR").unwrap());
     let snapshot_path = out.join("RUNJS_SNAPSHOT.bin");
@@ -27,7 +31,6 @@ fn main() {
             startup_snapshot: None,
             extensions: vec![extensions],
             compression_cb: None,
-            snapshot_module_load_cb: None,
             with_runtime_cb: Default::default(),
         },
     );

--- a/artemis-core/src/artifacts/os/windows/registry/keys/data.rs
+++ b/artemis-core/src/artifacts/os/windows/registry/keys/data.rs
@@ -133,8 +133,14 @@ fn check_big_data(
             // Check if we are at last big data entry
             // The last big data entry does not have to equal the max size (16344)
             if sizes_iter.peek().is_none() {
+                let end_string = 2;
                 // The final size should be the difference between the data size specified in the value key and our current data
-                let final_size = data_size as usize - binary_vec.len();
+                let final_size = if data_type == DataTypes::Binary {
+                    data_size as usize - binary_vec.len()
+                } else {
+                    (data_size as usize - start_size) + end_string
+                };
+
                 // Adjust the size based on final data size
                 let allocated_data = if final_size + start_size < large_data.len() {
                     &large_data[start_size..final_size + start_size]

--- a/artemis-core/src/artifacts/os/windows/search/ese.rs
+++ b/artemis-core/src/artifacts/os/windows/search/ese.rs
@@ -66,6 +66,7 @@ pub(crate) fn parse_search(
     Ok(())
 }
 
+/// Parse Windows `Search` at provided path
 pub(crate) fn parse_search_path(
     path: &str,
     tables: &[String],

--- a/artemis-core/src/error.rs
+++ b/artemis-core/src/error.rs
@@ -5,6 +5,7 @@ pub enum TomlError {
     NoFile,
     FailedToReadFile,
     BadToml,
+    BadJs,
 }
 
 impl std::error::Error for TomlError {}
@@ -15,6 +16,7 @@ impl fmt::Display for TomlError {
             TomlError::NoFile => write!(f, "Failed to read TOML file"),
             TomlError::FailedToReadFile => write!(f, "Failed to read TOML data"),
             TomlError::BadToml => write!(f, "Failed to parse TOML data"),
+            TomlError::BadJs => write!(f, "Failed run JavaScript code"),
         }
     }
 }

--- a/artemis-core/src/runtime/linux/extensions.rs
+++ b/artemis-core/src/runtime/linux/extensions.rs
@@ -9,7 +9,11 @@ use deno_core::{Extension, Op};
 
 /// Include all the `Artemis` function in the `Runtime`
 pub(crate) fn setup_extensions() -> Vec<Extension> {
-    let extensions = Extension::builder("artemis").ops(grab_functions()).build();
+    let extensions = Extension {
+        name: "artemis",
+        ops: grab_functions().into(),
+        ..Default::default()
+    };
     vec![extensions]
 }
 

--- a/artemis-core/src/runtime/macos/extensions.rs
+++ b/artemis-core/src/runtime/macos/extensions.rs
@@ -22,7 +22,11 @@ use deno_core::{Extension, Op};
 
 /// Include all the `Artemis` function in the `Runtime`
 pub(crate) fn setup_extensions() -> Vec<Extension> {
-    let extensions = Extension::builder("artemis").ops(grab_functions()).build();
+    let extensions = Extension {
+        name: "artemis",
+        ops: grab_functions().into(),
+        ..Default::default()
+    };
     vec![extensions]
 }
 

--- a/artemis-core/src/runtime/windows/extensions.rs
+++ b/artemis-core/src/runtime/windows/extensions.rs
@@ -27,7 +27,11 @@ use deno_core::{Extension, Op};
 
 /// Include all the `Artemis` function in the `Runtime`
 pub(crate) fn setup_extensions() -> Vec<Extension> {
-    let extensions = Extension::builder("artemis").ops(grab_functions()).build();
+    let extensions = Extension {
+        name: "artemis",
+        ops: grab_functions().into(),
+        ..Default::default()
+    };
     vec![extensions]
 }
 

--- a/artemis-core/src/utils/strings.rs
+++ b/artemis-core/src/utils/strings.rs
@@ -8,7 +8,18 @@ pub(crate) fn extract_utf16_string(data: &[u8]) -> String {
     let min_byte_size = 2;
     for wide_char in data.chunks(min_byte_size) {
         if wide_char == vec![0, 0] || wide_char.len() < min_byte_size {
+            // Check for last character
+            if !wide_char.is_empty() && !wide_char.contains(&0) {
+                utf16_data.push(wide_char[0] as u16);
+            }
             break;
+        }
+
+        // If Wide char does not contain 0, append separately
+        if !wide_char.contains(&0) {
+            utf16_data.push(wide_char[0] as u16);
+            utf16_data.push(wide_char[1] as u16);
+            continue;
         }
 
         utf16_data.push(u16::from_ne_bytes([wide_char[0], wide_char[1]]));
@@ -124,6 +135,15 @@ mod tests {
             0,
         ];
         assert_eq!(extract_utf16_string(&test_data), "OSQUERYD.EXE")
+    }
+
+    #[test]
+    fn test_extract_utf16_no_zeros() {
+        let test_data = vec![
+            75, 111, 110, 116, 114, 97, 115, 116, 32, 35, 49, 32, 40, 101, 120, 116, 114, 97, 103,
+            114, 111, 223, 41,
+        ];
+        assert_eq!(extract_utf16_string(&test_data), "Kontrast #1 (extragroß)")
     }
 
     #[test]

--- a/artemis-core/tests/test_data/deno_scripts/vanilla.js
+++ b/artemis-core/tests/test_data/deno_scripts/vanilla.js
@@ -1,0 +1,26 @@
+// https://raw.githubusercontent.com/puffycid/artemis-api/master/src/windows/processes.ts
+function getWinProcesses(md5, sha1, sha256, pe_info) {
+    const hashes = {
+      md5,
+      sha1,
+      sha256
+    };
+    const data = Deno.core.ops.get_processes(
+      JSON.stringify(hashes),
+      pe_info
+    );
+    const results = JSON.parse(data);
+    return results;
+  }
+  
+  // main.ts
+  function main() {
+    const md5 = false;
+    const sha1 = false;
+    const sha256 = false;
+    const pe_info = false;
+    const proc_list = getWinProcesses(md5, sha1, sha256, pe_info);
+    return proc_list;
+  }
+  main();
+  

--- a/artemis-core/tests/test_data/deno_scripts/vanilla.js
+++ b/artemis-core/tests/test_data/deno_scripts/vanilla.js
@@ -20,6 +20,7 @@ function getWinProcesses(md5, sha1, sha256, pe_info) {
     const sha256 = false;
     const pe_info = false;
     const proc_list = getWinProcesses(md5, sha1, sha256, pe_info);
+    console.log(proc_list[0].full_path);
     return proc_list;
   }
   main();

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -7,4 +7,4 @@ version = "0.1.0"
 base64 = "0.21.2"
 log = "0.4.19"
 artemis-core = {path = "../artemis-core"}
-clap = {version = "4.3.19", features = ["std", "help", "derive"]}
+clap = {version = "4.3.9", features = ["std", "help", "derive"]}

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2021"
 version = "0.1.0"
 
 [dependencies]
-base64 = "0.21.0"
-log = "0.4.17"
+base64 = "0.21.2"
+log = "0.4.19"
 artemis-core = {path = "../artemis-core"}
-clap = {version = "4.2.7", features = ["std", "help", "derive"]}
+clap = {version = "4.3.19", features = ["std", "help", "derive"]}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -5,13 +5,17 @@ use log::info;
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
 struct Args {
-    /// Full path tol TOML collector
+    /// Full path to TOML collector
     #[clap(short, long, value_parser)]
     toml: Option<String>,
 
     /// Base64 encoded TOML file
     #[clap(short, long, value_parser)]
-    data: Option<String>,
+    decode: Option<String>,
+
+    /// Full path to JavaScript file
+    #[clap(short, long, value_parser)]
+    javascript: Option<String>,
 }
 
 fn main() {
@@ -29,7 +33,7 @@ fn main() {
                 }
             }
         }
-    } else if let Some(data) = args.data {
+    } else if let Some(data) = args.decode {
         if !data.is_empty() {
             let toml_data_results = general_purpose::STANDARD.decode(&data);
             let toml_data = match toml_data_results {
@@ -50,8 +54,19 @@ fn main() {
                 }
             }
         }
+    } else if let Some(js) = args.javascript {
+        if !js.is_empty() {
+            let collection_results = artemis_core::core::parse_js_file(&js);
+            match collection_results {
+                Ok(_) => info!("[artemis] JavaScript execution success"),
+                Err(err) => {
+                    println!("[artemis] Failed to run JavaScript: {err:?}");
+                    return;
+                }
+            }
+        }
     } else {
-        println!("[artemis] No TOML file or data provided!");
+        println!("[artemis] No valid command args provided!");
         return;
     }
     println!("[artemis] Finished artemis collection!");


### PR DESCRIPTION
This PR adds a few fixes to parsing the Windows Registry.  
Also adds support for executing a JavaScript file directly with artemis

Ex: 
```
sudo ./artemis -j ../../artemis-core/tests/test_data/deno_scripts/vanilla.js
[artemis] Starting artemis collection!
[runtime]: "/usr/libexec/nesessionmanager"
[artemis] Finished artemis collection!
```