### PR TITLE
Security Key parsing support

### DIFF
--- a/.changes/unreleased/Added-20231105-002014.yaml
+++ b/.changes/unreleased/Added-20231105-002014.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Support for Registry Security Keys
+time: 2023-11-05T00:20:14.0246579-04:00

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,7 +178,7 @@ dependencies = [
  "simplelog",
  "sysinfo",
  "tokio",
- "toml 0.8.5",
+ "toml 0.8.6",
  "uuid",
  "walkdir",
  "xml2json-rs",
@@ -1018,16 +1018,16 @@ dependencies = [
 
 [[package]]
 name = "deno_core"
-version = "0.223.0"
+version = "0.225.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68c55228461e414205ff6eeabe4058dfe37d41663883d70e1809a84c1814288c"
+checksum = "68a284bcdd664d5dbbb8efce93b7822b9a0f125a1b53f0bc8edb876e4cee47ed"
 dependencies = [
  "anyhow",
  "bytes",
  "deno_ops",
  "deno_unsync",
  "futures",
- "indexmap 2.0.0",
+ "indexmap 2.1.0",
  "libc",
  "log",
  "once_cell",
@@ -1045,9 +1045,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.99.0"
+version = "0.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a755d96f9ccd44e4779d859ac1fc823be2b9c975821ac8b05b3e318bc5301aa8"
+checksum = "e1a813d4ea049601db9e5330c307b177c4f38e4baddf931c3c00c1a625b3dc1f"
 dependencies = [
  "deno-proc-macro-rules",
  "lazy-regex",
@@ -1074,9 +1074,12 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "derive-where"
@@ -1631,9 +1634,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
 dependencies = [
  "ahash",
  "allocator-api2",
@@ -1645,7 +1648,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
 dependencies = [
- "hashbrown 0.14.0",
+ "hashbrown 0.14.2",
 ]
 
 [[package]]
@@ -1837,12 +1840,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.2",
 ]
 
 [[package]]
@@ -2082,7 +2085,7 @@ dependencies = [
  "futures",
  "getrandom",
  "html-escape",
- "indexmap 2.0.0",
+ "indexmap 2.1.0",
  "itertools 0.10.5",
  "js-sys",
  "leptos_reactive",
@@ -2108,7 +2111,7 @@ checksum = "a6902fabee84955a85a6cdebf8ddfbfb134091087b172e32ebb26e571d4640ca"
 dependencies = [
  "anyhow",
  "camino",
- "indexmap 2.0.0",
+ "indexmap 2.1.0",
  "parking_lot",
  "proc-macro2",
  "quote",
@@ -2148,7 +2151,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b64d2b4bd0ab25a4897179ee603f2fa8178da6c9f97ef3efd4fa46580fd7efc1"
 dependencies = [
  "cfg-if",
- "indexmap 2.0.0",
+ "indexmap 2.1.0",
  "leptos",
  "tracing",
  "wasm-bindgen",
@@ -2164,7 +2167,7 @@ dependencies = [
  "base64",
  "cfg-if",
  "futures",
- "indexmap 2.0.0",
+ "indexmap 2.1.0",
  "js-sys",
  "paste",
  "pin-project",
@@ -2752,7 +2755,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.0.0",
+ "indexmap 2.1.0",
 ]
 
 [[package]]
@@ -2804,14 +2807,14 @@ checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "plist"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a4a0cfc5fb21a09dc6af4bf834cf10d4a32fccd9e2ea468c4b1751a097487aa"
+checksum = "e5699cc8a63d1aa2b1ee8e12b9ad70ac790d65788cd36101fa37f87ea46c4cef"
 dependencies = [
  "base64",
- "indexmap 1.9.3",
+ "indexmap 2.1.0",
  "line-wrap",
- "quick-xml 0.30.0",
+ "quick-xml 0.31.0",
  "serde",
  "time",
 ]
@@ -2870,6 +2873,12 @@ dependencies = [
  "pin-project-lite",
  "windows-sys",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -3493,11 +3502,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.107"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap 2.1.0",
  "itoa",
  "ryu",
  "serde",
@@ -3566,9 +3575,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.132.0"
+version = "0.134.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9378f2bc5e649f1cbc703ac75d90abe386f924d729215d95950f08c55dad4a8d"
+checksum = "b43265d540cbeb168d730b5df2069f8dfb9de318201f4e8f4f956876266432af"
 dependencies = [
  "bytes",
  "derive_more",
@@ -3595,7 +3604,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "toml 0.8.5",
+ "toml 0.8.6",
  "tower",
  "uuid",
 ]
@@ -4026,14 +4035,15 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f6bb557fd245c28e6411aa56b6403c689ad95061f50e4be16c274e70a17e48"
+checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
 dependencies = [
  "deranged",
  "itoa",
  "libc",
  "num_threads",
+ "powerfmt",
  "serde",
  "time-core",
  "time-macros",
@@ -4041,15 +4051,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a942f44339478ef67935ab2bbaec2fb0322496cf3cbe84b261e06ac3814c572"
+checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
 dependencies = [
  "time-core",
 ]
@@ -4165,14 +4175,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3efaf127c78d5339cc547cce4e4d973bd5e4f56e949a06d091c082ebeef2f800"
+checksum = "8ff9e3abce27ee2c9a37f9ad37238c1bdd4e789c84ba37df76aa4d528f5072cc"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.20.5",
+ "toml_edit 0.20.7",
 ]
 
 [[package]]
@@ -4190,18 +4200,18 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap 2.1.0",
  "toml_datetime",
  "winnow",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.20.5"
+version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "782bf6c2ddf761c1e7855405e8975472acf76f7f36d0d4328bd3b7a2fae12a85"
+checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap 2.1.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -4435,9 +4445,9 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "0.79.2"
+version = "0.81.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15561535230812a1db89a696f1f16a12ae6c2c370c6b2241c68d4cb33963faf"
+checksum = "b75f5f378b9b54aff3b10da8170d26af4cfd217f644cf671badcd13af5db4beb"
 dependencies = [
  "bitflags 1.3.2",
  "fslock",

--- a/artemis-core/Cargo.toml
+++ b/artemis-core/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 [dependencies]
 serde = { version = "1.0.190", features = ["derive"] }
 log = "0.4.20"
-serde_json = "1.0.107"
-toml = "0.8.5"
+serde_json = "1.0.108"
+toml = "0.8.6"
 base64 = "0.21.5"
 nom = "7.1.3"
 rusqlite = { version = "0.29.0", features = ["bundled"] }
@@ -30,11 +30,11 @@ reqwest = { version = "0.11.22", features = ["json", "blocking"] }
 jsonwebtoken = "9.1.0"
 rusty-s3 = "0.5.0"
 glob = "0.3.1"
-quick-xml = { version = "0.31.0", default-features = false}
+quick-xml = { version = "0.31.0", default-features = false }
 xml2json-rs = "1.0.1"
 
 # Deno Runtime integration
-deno_core = { version = "0.223.0" }
+deno_core = { version = "0.225.0" }
 tokio = { version = "1.33.0" }
 
 # Windows Dependencies
@@ -56,11 +56,11 @@ xz2 = { version = "0.1.7", default-features = false, features = ["static"] }
 # macOS Dependencies
 [target.'cfg(target_os = "macos")'.dependencies]
 macos-unifiedlogs = { git = "https://github.com/mandiant/macos-UnifiedLogs", rev = "06c6a94be890442928df65ab37e834d2723c9e3d" }
-plist = "1.5.1"
+plist = "1.6.0"
 
 # Dependencies at compile time
 [build-dependencies]
-deno_core = { version = "0.223.0" }
+deno_core = { version = "0.225.0" }
 
 # Dependencies for tests
 [dev-dependencies]

--- a/artemis-core/src/artifacts/os/windows/registry/keys/data.rs
+++ b/artemis-core/src/artifacts/os/windows/registry/keys/data.rs
@@ -66,7 +66,7 @@ pub(crate) fn parse_qword_filetime(
     data_size: u32,
     filetime: bool,
 ) -> nom::IResult<&[u8], String> {
-    let (input, _) = take(offset as usize)(reg_data)?;
+    let (input, _) = take(offset)(reg_data)?;
     let (input, (allocated, data_cell_size)) = is_allocated(input)?;
 
     if !allocated {
@@ -102,7 +102,7 @@ fn check_big_data(
     data_type: DataTypes,
     minor_version: u32,
 ) -> nom::IResult<&[u8], String> {
-    let (input, _) = take(offset as usize)(reg_data)?;
+    let (input, _) = take(offset)(reg_data)?;
 
     let (input, (allocated, data_cell_size)) = is_allocated(input)?;
 

--- a/artemis-core/src/artifacts/os/windows/registry/keys/mod.rs
+++ b/artemis-core/src/artifacts/os/windows/registry/keys/mod.rs
@@ -1,3 +1,4 @@
 mod data;
 pub(crate) mod nk;
+pub(crate) mod sk;
 pub(crate) mod vk;

--- a/artemis-core/src/artifacts/os/windows/registry/keys/nk.rs
+++ b/artemis-core/src/artifacts/os/windows/registry/keys/nk.rs
@@ -1,6 +1,3 @@
-use log::error;
-use nom::bytes::complete::take;
-
 use crate::{
     artifacts::os::windows::registry::{
         cell::{walk_registry, walk_values},
@@ -16,6 +13,8 @@ use crate::{
         time::filetime_to_unixepoch,
     },
 };
+use log::error;
+use nom::bytes::complete::take;
 
 #[derive(Debug)]
 pub(crate) struct NameKey {
@@ -109,7 +108,9 @@ impl NameKey {
             values: Vec::new(),
             last_modified: filetime_to_unixepoch(&last_modified),
             depth: params.key_tracker.len(),
+            security_offset: key_security_offset,
         };
+
         params.key_tracker.push(name_key.key_name);
 
         registry_entry.path = params.key_tracker.join("\\");

--- a/artemis-core/src/artifacts/os/windows/registry/keys/sk.rs
+++ b/artemis-core/src/artifacts/os/windows/registry/keys/sk.rs
@@ -1,0 +1,90 @@
+use crate::{
+    artifacts::os::windows::{
+        registry::cell::{get_cell_type, is_allocated, CellType},
+        securitydescriptor::descriptor::Descriptor,
+    },
+    utils::nom_helper::{nom_unsigned_four_bytes, nom_unsigned_two_bytes, Endian},
+};
+use nom::bytes::complete::take;
+use serde::Serialize;
+
+#[derive(Debug, Serialize, Clone)]
+pub(crate) struct SecurityKey {
+    pub(crate) reference_count: u32,
+    pub(crate) info: Descriptor,
+}
+
+impl SecurityKey {
+    /// Parse the Security Key information on a Key. Contains ACLs and SIDs
+    pub(crate) fn parse_security_key(
+        reg_data: &[u8],
+        offset: u32,
+    ) -> nom::IResult<&[u8], SecurityKey> {
+        let (offset_start, _) = take(offset)(reg_data)?;
+        let (input, (is_allocated, size)) = is_allocated(offset_start)?;
+
+        let mut sk_info = SecurityKey {
+            reference_count: 0,
+            info: Descriptor {
+                control_flags: Vec::new(),
+                sacls: Vec::new(),
+                dacls: Vec::new(),
+                owner_sid: String::new(),
+                group_sid: String::new(),
+            },
+        };
+        if !is_allocated {
+            return Ok((reg_data, sk_info));
+        }
+        let adjust_size = 4;
+        // Size includes the size itself. We already nom'd that
+        let (_, input) = take(size - adjust_size)(input)?;
+        let (input, cell_type) = get_cell_type(input)?;
+
+        if cell_type != CellType::Sk {
+            return Ok((reg_data, sk_info));
+        }
+
+        let (input, _sig) = nom_unsigned_two_bytes(input, Endian::Le)?;
+        let (input, _unknown) = nom_unsigned_two_bytes(input, Endian::Le)?;
+
+        let (input, _previous_offset) = nom_unsigned_four_bytes(input, Endian::Le)?;
+        let (input, _next_offset) = nom_unsigned_four_bytes(input, Endian::Le)?;
+
+        let (input, reference_count) = nom_unsigned_four_bytes(input, Endian::Le)?;
+        let (input, nt_descriptor_size) = nom_unsigned_four_bytes(input, Endian::Le)?;
+
+        let (input, descriptor_data) = take(nt_descriptor_size)(input)?;
+        let (_descriptor_data, security_info) = Descriptor::parse_descriptor(descriptor_data)?;
+
+        sk_info.reference_count = reference_count;
+        sk_info.info = security_info;
+
+        Ok((input, sk_info))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::artifacts::os::windows::registry::keys::sk::SecurityKey;
+
+    #[test]
+    fn test_parse_security_key() {
+        let test = [
+            8, 255, 255, 255, 115, 107, 0, 0, 168, 10, 93, 0, 208, 250, 205, 0, 1, 0, 0, 0, 224, 0,
+            0, 0, 1, 0, 20, 156, 196, 0, 0, 0, 212, 0, 0, 0, 0, 0, 0, 0, 20, 0, 0, 0, 2, 0, 176, 0,
+            6, 0, 0, 0, 0, 2, 24, 0, 25, 0, 2, 0, 1, 2, 0, 0, 0, 0, 0, 5, 32, 0, 0, 0, 33, 2, 0, 0,
+            0, 2, 24, 0, 63, 0, 15, 0, 1, 2, 0, 0, 0, 0, 0, 5, 32, 0, 0, 0, 32, 2, 0, 0, 0, 2, 20,
+            0, 63, 0, 15, 0, 1, 1, 0, 0, 0, 0, 0, 5, 18, 0, 0, 0, 0, 2, 20, 0, 63, 0, 15, 0, 1, 1,
+            0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 2, 24, 0, 25, 0, 2, 0, 1, 2, 0, 0, 0, 0, 0, 15, 2, 0,
+            0, 0, 1, 0, 0, 0, 0, 2, 56, 0, 25, 0, 2, 0, 1, 10, 0, 0, 0, 0, 0, 15, 3, 0, 0, 0, 0, 4,
+            0, 0, 176, 49, 128, 63, 108, 188, 99, 76, 60, 224, 80, 209, 151, 12, 161, 98, 15, 1,
+            203, 25, 126, 122, 166, 192, 250, 230, 151, 241, 25, 163, 12, 206, 1, 2, 0, 0, 0, 0, 0,
+            5, 32, 0, 0, 0, 32, 2, 0, 0, 1, 1, 0, 0, 0, 0, 0, 5, 18, 0, 0, 0,
+        ];
+        let (_, results) = SecurityKey::parse_security_key(&test, 0).unwrap();
+
+        assert_eq!(results.reference_count, 1);
+        assert_eq!(results.info.owner_sid, "S-1-5-32-544");
+    }
+}

--- a/artemis-core/src/artifacts/os/windows/registry/parser.rs
+++ b/artemis-core/src/artifacts/os/windows/registry/parser.rs
@@ -53,6 +53,7 @@ pub(crate) struct RegistryEntry {
     pub(crate) values: Vec<KeyValue>,
     pub(crate) last_modified: i64,
     pub(crate) depth: usize,
+    pub(crate) security_offset: i32,
 }
 
 #[derive(Debug, Serialize, Clone)]

--- a/artemis-core/src/artifacts/os/windows/securitydescriptor/descriptor.rs
+++ b/artemis-core/src/artifacts/os/windows/securitydescriptor/descriptor.rs
@@ -1,0 +1,212 @@
+use super::{
+    acl::{AccessControlEntry, AccessItem},
+    sid::grab_sid,
+};
+use crate::utils::nom_helper::{
+    nom_unsigned_four_bytes, nom_unsigned_one_byte, nom_unsigned_two_bytes, Endian,
+};
+use nom::bytes::complete::take;
+use serde::Serialize;
+
+#[derive(Debug, Serialize, Clone)]
+pub(crate) struct Descriptor {
+    pub(crate) control_flags: Vec<ControlFlags>,
+    pub(crate) sacls: Vec<AccessControlEntry>,
+    pub(crate) dacls: Vec<AccessControlEntry>,
+    pub(crate) owner_sid: String,
+    pub(crate) group_sid: String,
+}
+
+#[derive(Debug, PartialEq, Serialize, Clone)]
+pub(crate) enum ControlFlags {
+    OwnerDefaulted,
+    GroupDefaulted,
+    DaclPresent,
+    DaclDefaulted,
+    SaclPresent,
+    SaclDefaulted,
+    DaclAutoInheritReq,
+    SaclAutoInheritReq,
+    DaclAutoInherited,
+    SaclAutoInherited,
+    DaclProtected,
+    SaclProtected,
+    ResourceManagerControlValid,
+    SelfRelative,
+}
+
+impl Descriptor {
+    /// Parse the Security Descriptor data. Typically contains  ACLs and SIDs
+    pub(crate) fn parse_descriptor(data: &[u8]) -> nom::IResult<&[u8], Descriptor> {
+        let (input, _revision) = nom_unsigned_one_byte(data, Endian::Le)?;
+        let (input, _padding) = nom_unsigned_one_byte(input, Endian::Le)?;
+        let (input, control_flags) = nom_unsigned_two_bytes(input, Endian::Le)?;
+        let (input, owner_sid_offset) = nom_unsigned_four_bytes(input, Endian::Le)?;
+        let (input, group_sid_offset) = nom_unsigned_four_bytes(input, Endian::Le)?;
+        let (input, sacl_offset) = nom_unsigned_four_bytes(input, Endian::Le)?;
+        let (input, dacl_offset) = nom_unsigned_four_bytes(input, Endian::Le)?;
+
+        let empty = 0;
+        let mut security_info = Descriptor {
+            control_flags: Descriptor::get_flags(&control_flags),
+            sacls: Vec::new(),
+            dacls: Vec::new(),
+            owner_sid: String::new(),
+            group_sid: String::new(),
+        };
+
+        if sacl_offset != empty {
+            let (acl_start, _) = take(sacl_offset)(data)?;
+            let (_, acl) = AccessControlEntry::parse_acl(acl_start, &AccessItem::Registry)?;
+            security_info.sacls = acl;
+        }
+        if dacl_offset != empty {
+            let (acl_start, _) = take(dacl_offset)(data)?;
+            let (_, acl) = AccessControlEntry::parse_acl(acl_start, &AccessItem::Registry)?;
+            security_info.dacls = acl;
+        }
+
+        if owner_sid_offset != empty {
+            let (sid_start, _) = take(owner_sid_offset)(data)?;
+            let (_, sid) = grab_sid(sid_start)?;
+            security_info.owner_sid = sid;
+        }
+        if group_sid_offset != empty {
+            let (sid_start, _) = take(group_sid_offset)(data)?;
+            let (_, sid) = grab_sid(sid_start)?;
+            security_info.group_sid = sid;
+        }
+
+        Ok((input, security_info))
+    }
+
+    /// Get the Control Flags associated with the security descriptor
+    fn get_flags(control: &u16) -> Vec<ControlFlags> {
+        let own_default = 0x1;
+        let group_default = 0x2;
+        let dacl_present = 0x4;
+        let dacl_default = 0x8;
+        let sacl_present = 0x10;
+        let sacl_default = 0x20;
+        let dacl_auto_req = 0x100;
+        let sacl_auto_req = 0x200;
+        let dacl_auto = 0x400;
+        let sacl_auto = 0x800;
+        let dacl_protected = 0x1000;
+        let sacl_protected = 0x2000;
+        let rm_control = 0x4000;
+        let relative = 0x8000;
+
+        let mut flags = Vec::new();
+
+        if (control & own_default) == own_default {
+            flags.push(ControlFlags::OwnerDefaulted);
+        }
+        if (control & group_default) == group_default {
+            flags.push(ControlFlags::GroupDefaulted);
+        }
+        if (control & dacl_present) == dacl_present {
+            flags.push(ControlFlags::DaclPresent);
+        }
+        if (control & dacl_default) == dacl_default {
+            flags.push(ControlFlags::DaclDefaulted);
+        }
+        if (control & sacl_present) == sacl_present {
+            flags.push(ControlFlags::SaclPresent);
+        }
+        if (control & sacl_default) == sacl_default {
+            flags.push(ControlFlags::SaclDefaulted);
+        }
+        if (control & dacl_auto_req) == dacl_auto_req {
+            flags.push(ControlFlags::DaclAutoInheritReq);
+        }
+        if (control & sacl_auto_req) == sacl_auto_req {
+            flags.push(ControlFlags::SaclAutoInheritReq);
+        }
+        if (control & dacl_auto) == dacl_auto {
+            flags.push(ControlFlags::DaclAutoInherited);
+        }
+        if (control & sacl_auto) == sacl_auto {
+            flags.push(ControlFlags::SaclAutoInherited);
+        }
+        if (control & dacl_protected) == dacl_protected {
+            flags.push(ControlFlags::DaclProtected);
+        }
+        if (control & sacl_protected) == sacl_protected {
+            flags.push(ControlFlags::SaclProtected);
+        }
+        if (control & rm_control) == rm_control {
+            flags.push(ControlFlags::ResourceManagerControlValid);
+        }
+        if (control & relative) == relative {
+            flags.push(ControlFlags::SelfRelative);
+        }
+
+        flags
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::artifacts::os::windows::securitydescriptor::acl::AccessMask::{
+        EnumerateSubKeys, Execute, Notify, QueryValue, Read, ReadControl,
+    };
+    use crate::artifacts::os::windows::securitydescriptor::descriptor::ControlFlags::{
+        DaclAutoInherited, DaclPresent, DaclProtected, OwnerDefaulted, SaclAutoInherited,
+        SaclPresent, SelfRelative,
+    };
+    use crate::artifacts::os::windows::securitydescriptor::{
+        acl::AceTypes, descriptor::Descriptor,
+    };
+
+    #[test]
+    fn test_parse_descriptor() {
+        let test = [
+            1, 0, 20, 156, 196, 0, 0, 0, 212, 0, 0, 0, 0, 0, 0, 0, 20, 0, 0, 0, 2, 0, 176, 0, 6, 0,
+            0, 0, 0, 2, 24, 0, 25, 0, 2, 0, 1, 2, 0, 0, 0, 0, 0, 5, 32, 0, 0, 0, 33, 2, 0, 0, 0, 2,
+            24, 0, 63, 0, 15, 0, 1, 2, 0, 0, 0, 0, 0, 5, 32, 0, 0, 0, 32, 2, 0, 0, 0, 2, 20, 0, 63,
+            0, 15, 0, 1, 1, 0, 0, 0, 0, 0, 5, 18, 0, 0, 0, 0, 2, 20, 0, 63, 0, 15, 0, 1, 1, 0, 0,
+            0, 0, 0, 3, 0, 0, 0, 0, 0, 2, 24, 0, 25, 0, 2, 0, 1, 2, 0, 0, 0, 0, 0, 15, 2, 0, 0, 0,
+            1, 0, 0, 0, 0, 2, 56, 0, 25, 0, 2, 0, 1, 10, 0, 0, 0, 0, 0, 15, 3, 0, 0, 0, 0, 4, 0, 0,
+            176, 49, 128, 63, 108, 188, 99, 76, 60, 224, 80, 209, 151, 12, 161, 98, 15, 1, 203, 25,
+            126, 122, 166, 192, 250, 230, 151, 241, 25, 163, 12, 206, 1, 2, 0, 0, 0, 0, 0, 5, 32,
+            0, 0, 0, 32, 2, 0, 0, 1, 1, 0, 0, 0, 0, 0, 5, 18, 0, 0, 0,
+        ];
+        let (_, results) = Descriptor::parse_descriptor(&test).unwrap();
+
+        assert_eq!(results.group_sid, "S-1-5-18");
+        assert_eq!(
+            results.control_flags,
+            vec![
+                DaclPresent,
+                SaclPresent,
+                DaclAutoInherited,
+                SaclAutoInherited,
+                DaclProtected,
+                SelfRelative
+            ]
+        );
+        assert_eq!(results.owner_sid, "S-1-5-32-544");
+        assert_eq!(results.dacls[0].ace_type, AceTypes::AccessAllowedAceType);
+        assert_eq!(
+            results.dacls[0].access_rights,
+            vec![
+                ReadControl,
+                EnumerateSubKeys,
+                Execute,
+                Read,
+                Notify,
+                QueryValue
+            ]
+        );
+        assert_eq!(results.dacls[0].sid, "S-1-5-32-545");
+        assert_eq!(results.dacls.len(), 6);
+    }
+
+    #[test]
+    fn test_get_flags() {
+        let test = 0x1;
+        let results = Descriptor::get_flags(&test);
+        assert_eq!(results[0], OwnerDefaulted)
+    }
+}

--- a/artemis-core/src/artifacts/os/windows/securitydescriptor/mod.rs
+++ b/artemis-core/src/artifacts/os/windows/securitydescriptor/mod.rs
@@ -1,2 +1,3 @@
 pub(crate) mod acl;
+pub(crate) mod descriptor;
 pub(crate) mod sid;

--- a/artemis-core/src/runtime/run.rs
+++ b/artemis-core/src/runtime/run.rs
@@ -138,7 +138,7 @@ fn create_worker_options() -> Result<JsRuntime, AnyError> {
         inspector: false,
         is_main: Default::default(),
         preserve_snapshotted_modules: None,
-        op_metrics_fn: None,
+        op_metrics_factory_fn: None,
         feature_checker: None,
     });
 

--- a/artemis-core/src/runtime/windows/extensions.rs
+++ b/artemis-core/src/runtime/windows/extensions.rs
@@ -8,7 +8,7 @@ use super::{
     pe::get_pe,
     prefetch::{get_alt_prefetch, get_prefetch, get_prefetch_path},
     recyclebin::{get_alt_recycle_bin, get_recycle_bin, get_recycle_bin_file},
-    registry::get_registry,
+    registry::{get_registry, get_sk_info},
     search::get_search,
     services::{get_alt_services, get_service_file, get_services},
     shellbags::{get_alt_shellbags, get_shellbags},
@@ -81,6 +81,7 @@ fn grab_functions() -> Vec<deno_core::OpDecl> {
         get_recycle_bin::DECL,
         get_alt_recycle_bin::DECL,
         get_recycle_bin_file::DECL,
+        get_sk_info::DECL,
     ];
     exts.append(&mut app_functions());
     exts.append(&mut system_functions());

--- a/artemis-core/src/runtime/windows/registry.rs
+++ b/artemis-core/src/runtime/windows/registry.rs
@@ -27,6 +27,7 @@ pub(crate) fn get_registry(#[string] path: String) -> Result<String, AnyError> {
 
 #[op2]
 #[string]
+/// Expose parsing the Security Key to `Deno`
 pub(crate) fn get_sk_info(#[string] path: String, offset: i32) -> Result<String, AnyError> {
     let sk_result = lookup_sk_info(&path, offset);
     let sk = match sk_result {

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -22,9 +22,9 @@ axum = { version = "0.6.20", default-features = false, features = [
 tokio = { version = "1.33.0", features = ["full"] }
 log = "0.4.20"
 serde = { version = "1.0.190", features = ["derive"] }
-serde_json = "1.0.107"
+serde_json = "1.0.108"
 uuid = { version = "1.5.0", features = ["v4"] }
-toml = "0.8.5"
+toml = "0.8.6"
 futures = "0.3.29"
 flate2 = "1.0.28"
 rust-embed = "8.0.0"


### PR DESCRIPTION
This PR adds support for parsing the Security Key data for Registry keys.
The SK contains permissions and ACLs information for a Registry Key.

Its not super useful from a forensic use case, but still kind of cool artemis supports it.