### PR TITLE
Support for ESE parsing from javascript

### DIFF
--- a/.changes/unreleased/ArtemisApi-20231111-211245.yaml
+++ b/.changes/unreleased/ArtemisApi-20231111-211245.yaml
@@ -1,0 +1,3 @@
+kind: ArtemisApi
+body: Can now parse and dump table(s) in ESE dbs
+time: 2023-11-11T21:12:45.3234544-05:00

--- a/.changes/unreleased/Fixed-20231111-211338.yaml
+++ b/.changes/unreleased/Fixed-20231111-211338.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Error when parsed ESE tables did not return all data
+time: 2023-11-11T21:13:38.036361-05:00

--- a/artemis-core/src/artifacts/os/files/filelisting.rs
+++ b/artemis-core/src/artifacts/os/files/filelisting.rs
@@ -511,7 +511,7 @@ mod tests {
     #[test]
     #[cfg(target_os = "macos")]
     fn test_skip_firmlinks() {
-        use crate::artifacts::os::files::filelisting::skip_firmlinks;
+        use crate::artifacts::os::files::filelisting::{read_firmlinks, skip_firmlinks};
         let skip_path = WalkDir::new("/Users").max_depth(1);
         let results = read_firmlinks().unwrap();
         assert!(results.len() > 3);

--- a/artemis-core/src/artifacts/os/files/filelisting.rs
+++ b/artemis-core/src/artifacts/os/files/filelisting.rs
@@ -322,7 +322,7 @@ mod tests {
     use crate::artifacts::os::files::filelisting::file_metadata;
     use crate::artifacts::os::files::filelisting::get_filelist;
     use crate::{
-        artifacts::os::files::filelisting::{read_firmlinks, skip_firmlinks, user_regex, Hashes},
+        artifacts::os::files::filelisting::{user_regex, Hashes},
         structs::toml::Output,
     };
     use common::files::FileInfo;
@@ -501,13 +501,17 @@ mod tests {
     }
 
     #[test]
+    #[cfg(target_os = "macos")]
     fn test_read_firmlinks() {
+        use crate::artifacts::os::files::filelisting::read_firmlinks;
         let results = read_firmlinks().unwrap();
         assert!(results.len() > 3);
     }
 
     #[test]
+    #[cfg(target_os = "macos")]
     fn test_skip_firmlinks() {
+        use crate::artifacts::os::files::filelisting::skip_firmlinks;
         let skip_path = WalkDir::new("/Users").max_depth(1);
         let results = read_firmlinks().unwrap();
         assert!(results.len() > 3);

--- a/artemis-core/src/artifacts/os/windows/ese/catalog.rs
+++ b/artemis-core/src/artifacts/os/windows/ese/catalog.rs
@@ -88,6 +88,7 @@ pub(crate) struct VariableData {
     pub(crate) size: u16,
 }
 
+#[derive(Debug)]
 pub(crate) struct TaggedData {
     pub(crate) column: u16,
     pub(crate) offset: u16,

--- a/artemis-core/src/artifacts/os/windows/ese/pages/leaf.rs
+++ b/artemis-core/src/artifacts/os/windows/ese/pages/leaf.rs
@@ -33,7 +33,7 @@ pub(crate) struct SpaceTree {
     pub(crate) number_pages: u32,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub(crate) struct DataDefinition {
     /**The last fixed data. Ex: A value of three (3) means there may be fixed data for 1,2,3 values. Dependent on table */
     pub(crate) last_fixed_data: u8,

--- a/artemis-core/src/artifacts/os/windows/ese/parser.rs
+++ b/artemis-core/src/artifacts/os/windows/ese/parser.rs
@@ -96,4 +96,11 @@ mod tests {
         assert_eq!(job[0][1].column_type, ColumnType::LongBinary);
         assert_eq!(job[0][1].column_data.len(), 1432);
     }
+
+    #[test]
+    fn test_security_database() {
+        let test = "C:\\Windows\\security\\database\\secedit.sdb";
+        let results = grab_ese_tables(test, &["SmTblSmp".to_owned()]).unwrap();
+        assert!(!results.is_empty());
+    }
 }

--- a/artemis-core/src/artifacts/os/windows/ese/tables.rs
+++ b/artemis-core/src/artifacts/os/windows/ese/tables.rs
@@ -156,6 +156,7 @@ pub(crate) fn read_ese<'a>(
             )));
         }
     };
+
     let mut info = TableInfo {
         obj_id_table: 0,
         table_page: 0,
@@ -893,7 +894,13 @@ fn parse_tagged_data<'a>(
                 continue;
             }
 
-            let tag_size = next_value.offset - value.offset;
+            // Check and make sure next tag offset is lower than the bit flag
+            let tag_size = if next_value.offset > bit_flag {
+                (next_value.offset - bit_flag) - value.offset
+            } else {
+                next_value.offset - value.offset
+            };
+
             let (input, data) = take(tag_size)(tag_data_start)?;
             tag_data_start = input;
             let (tag_data, flag) = nom_unsigned_one_byte(data, Endian::Le)?;

--- a/artemis-core/src/runtime/windows/ese.rs
+++ b/artemis-core/src/runtime/windows/ese.rs
@@ -1,0 +1,58 @@
+use crate::{artifacts::os::windows::ese::parser::grab_ese_tables, runtime::error::RuntimeError};
+use deno_core::{error::AnyError, op2};
+use log::error;
+
+#[op2]
+#[string]
+pub(crate) fn get_table(
+    #[string] path: String,
+    #[serde] table: Vec<String>,
+) -> Result<String, AnyError> {
+    let ese_result = grab_ese_tables(&path, &table);
+    let ese = match ese_result {
+        Ok(results) => results,
+        Err(err) => {
+            error!("[runtime] Failed to parse ESE file {path}: {err:?}");
+            return Err(RuntimeError::ExecuteScript.into());
+        }
+    };
+
+    let results = serde_json::to_string(&ese)?;
+    Ok(results)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        runtime::deno::execute_script, structs::artifacts::runtime::script::JSScript,
+        structs::toml::Output,
+    };
+
+    fn output_options(name: &str, output: &str, directory: &str, compress: bool) -> Output {
+        Output {
+            name: name.to_string(),
+            directory: directory.to_string(),
+            format: String::from("json"),
+            compress,
+            url: Some(String::new()),
+            api_key: Some(String::new()),
+            endpoint_id: String::from("abcd"),
+            collection_id: 0,
+            output: output.to_string(),
+            filter_name: None,
+            filter_script: None,
+            logging: None,
+        }
+    }
+
+    #[test]
+    fn test_get_table() {
+        let test = "Ly8gLi4vLi4vYXJ0ZW1pcy1hcGkvc3JjL3dpbmRvd3MvZXNlLnRzCmZ1bmN0aW9uIHBhcnNlVGFibGUocGF0aCwgdGFibGVzKSB7CiAgY29uc3QgZGF0YSA9IERlbm8uY29yZS5vcHMuZ2V0X3RhYmxlKHBhdGgsIHRhYmxlcyk7CiAgaWYgKGRhdGEgaW5zdGFuY2VvZiBFcnJvcikgewogICAgcmV0dXJuIGRhdGE7CiAgfQogIGNvbnN0IHJlc3VsdHMgPSBKU09OLnBhcnNlKGRhdGEpOwogIHJldHVybiByZXN1bHRzOwp9CgovLyBtYWluLnRzCmZ1bmN0aW9uIG1haW4oKSB7CiAgY29uc3QgZGIgPSAiQzpcXFdpbmRvd3NcXHNlY3VyaXR5XFxkYXRhYmFzZVxcc2VjZWRpdC5zZGIiOwogIGNvbnN0IHRhYmxlcyA9IFsiU21UYmxTbXAiXTsKICBjb25zdCBkYXRhID0gcGFyc2VUYWJsZShkYiwgdGFibGVzKTsKICBjb25zb2xlLmxvZyhgRVNFICR7dGFibGVzWzBdfSBsZW46ICR7ZGF0YVsiU21UYmxTbXAiXS5sZW5ndGh9YCk7Cn0KbWFpbigpOwo=";
+        let mut output = output_options("runtime_test", "local", "./tmp", false);
+        let script = JSScript {
+            name: String::from("recent_files"),
+            script: test.to_string(),
+        };
+        execute_script(&mut output, &script).unwrap();
+    }
+}

--- a/artemis-core/src/runtime/windows/extensions.rs
+++ b/artemis-core/src/runtime/windows/extensions.rs
@@ -2,6 +2,7 @@ use super::{
     accounts::{get_alt_users, get_users},
     amcache::{get_alt_amcache, get_amcache},
     bits::{get_bits, get_bits_path},
+    ese::get_table,
     eventlogs::get_eventlogs,
     jumplists::{get_alt_jumplists, get_jumplist_file, get_jumplists},
     ntfs::{read_ads_data, read_raw_file},
@@ -82,6 +83,7 @@ fn grab_functions() -> Vec<deno_core::OpDecl> {
         get_alt_recycle_bin::DECL,
         get_recycle_bin_file::DECL,
         get_sk_info::DECL,
+        get_table::DECL,
     ];
     exts.append(&mut app_functions());
     exts.append(&mut system_functions());

--- a/artemis-core/src/runtime/windows/mod.rs
+++ b/artemis-core/src/runtime/windows/mod.rs
@@ -1,6 +1,7 @@
 mod accounts;
 mod amcache;
 mod bits;
+mod ese;
 mod eventlogs;
 pub(crate) mod extensions;
 mod jumplists;

--- a/common/src/windows.rs
+++ b/common/src/windows.rs
@@ -329,7 +329,7 @@ pub enum AccessMask {
  * A simple abstracted table dump from the ESE database  
  * Will auto parse non-binary column types
  */
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct TableDump {
     /**The column type. Ex: GUID, binary, text, bit, long, etc */
     pub column_type: ColumnType,
@@ -339,7 +339,7 @@ pub struct TableDump {
     pub column_data: String,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub enum ColumnType {
     Nil,
     Bit,


### PR DESCRIPTION
This PR adds support for parsing any ESE database using the JavaScript runtime.

The Rust based ESE parser is doing all of the parsing, the JS code is simply providing the file path and tables to be parsed.

Also this PR fixes a small ESE parsing where sometimes not of the data was returned