### PR TITLE
Lower memory when parsing Linux Journal files

### DIFF
--- a/.changes/unreleased/Changed-20250611-214652.yaml
+++ b/.changes/unreleased/Changed-20250611-214652.yaml
@@ -1,3 +1,3 @@
-kind: Fixed
+kind: Changed
 body: Lowered memory usage when parsing linux journal files
 time: 2025-06-11T21:46:52.748381596-04:00

--- a/.changes/unreleased/Changed-20250611-214652.yaml
+++ b/.changes/unreleased/Changed-20250611-214652.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Lowered memory usage when parsing linux journal files
+time: 2025-06-11T21:46:52.748381596-04:00

--- a/.changes/unreleased/Changed-20250611-214728.yaml
+++ b/.changes/unreleased/Changed-20250611-214728.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: Faster processing when compressing json output
+time: 2025-06-11T21:47:28.806789268-04:00

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aes"
@@ -223,7 +223,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
  "synstructure",
 ]
 
@@ -235,7 +235,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -428,7 +428,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -724,7 +724,7 @@ checksum = "9fd3f870829131332587f607a7ff909f1af5fc523fd1b192db55fbbdf52e8d3c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
  "synstructure",
 ]
 
@@ -821,7 +821,7 @@ checksum = "7ecc273b49b3205b83d648f0690daa588925572cc5063745bfe547fe7ec8e1a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -893,9 +893,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "chrono"
@@ -951,9 +951,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.39"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
+checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -961,9 +961,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.39"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
+checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
 dependencies = [
  "anstream",
  "anstyle",
@@ -973,21 +973,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.32"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "cobs"
@@ -1354,7 +1354,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -1365,7 +1365,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -1439,7 +1439,7 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -1452,7 +1452,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -1502,7 +1502,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -1670,7 +1670,7 @@ checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -1945,7 +1945,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -1997,7 +1997,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -2169,9 +2169,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hkdf"
@@ -2622,7 +2622,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2926,7 +2926,7 @@ checksum = "04d55ca5d5a14363da83bf3c33874b8feaa34653e760d5216d7ef9829c88001a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2994,7 +2994,7 @@ dependencies = [
  "quote",
  "regex-syntax",
  "rustc_version",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -3091,9 +3091,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "memfd"
@@ -3155,9 +3155,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
 ]
@@ -3169,7 +3169,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
 ]
 
@@ -3312,7 +3312,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -3363,7 +3363,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -3456,7 +3456,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -3630,7 +3630,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -3700,13 +3700,13 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plist"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac26e981c03a6e53e0aee43c113e3202f5581d5360dae7bd2c70e800dd0451d"
+checksum = "3d77244ce2d584cd84f6a15f86195b8c9b2a0dfbfd817c09e0464244091a58ed"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.9.0",
- "quick-xml 0.32.0",
+ "quick-xml 0.37.5",
  "serde",
  "time",
 ]
@@ -3928,15 +3928,6 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "quick-xml"
 version = "0.36.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
@@ -4100,9 +4091,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.19"
+version = "0.12.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2f8e5513d63f2e5b386eb5106dc67eaf3f84e95258e210489136b8b92ad6119"
+checksum = "eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4118,13 +4109,11 @@ dependencies = [
  "hyper-rustls",
  "hyper-tls",
  "hyper-util",
- "ipnet",
  "js-sys",
  "log",
  "mime",
  "mime_guess",
  "native-tls",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "rustls-pki-types",
@@ -4222,9 +4211,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
 name = "rustc-hash"
@@ -4346,7 +4335,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3640bec8aad418d7d03c72ea2de10d5c646a598f9883c7babc160d91e3c1b26c"
 dependencies = [
- "twox-hash 2.1.0",
+ "twox-hash 2.1.1",
 ]
 
 [[package]]
@@ -4448,7 +4437,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -4706,7 +4695,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -4741,9 +4730,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "f6397daf94fa90f058bd0fd88429dd9e5738999cca8d701813c80723add80462"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4767,7 +4756,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -4781,7 +4770,7 @@ dependencies = [
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
- "windows 0.61.1",
+ "windows 0.61.2",
 ]
 
 [[package]]
@@ -4888,7 +4877,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -4899,7 +4888,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -5016,7 +5005,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -5175,9 +5164,9 @@ dependencies = [
 
 [[package]]
 name = "twox-hash"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7b17f197b3050ba473acf9181f7b1d3b66d1cf7356c6cc57886662276e65908"
+checksum = "8b907da542cbced5261bd3256de1b3a1bf340a3d37f93425a07362a1d687de56"
 
 [[package]]
 name = "typenum"
@@ -5199,9 +5188,9 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "unicode-xid"
@@ -5320,7 +5309,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -5334,9 +5323,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -5369,7 +5358,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
  "wasm-bindgen-shared",
 ]
 
@@ -5404,7 +5393,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5624,7 +5613,7 @@ checksum = "55b39ffeda28be925babb2d45067d8ba2c67d2227328c5364d23b4152eba9950"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -5701,9 +5690,9 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.61.1"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5ee8f3d025738cb02bad7868bbb5f8a6327501e870bf51f1b455b0a2454a419"
+checksum = "e2b85ac982d24496e0b49912479da8a89c0ba7b1d8bf6de49df12af42e94b325"
 dependencies = [
  "windows-collections 0.2.0",
  "windows-core 0.61.2",
@@ -5785,7 +5774,7 @@ checksum = "83577b051e2f49a058c308f17f273b570a6a758386fc291b5f6a934dd84e48c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -5796,7 +5785,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -5807,14 +5796,14 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "d3bfe459f85da17560875b8bf1423d6f113b7a87a5d942e7da0ac71be7c61f8b"
 
 [[package]]
 name = "windows-numerics"
@@ -5967,9 +5956,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
 dependencies = [
  "memchr",
 ]
@@ -6145,7 +6134,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -6210,7 +6199,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
  "synstructure",
 ]
 
@@ -6222,7 +6211,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
  "synstructure",
 ]
 
@@ -6243,7 +6232,7 @@ checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -6263,7 +6252,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
  "synstructure",
 ]
 
@@ -6314,7 +6303,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -6325,7 +6314,7 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.102",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ base64 = "0.22.1"
 tokio = { version = "1.45.1", features = ["full"] }
 flate2 = "1.1.2"
 glob = "0.3.2"
-reqwest = { version = "0.12.19", features = [
+reqwest = { version = "0.12.20", features = [
     "json",
     "blocking",
     "native-tls-vendored",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -11,7 +11,7 @@ description = { workspace = true }
 base64 = { workspace = true }
 log = { workspace = true }
 forensics = { path = "../forensics", default-features = false }
-clap = { version = "4.5.39", features = ["std", "help", "derive"] }
+clap = { version = "4.5.40", features = ["std", "help", "derive"] }
 
 # Artemis features
 [features]

--- a/daemon/src/start.rs
+++ b/daemon/src/start.rs
@@ -13,7 +13,10 @@ pub(crate) struct DaemonConfig {
     pub(crate) client: DaemonToml,
 }
 
+/// Start artemis as a daemon and collect data based on remote server responses
 pub fn start_daemon(path: Option<&str>, alt_base: Option<&str>) {
+    // We will enroll to a remote server based on a server.toml config
+    // By default we assume server.toml is in same directory as binary
     let mut server_path = "server.toml";
 
     if let Some(config_path) = path {
@@ -53,6 +56,7 @@ fn start(config: &mut DaemonConfig) {
     let mut count = 0;
 
     let pause = 8;
+    let collection_poll = 60;
     loop {
         if count == max_attempts {
             let long_pause = 300;
@@ -69,8 +73,7 @@ fn start(config: &mut DaemonConfig) {
             }
         };
         setup_collection(config, &collection);
+        // Next poll will be in 60 seconds
+        sleep(Duration::from_secs(collection_poll));
     }
 }
-
-#[cfg(test)]
-mod tests {}

--- a/forensics/Cargo.toml
+++ b/forensics/Cargo.toml
@@ -47,7 +47,7 @@ ruzstd = "0.8.1"
 lz4_flex = "0.11.3"
 xz2 = { version = "0.1.7", default-features = false, features = ["static"] }
 macos-unifiedlogs = "0.2.0"
-plist = "1.7.1"
+plist = "1.7.2"
 aes = "0.8.4"
 cbc = "0.1.2"
 yara-x = { version = "1.0.1", optional = true, default-features = false, features = [
@@ -70,7 +70,7 @@ url = "2.5.4"
 common = { path = "../common" }
 timeline = { path = "../timeline" }
 sunlight = "0.1.1"
-miniz_oxide = { version = "0.8.8", features = ["std", "with-alloc"] }
+miniz_oxide = { version = "0.8.9", features = ["std", "with-alloc"] }
 lumination = "0.1.1"
 
 # JS API

--- a/forensics/src/artifacts/os/linux/journals/error.rs
+++ b/forensics/src/artifacts/os/linux/journals/error.rs
@@ -5,7 +5,6 @@ pub(crate) enum JournalError {
     SeekError,
     ReadError,
     ObjectHeader,
-    Serialize,
     ReaderError,
     JournalHeader,
     NotJournal,
@@ -20,7 +19,6 @@ impl fmt::Display for JournalError {
             JournalError::ReadError => write!(f, "Failed to read journal data"),
             JournalError::ObjectHeader => write!(f, "Failed to parse object header"),
             JournalError::JournalHeader => write!(f, "Failed to parse journal header"),
-            JournalError::Serialize => write!(f, "Could not serialize data"),
             JournalError::ReaderError => write!(f, "Could not create reader"),
             JournalError::NotJournal => write!(f, "Not a journal file"),
         }

--- a/forensics/src/artifacts/os/linux/journals/journal.rs
+++ b/forensics/src/artifacts/os/linux/journals/journal.rs
@@ -3,17 +3,13 @@ use super::{
     header::{IncompatFlags, JournalHeader},
     objects::{
         array::EntryArray,
-        entry::Entry,
         header::{ObjectHeader, ObjectType},
     },
 };
-use crate::{
-    artifacts::os::macos::artifacts::output_data, filesystem::files::file_reader,
-    structs::toml::Output, utils::time::unixepoch_microseconds_to_iso,
-};
-use common::linux::{Facility, Journal, Priority};
+use crate::{filesystem::files::file_reader, structs::toml::Output};
+use common::linux::Journal;
 use log::error;
-use std::{collections::HashMap, fs::File, io::Read};
+use std::{collections::HashSet, fs::File, io::Read};
 
 /// Parse provided `Journal` file path. Will output results when finished. Use `parse_journal_file` if you want the results
 pub(crate) fn parse_journal(
@@ -96,8 +92,8 @@ pub(crate) fn parse_journal_file(path: &str) -> Result<Vec<Journal>, JournalErro
 
     let mut offset = journal_header.entry_array_offset;
     // Track offsets to make sure we do not encounter infinite loops
-    let mut offset_tracker: HashMap<u64, bool> = HashMap::new();
-    offset_tracker.insert(offset, false);
+    let mut offset_tracker: HashSet<u64> = HashSet::new();
+    offset_tracker.insert(offset);
 
     let last_entry = 0;
 
@@ -117,7 +113,7 @@ pub(crate) fn parse_journal_file(path: &str) -> Result<Vec<Journal>, JournalErro
         }
 
         let entry_result =
-            EntryArray::walk_entries(&mut reader, &object_header.payload, is_compact);
+            EntryArray::walk_all_entries(&mut reader, &object_header.payload, &is_compact);
         let mut entry_array = match entry_result {
             Ok((_, result)) => result,
             Err(_err) => {
@@ -129,13 +125,13 @@ pub(crate) fn parse_journal_file(path: &str) -> Result<Vec<Journal>, JournalErro
         entries.entries.append(&mut entry_array.entries);
         offset = entry_array.next_entry_array_offset;
 
-        if offset_tracker.contains_key(&offset) {
+        if offset_tracker.contains(&offset) {
             error!("[journal] Found recursive offset. Exiting now");
             break;
         }
     }
 
-    let messages = parse_messages(&entries.entries);
+    let messages = EntryArray::parse_messages(&entries.entries);
 
     Ok(messages)
 }
@@ -152,15 +148,9 @@ fn get_entries(
     let mut offset = array_offset;
     let last_entry = 0;
 
-    let mut entries = EntryArray {
-        entries: Vec::new(),
-        next_entry_array_offset: 0,
-    };
-
-    let limit = 10000;
     // Track offsets to make sure we do not encounter infinite loops
-    let mut offset_tracker: HashMap<u64, bool> = HashMap::new();
-    offset_tracker.insert(offset, false);
+    let mut offset_tracker: HashSet<u64> = HashSet::new();
+    offset_tracker.insert(offset);
 
     while offset != last_entry {
         let object_header = ObjectHeader::parse_header(reader, offset)?;
@@ -172,318 +162,40 @@ fn get_entries(
             break;
         }
 
-        let entry_result = EntryArray::walk_entries(reader, &object_header.payload, is_compact);
-        let mut entry_array = match entry_result {
+        let entry_result = EntryArray::walk_entries(
+            reader,
+            &object_header.payload,
+            &is_compact,
+            output,
+            filter,
+            start_time,
+        );
+        let next_offset = match entry_result {
             Ok((_, result)) => result,
             Err(_err) => {
                 error!("[journal] Could not walk journal entries. Exiting early");
                 break;
             }
         };
-        entries.entries.append(&mut entry_array.entries);
-        offset = entry_array.next_entry_array_offset;
-        if offset_tracker.contains_key(&offset) {
+        offset = next_offset;
+        if offset_tracker.contains(&offset) {
             error!("[journal] Found recursive offset. Exiting now");
             break;
         }
 
-        offset_tracker.insert(offset, false);
-
-        // The Journal file can be configured to be very large. Default size is usually ~10MB
-        // To limit memory usage we output every 100k entries
-        if entries.entries.len() >= limit {
-            let messages = parse_messages(&entries.entries);
-            let serde_data_result = serde_json::to_value(messages);
-            let mut serde_data = match serde_data_result {
-                Ok(results) => results,
-                Err(err) => {
-                    error!("[journal] Failed to serialize journal data: {err:?}");
-                    continue;
-                }
-            };
-
-            let _ = output_data(&mut serde_data, "journal", output, start_time, filter);
-            // Now empty the vec
-            entries.entries = Vec::new();
-        }
+        offset_tracker.insert(offset);
     }
 
-    if entries.entries.is_empty() {
-        return Ok(());
-    }
-
-    let messages = parse_messages(&entries.entries);
-    let serde_data_result = serde_json::to_value(messages);
-    let mut serde_data: serde_json::Value = match serde_data_result {
-        Ok(results) => results,
-        Err(err) => {
-            error!("[journal] Failed to serialize last journal data: {err:?}");
-            return Err(JournalError::Serialize);
-        }
-    };
-
-    let _ = output_data(&mut serde_data, "journal", output, start_time, filter);
     Ok(())
-}
-
-/// Parse the `Journal` message
-fn parse_messages(entries: &[Entry]) -> Vec<Journal> {
-    let mut journal_entries: Vec<Journal> = Vec::new();
-
-    for entry in entries {
-        let mut journal = Journal {
-            uid: 0,
-            gid: 0,
-            pid: 0,
-            comm: String::new(),
-            priority: Priority::None,
-            syslog_facility: Facility::None,
-            thread_id: 0,
-            syslog_identifier: String::new(),
-            executable: String::new(),
-            cmdline: String::new(),
-            cap_effective: String::new(),
-            audit_session: 0,
-            audit_loginuid: 0,
-            systemd_cgroup: String::new(),
-            systemd_owner_uid: 0,
-            systemd_unit: String::new(),
-            systemd_user_unit: String::new(),
-            systemd_slice: String::new(),
-            systemd_user_slice: String::new(),
-            systemd_invocation_id: String::new(),
-            boot_id: String::new(),
-            machine_id: String::new(),
-            hostname: String::new(),
-            runtime_scope: String::new(),
-            source_realtime: String::new(),
-            realtime: unixepoch_microseconds_to_iso(&(entry.realtime as i64)),
-            seqnum: entry.seqnum,
-            transport: String::new(),
-            message: String::new(),
-            message_id: String::new(),
-            unit_result: String::new(),
-            code_line: 0,
-            code_function: String::new(),
-            code_file: String::new(),
-            user_invocation_id: String::new(),
-            user_unit: String::new(),
-            custom: HashMap::new(),
-        };
-
-        for data in &entry.data_objects {
-            if data.message.starts_with("_PID=") {
-                if let Some((_, pid)) = data.message.split_once('=') {
-                    journal.pid = pid.parse::<usize>().unwrap_or_default();
-                }
-            } else if data.message.starts_with("_TRANSPORT=") {
-                if let Some((_, transport)) = data.message.split_once('=') {
-                    journal.transport = transport.to_string();
-                }
-            } else if data.message.starts_with("_UID=") {
-                if let Some((_, uid)) = data.message.split_once('=') {
-                    journal.uid = uid.parse::<u32>().unwrap_or_default();
-                }
-            } else if data.message.starts_with("_GID=") {
-                if let Some((_, gid)) = data.message.split_once('=') {
-                    journal.gid = gid.parse::<u32>().unwrap_or_default();
-                }
-            } else if data.message.starts_with("_COMM=") {
-                if let Some((_, comm)) = data.message.split_once('=') {
-                    journal.comm = comm.to_string();
-                }
-            } else if data.message.starts_with("_EXE=") {
-                if let Some((_, exe)) = data.message.split_once('=') {
-                    journal.executable = exe.to_string();
-                }
-            } else if data.message.starts_with("_CMDLINE=") {
-                if let Some((_, cmdline)) = data.message.split_once('=') {
-                    journal.cmdline = cmdline.to_string();
-                }
-            } else if data.message.starts_with("_CAP_EFFECTIVE=") {
-                if let Some((_, cap)) = data.message.split_once('=') {
-                    journal.cap_effective = cap.to_string();
-                }
-            } else if data.message.starts_with("_AUDIT_SESSION=") {
-                if let Some((_, session)) = data.message.split_once('=') {
-                    journal.audit_session = session.parse::<usize>().unwrap_or_default();
-                }
-            } else if data.message.starts_with("_SYSTEMD_INVOCATION_ID=") {
-                if let Some((_, invoc)) = data.message.split_once('=') {
-                    journal.systemd_invocation_id = invoc.to_string();
-                }
-            } else if data.message.starts_with("_AUDIT_LOGINUID=") {
-                if let Some((_, audit)) = data.message.split_once('=') {
-                    journal.audit_loginuid = audit.parse::<u32>().unwrap_or_default();
-                }
-            } else if data.message.starts_with("_SYSTEMD_CGROUP=") {
-                if let Some((_, cgroup)) = data.message.split_once('=') {
-                    journal.systemd_cgroup = cgroup.to_string();
-                }
-            } else if data.message.starts_with("_SYSTEMD_OWNER_UID=") {
-                if let Some((_, uid)) = data.message.split_once('=') {
-                    journal.systemd_owner_uid = uid.parse::<usize>().unwrap_or_default();
-                }
-            } else if data.message.starts_with("_SYSTEMD_UNIT=") {
-                if let Some((_, unit)) = data.message.split_once('=') {
-                    journal.systemd_unit = unit.to_string();
-                }
-            } else if data.message.starts_with("_SYSTEMD_USER_UNIT=") {
-                if let Some((_, unit)) = data.message.split_once('=') {
-                    journal.systemd_user_unit = unit.to_string();
-                }
-            } else if data.message.starts_with("_SYSTEMD_SLICE=") {
-                if let Some((_, slice)) = data.message.split_once('=') {
-                    journal.systemd_slice = slice.to_string();
-                }
-            } else if data.message.starts_with("_SYSTEMD_USER_SLICE=") {
-                if let Some((_, slice)) = data.message.split_once('=') {
-                    journal.systemd_user_slice = slice.to_string();
-                }
-            } else if data.message.starts_with("_BOOT_ID=") {
-                if let Some((_, boot)) = data.message.split_once('=') {
-                    journal.boot_id = boot.to_string();
-                }
-            } else if data.message.starts_with("_MACHINE_ID=") {
-                if let Some((_, id)) = data.message.split_once('=') {
-                    journal.machine_id = id.to_string();
-                }
-            } else if data.message.starts_with("_HOSTNAME=") {
-                if let Some((_, host)) = data.message.split_once('=') {
-                    journal.hostname = host.to_string();
-                }
-            } else if data.message.starts_with("_RUNTIME_SCOPE=") {
-                if let Some((_, scope)) = data.message.split_once('=') {
-                    journal.runtime_scope = scope.to_string();
-                }
-            } else if data.message.starts_with("_SOURCE_REALTIME_TIMESTAMP=") {
-                if let Some((_, timestamp)) = data.message.split_once('=') {
-                    journal.source_realtime = unixepoch_microseconds_to_iso(
-                        &timestamp.parse::<i64>().unwrap_or_default(),
-                    );
-                }
-            } else if data.message.starts_with("PRIORITY=") {
-                if let Some((_, priority)) = data.message.split_once('=') {
-                    journal.priority = get_priority(&priority.parse::<u32>().unwrap_or_default());
-                }
-            } else if data.message.starts_with("SYSLOG_FACILITY=") {
-                if let Some((_, facility)) = data.message.split_once('=') {
-                    journal.syslog_facility =
-                        get_facility(&facility.parse::<u32>().unwrap_or_default());
-                }
-            } else if data.message.starts_with("TID=") {
-                if let Some((_, tid)) = data.message.split_once('=') {
-                    journal.thread_id = tid.parse::<usize>().unwrap_or_default();
-                }
-            } else if data.message.starts_with("SYSLOG_IDENTIFIER=") {
-                if let Some((_, id)) = data.message.split_once('=') {
-                    journal.syslog_identifier = id.to_string();
-                }
-            } else if data.message.starts_with("CODE_FILE=") {
-                if let Some((_, code)) = data.message.split_once('=') {
-                    journal.code_file = code.to_string();
-                }
-            } else if data.message.starts_with("USER_INVOCATION_ID=") {
-                if let Some((_, id)) = data.message.split_once('=') {
-                    journal.user_invocation_id = id.to_string();
-                }
-            } else if data.message.starts_with("USER_UNIT=") {
-                if let Some((_, unit)) = data.message.split_once('=') {
-                    journal.user_unit = unit.to_string();
-                }
-            } else if data.message.starts_with("CODE_LINE=") {
-                if let Some((_, code)) = data.message.split_once('=') {
-                    journal.code_line = code.parse::<usize>().unwrap_or_default();
-                }
-            } else if data.message.starts_with("CODE_FUNC=") {
-                if let Some((_, code)) = data.message.split_once('=') {
-                    journal.code_function = code.to_string();
-                }
-            } else if data.message.starts_with("MESSAGE_ID=") {
-                if let Some((_, message)) = data.message.split_once('=') {
-                    journal.message_id = message.to_string();
-                }
-            } else if data.message.starts_with("MESSAGE=") {
-                if let Some((_, message)) = data.message.split_once('=') {
-                    journal.message = message.to_string();
-                }
-            } else if data.message.starts_with("UNIT_RESULT=") {
-                if let Some((_, unit)) = data.message.split_once('=') {
-                    journal.unit_result = unit.to_string();
-                }
-            } else if let Some((field, field_data)) = data.message.split_once('=') {
-                journal
-                    .custom
-                    .insert(field.to_string(), field_data.to_string());
-            }
-        }
-
-        journal_entries.push(journal);
-    }
-    journal_entries
-}
-
-/// Get message priority
-fn get_priority(priority: &u32) -> Priority {
-    match priority {
-        0 => Priority::Emergency,
-        1 => Priority::Alert,
-        2 => Priority::Critical,
-        3 => Priority::Error,
-        4 => Priority::Warning,
-        5 => Priority::Notice,
-        6 => Priority::Informational,
-        7 => Priority::Debug,
-        _ => Priority::None,
-    }
-}
-
-/// Get syslog facility if any
-fn get_facility(facility: &u32) -> Facility {
-    match facility {
-        0 => Facility::Kernel,
-        1 => Facility::User,
-        2 => Facility::Mail,
-        3 => Facility::Daemon,
-        4 => Facility::Authentication,
-        5 => Facility::Syslog,
-        6 => Facility::LinePrinter,
-        7 => Facility::News,
-        8 => Facility::Uucp,
-        9 => Facility::Clock,
-        10 => Facility::AuthenticationPriv,
-        11 => Facility::Ftp,
-        12 => Facility::Ntp,
-        13 => Facility::LogAudit,
-        14 => Facility::LogAlert,
-        15 => Facility::Cron,
-        16 => Facility::Local0,
-        17 => Facility::Local1,
-        18 => Facility::Local2,
-        19 => Facility::Local3,
-        20 => Facility::Local4,
-        21 => Facility::Local5,
-        22 => Facility::Local6,
-        23 => Facility::Local7,
-        _ => Facility::None,
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::{get_entries, parse_journal};
     use crate::{
-        artifacts::os::linux::journals::{
-            journal::{get_facility, get_priority, parse_journal_file},
-            objects::{
-                array::EntryArray,
-                header::{ObjectHeader, ObjectType},
-            },
-        },
-        filesystem::files::file_reader,
-        structs::toml::Output,
+        artifacts::os::linux::journals::journal::parse_journal_file,
+        filesystem::files::file_reader, structs::toml::Output,
     };
-    use common::linux::{Facility, Priority};
     use std::path::PathBuf;
 
     fn output_options(name: &str, output: &str, directory: &str, compress: bool) -> Output {
@@ -527,49 +239,6 @@ mod tests {
         let mut reader = file_reader(&test_location.display().to_string()).unwrap();
         let mut output = output_options("journal_test", "local", "./tmp", false);
         get_entries(&mut reader, 3738992, true, &mut output, &false, &0).unwrap();
-    }
-
-    #[test]
-    fn test_parse_messages() {
-        let mut test_location = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        test_location.push("tests/test_data/linux/journal/user-1000@e755452aab34485787b6d73f3035fb8c-000000000000068d-0005ff8ae923c73b.journal");
-
-        let mut reader = file_reader(&test_location.display().to_string()).unwrap();
-        let mut offset = 3738992;
-        let last_entry = 0;
-
-        let mut entries = EntryArray {
-            entries: Vec::new(),
-            next_entry_array_offset: 0,
-        };
-
-        while offset != last_entry {
-            let object_header = ObjectHeader::parse_header(&mut reader, offset).unwrap();
-            if object_header.obj_type != ObjectType::EntryArray {
-                break;
-            }
-
-            let (_, mut entry_array) =
-                EntryArray::walk_entries(&mut reader, &object_header.payload, true).unwrap();
-            entries.entries.append(&mut entry_array.entries);
-            offset = entry_array.next_entry_array_offset;
-        }
-
-        assert_eq!(entries.entries.len(), 410);
-    }
-
-    #[test]
-    fn test_get_priority() {
-        let test = 1;
-        let result = get_priority(&test);
-        assert_eq!(result, Priority::Alert);
-    }
-
-    #[test]
-    fn test_get_facility() {
-        let test = 1;
-        let result = get_facility(&test);
-        assert_eq!(result, Facility::User);
     }
 
     #[test]

--- a/forensics/src/artifacts/os/linux/journals/objects/array.rs
+++ b/forensics/src/artifacts/os/linux/journals/objects/array.rs
@@ -2,9 +2,17 @@ use super::{
     entry::Entry,
     header::{ObjectHeader, ObjectType},
 };
-use crate::utils::nom_helper::{Endian, nom_unsigned_eight_bytes, nom_unsigned_four_bytes};
+use crate::{
+    artifacts::os::linux::artifacts::output_data,
+    structs::toml::Output,
+    utils::{
+        nom_helper::{Endian, nom_unsigned_eight_bytes, nom_unsigned_four_bytes},
+        time::unixepoch_microseconds_to_iso,
+    },
+};
+use common::linux::{Facility, Journal, Priority};
 use log::{error, warn};
-use std::fs::File;
+use std::{collections::HashMap, fs::File};
 
 #[derive(Debug)]
 pub(crate) struct EntryArray {
@@ -14,11 +22,108 @@ pub(crate) struct EntryArray {
 }
 
 impl EntryArray {
-    /// Walk through Array of entries
+    /// Walk through Array of entries and output the results
+    /// Returns offset to next array of data
     pub(crate) fn walk_entries<'a>(
         reader: &mut File,
         data: &'a [u8],
-        is_compact: bool,
+        is_compact: &bool,
+        output: &mut Output,
+        filter: &bool,
+        start_time: &u64,
+    ) -> nom::IResult<&'a [u8], u64> {
+        let (mut input, next_entry_array_offset) = nom_unsigned_eight_bytes(data, Endian::Le)?;
+
+        let min_size = 4;
+        let mut entry_array = EntryArray {
+            entries: Vec::new(),
+            next_entry_array_offset,
+        };
+        let last_entry = 0;
+        // Limit memory usage by outputting every 1k log entries
+        let limit = 1000;
+        while !input.is_empty() && input.len() >= min_size {
+            let (remaining_input, offset) = if *is_compact {
+                let (remaining_input, offset) = nom_unsigned_four_bytes(input, Endian::Le)?;
+                (remaining_input, offset as u64)
+            } else {
+                nom_unsigned_eight_bytes(input, Endian::Le)?
+            };
+            input = remaining_input;
+
+            if offset == last_entry {
+                break;
+            }
+            let object_result = ObjectHeader::parse_header(reader, offset);
+            let object_header = match object_result {
+                Ok(result) => result,
+                Err(err) => {
+                    error!["[journal] Could not parse object header for entry in array: {err:?}"];
+                    continue;
+                }
+            };
+
+            if object_header.obj_type != ObjectType::Entry {
+                warn!("[journal] Did not get Entry object type!");
+                continue;
+            }
+
+            // Parse the log entry
+            let entry_result = Entry::parse_entry(reader, &object_header.payload, is_compact);
+            let entry = match entry_result {
+                Ok((_, result)) => result,
+                Err(_err) => {
+                    error!("[journal] Could not parse entry data");
+                    continue;
+                }
+            };
+            entry_array.entries.push(entry);
+
+            // The Journal file can be configured to be very large. Default size is usually ~10MB
+            // To limit memory usage we output every 1k entries
+            if entry_array.entries.len() >= limit {
+                let messages = EntryArray::parse_messages(&entry_array.entries);
+                let serde_data_result = serde_json::to_value(messages);
+                let mut serde_data = match serde_data_result {
+                    Ok(results) => results,
+                    Err(err) => {
+                        error!("[journal] Failed to serialize journal data: {err:?}");
+                        continue;
+                    }
+                };
+
+                let _ = output_data(&mut serde_data, "journal", output, start_time, filter);
+                // Now empty the vec
+                entry_array.entries = Vec::new();
+            }
+        }
+
+        if entry_array.entries.is_empty() {
+            return Ok((input, entry_array.next_entry_array_offset));
+        }
+
+        // Output any leftover messages
+        let messages = EntryArray::parse_messages(&entry_array.entries);
+        let serde_data_result = serde_json::to_value(messages);
+        let mut serde_data: serde_json::Value = match serde_data_result {
+            Ok(results) => results,
+            Err(err) => {
+                error!("[journal] Failed to serialize last journal data: {err:?}");
+                return Ok((input, entry_array.next_entry_array_offset));
+            }
+        };
+
+        let _ = output_data(&mut serde_data, "journal", output, start_time, filter);
+
+        Ok((input, entry_array.next_entry_array_offset))
+    }
+
+    /// Walk through Array of entries and return to caller.
+    /// Used for JS runtime
+    pub(crate) fn walk_all_entries<'a>(
+        reader: &mut File,
+        data: &'a [u8],
+        is_compact: &bool,
     ) -> nom::IResult<&'a [u8], EntryArray> {
         let (mut input, next_entry_array_offset) = nom_unsigned_eight_bytes(data, Endian::Le)?;
 
@@ -29,7 +134,7 @@ impl EntryArray {
         };
         let last_entry = 0;
         while !input.is_empty() && input.len() >= min_size {
-            let (remaining_input, offset) = if is_compact {
+            let (remaining_input, offset) = if *is_compact {
                 let (remaining_input, offset) = nom_unsigned_four_bytes(input, Endian::Le)?;
                 (remaining_input, offset as u64)
             } else {
@@ -67,6 +172,250 @@ impl EntryArray {
 
         Ok((input, entry_array))
     }
+
+    /// Parse the `Journal` message
+    pub(crate) fn parse_messages(entries: &[Entry]) -> Vec<Journal> {
+        let mut journal_entries: Vec<Journal> = Vec::new();
+
+        for entry in entries {
+            let mut journal = Journal {
+                uid: 0,
+                gid: 0,
+                pid: 0,
+                comm: String::new(),
+                priority: Priority::None,
+                syslog_facility: Facility::None,
+                thread_id: 0,
+                syslog_identifier: String::new(),
+                executable: String::new(),
+                cmdline: String::new(),
+                cap_effective: String::new(),
+                audit_session: 0,
+                audit_loginuid: 0,
+                systemd_cgroup: String::new(),
+                systemd_owner_uid: 0,
+                systemd_unit: String::new(),
+                systemd_user_unit: String::new(),
+                systemd_slice: String::new(),
+                systemd_user_slice: String::new(),
+                systemd_invocation_id: String::new(),
+                boot_id: String::new(),
+                machine_id: String::new(),
+                hostname: String::new(),
+                runtime_scope: String::new(),
+                source_realtime: String::new(),
+                realtime: unixepoch_microseconds_to_iso(&(entry.realtime as i64)),
+                seqnum: entry.seqnum,
+                transport: String::new(),
+                message: String::new(),
+                message_id: String::new(),
+                unit_result: String::new(),
+                code_line: 0,
+                code_function: String::new(),
+                code_file: String::new(),
+                user_invocation_id: String::new(),
+                user_unit: String::new(),
+                custom: HashMap::new(),
+            };
+
+            for data in &entry.data_objects {
+                if data.message.starts_with("_PID=") {
+                    if let Some((_, pid)) = data.message.split_once('=') {
+                        journal.pid = pid.parse::<usize>().unwrap_or_default();
+                    }
+                } else if data.message.starts_with("_TRANSPORT=") {
+                    if let Some((_, transport)) = data.message.split_once('=') {
+                        journal.transport = transport.to_string();
+                    }
+                } else if data.message.starts_with("_UID=") {
+                    if let Some((_, uid)) = data.message.split_once('=') {
+                        journal.uid = uid.parse::<u32>().unwrap_or_default();
+                    }
+                } else if data.message.starts_with("_GID=") {
+                    if let Some((_, gid)) = data.message.split_once('=') {
+                        journal.gid = gid.parse::<u32>().unwrap_or_default();
+                    }
+                } else if data.message.starts_with("_COMM=") {
+                    if let Some((_, comm)) = data.message.split_once('=') {
+                        journal.comm = comm.to_string();
+                    }
+                } else if data.message.starts_with("_EXE=") {
+                    if let Some((_, exe)) = data.message.split_once('=') {
+                        journal.executable = exe.to_string();
+                    }
+                } else if data.message.starts_with("_CMDLINE=") {
+                    if let Some((_, cmdline)) = data.message.split_once('=') {
+                        journal.cmdline = cmdline.to_string();
+                    }
+                } else if data.message.starts_with("_CAP_EFFECTIVE=") {
+                    if let Some((_, cap)) = data.message.split_once('=') {
+                        journal.cap_effective = cap.to_string();
+                    }
+                } else if data.message.starts_with("_AUDIT_SESSION=") {
+                    if let Some((_, session)) = data.message.split_once('=') {
+                        journal.audit_session = session.parse::<usize>().unwrap_or_default();
+                    }
+                } else if data.message.starts_with("_SYSTEMD_INVOCATION_ID=") {
+                    if let Some((_, invoc)) = data.message.split_once('=') {
+                        journal.systemd_invocation_id = invoc.to_string();
+                    }
+                } else if data.message.starts_with("_AUDIT_LOGINUID=") {
+                    if let Some((_, audit)) = data.message.split_once('=') {
+                        journal.audit_loginuid = audit.parse::<u32>().unwrap_or_default();
+                    }
+                } else if data.message.starts_with("_SYSTEMD_CGROUP=") {
+                    if let Some((_, cgroup)) = data.message.split_once('=') {
+                        journal.systemd_cgroup = cgroup.to_string();
+                    }
+                } else if data.message.starts_with("_SYSTEMD_OWNER_UID=") {
+                    if let Some((_, uid)) = data.message.split_once('=') {
+                        journal.systemd_owner_uid = uid.parse::<usize>().unwrap_or_default();
+                    }
+                } else if data.message.starts_with("_SYSTEMD_UNIT=") {
+                    if let Some((_, unit)) = data.message.split_once('=') {
+                        journal.systemd_unit = unit.to_string();
+                    }
+                } else if data.message.starts_with("_SYSTEMD_USER_UNIT=") {
+                    if let Some((_, unit)) = data.message.split_once('=') {
+                        journal.systemd_user_unit = unit.to_string();
+                    }
+                } else if data.message.starts_with("_SYSTEMD_SLICE=") {
+                    if let Some((_, slice)) = data.message.split_once('=') {
+                        journal.systemd_slice = slice.to_string();
+                    }
+                } else if data.message.starts_with("_SYSTEMD_USER_SLICE=") {
+                    if let Some((_, slice)) = data.message.split_once('=') {
+                        journal.systemd_user_slice = slice.to_string();
+                    }
+                } else if data.message.starts_with("_BOOT_ID=") {
+                    if let Some((_, boot)) = data.message.split_once('=') {
+                        journal.boot_id = boot.to_string();
+                    }
+                } else if data.message.starts_with("_MACHINE_ID=") {
+                    if let Some((_, id)) = data.message.split_once('=') {
+                        journal.machine_id = id.to_string();
+                    }
+                } else if data.message.starts_with("_HOSTNAME=") {
+                    if let Some((_, host)) = data.message.split_once('=') {
+                        journal.hostname = host.to_string();
+                    }
+                } else if data.message.starts_with("_RUNTIME_SCOPE=") {
+                    if let Some((_, scope)) = data.message.split_once('=') {
+                        journal.runtime_scope = scope.to_string();
+                    }
+                } else if data.message.starts_with("_SOURCE_REALTIME_TIMESTAMP=") {
+                    if let Some((_, timestamp)) = data.message.split_once('=') {
+                        journal.source_realtime = unixepoch_microseconds_to_iso(
+                            &timestamp.parse::<i64>().unwrap_or_default(),
+                        );
+                    }
+                } else if data.message.starts_with("PRIORITY=") {
+                    if let Some((_, priority)) = data.message.split_once('=') {
+                        journal.priority =
+                            EntryArray::get_priority(&priority.parse::<u32>().unwrap_or_default());
+                    }
+                } else if data.message.starts_with("SYSLOG_FACILITY=") {
+                    if let Some((_, facility)) = data.message.split_once('=') {
+                        journal.syslog_facility =
+                            EntryArray::get_facility(&facility.parse::<u32>().unwrap_or_default());
+                    }
+                } else if data.message.starts_with("TID=") {
+                    if let Some((_, tid)) = data.message.split_once('=') {
+                        journal.thread_id = tid.parse::<usize>().unwrap_or_default();
+                    }
+                } else if data.message.starts_with("SYSLOG_IDENTIFIER=") {
+                    if let Some((_, id)) = data.message.split_once('=') {
+                        journal.syslog_identifier = id.to_string();
+                    }
+                } else if data.message.starts_with("CODE_FILE=") {
+                    if let Some((_, code)) = data.message.split_once('=') {
+                        journal.code_file = code.to_string();
+                    }
+                } else if data.message.starts_with("USER_INVOCATION_ID=") {
+                    if let Some((_, id)) = data.message.split_once('=') {
+                        journal.user_invocation_id = id.to_string();
+                    }
+                } else if data.message.starts_with("USER_UNIT=") {
+                    if let Some((_, unit)) = data.message.split_once('=') {
+                        journal.user_unit = unit.to_string();
+                    }
+                } else if data.message.starts_with("CODE_LINE=") {
+                    if let Some((_, code)) = data.message.split_once('=') {
+                        journal.code_line = code.parse::<usize>().unwrap_or_default();
+                    }
+                } else if data.message.starts_with("CODE_FUNC=") {
+                    if let Some((_, code)) = data.message.split_once('=') {
+                        journal.code_function = code.to_string();
+                    }
+                } else if data.message.starts_with("MESSAGE_ID=") {
+                    if let Some((_, message)) = data.message.split_once('=') {
+                        journal.message_id = message.to_string();
+                    }
+                } else if data.message.starts_with("MESSAGE=") {
+                    if let Some((_, message)) = data.message.split_once('=') {
+                        journal.message = message.to_string();
+                    }
+                } else if data.message.starts_with("UNIT_RESULT=") {
+                    if let Some((_, unit)) = data.message.split_once('=') {
+                        journal.unit_result = unit.to_string();
+                    }
+                } else if let Some((field, field_data)) = data.message.split_once('=') {
+                    journal
+                        .custom
+                        .insert(field.to_string(), field_data.to_string());
+                }
+            }
+
+            journal_entries.push(journal);
+        }
+        journal_entries
+    }
+
+    /// Get message priority
+    fn get_priority(priority: &u32) -> Priority {
+        match priority {
+            0 => Priority::Emergency,
+            1 => Priority::Alert,
+            2 => Priority::Critical,
+            3 => Priority::Error,
+            4 => Priority::Warning,
+            5 => Priority::Notice,
+            6 => Priority::Informational,
+            7 => Priority::Debug,
+            _ => Priority::None,
+        }
+    }
+
+    /// Get syslog facility if any
+    fn get_facility(facility: &u32) -> Facility {
+        match facility {
+            0 => Facility::Kernel,
+            1 => Facility::User,
+            2 => Facility::Mail,
+            3 => Facility::Daemon,
+            4 => Facility::Authentication,
+            5 => Facility::Syslog,
+            6 => Facility::LinePrinter,
+            7 => Facility::News,
+            8 => Facility::Uucp,
+            9 => Facility::Clock,
+            10 => Facility::AuthenticationPriv,
+            11 => Facility::Ftp,
+            12 => Facility::Ntp,
+            13 => Facility::LogAudit,
+            14 => Facility::LogAlert,
+            15 => Facility::Cron,
+            16 => Facility::Local0,
+            17 => Facility::Local1,
+            18 => Facility::Local2,
+            19 => Facility::Local3,
+            20 => Facility::Local4,
+            21 => Facility::Local5,
+            22 => Facility::Local6,
+            23 => Facility::Local7,
+            _ => Facility::None,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -78,8 +427,28 @@ mod tests {
             objects::header::{ObjectHeader, ObjectType},
         },
         filesystem::files::file_reader,
+        structs::toml::Output,
     };
+    use common::linux::{Facility, Priority};
     use std::{io::Read, path::PathBuf};
+
+    fn output_options(name: &str, output: &str, directory: &str, compress: bool) -> Output {
+        Output {
+            name: name.to_string(),
+            directory: directory.to_string(),
+            format: String::from("json"),
+            compress,
+            timeline: false,
+            url: Some(String::new()),
+            api_key: Some(String::new()),
+            endpoint_id: String::from("abcd"),
+            collection_id: 0,
+            output: output.to_string(),
+            filter_name: Some(String::new()),
+            filter_script: Some(String::new()),
+            logging: Some(String::new()),
+        }
+    }
 
     #[test]
     fn test_walk_entries() {
@@ -98,9 +467,91 @@ mod tests {
         } else {
             false
         };
+        let mut output = output_options("journal_test", "local", "./tmp", false);
+
+        let (_, result) = EntryArray::walk_entries(
+            &mut reader,
+            &object.payload,
+            &is_compact,
+            &mut output,
+            &false,
+            &0,
+        )
+        .unwrap();
+        assert_eq!(result, 3744448);
+    }
+
+    #[test]
+    fn test_walk_all_entries() {
+        let mut test_location = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        test_location.push("tests/test_data/linux/journal/user-1000@e755452aab34485787b6d73f3035fb8c-000000000000068d-0005ff8ae923c73b.journal");
+
+        let mut reader = file_reader(&test_location.display().to_string()).unwrap();
+        let mut buff = [0; 264];
+        let _ = reader.read(&mut buff).unwrap();
+
+        let (_, header) = JournalHeader::parse_header(&buff).unwrap();
+        let object = ObjectHeader::parse_header(&mut reader, header.entry_array_offset).unwrap();
+        assert_eq!(object.obj_type, ObjectType::EntryArray);
+        let is_compact = if header.incompatible_flags.contains(&IncompatFlags::Compact) {
+            true
+        } else {
+            false
+        };
+
         let (_, result) =
-            EntryArray::walk_entries(&mut reader, &object.payload, is_compact).unwrap();
-        assert_eq!(result.next_entry_array_offset, 3744448);
+            EntryArray::walk_all_entries(&mut reader, &object.payload, &is_compact).unwrap();
         assert_eq!(result.entries.len(), 4);
+        assert_eq!(result.entries[2].realtime, 1688346965580106);
+    }
+
+    #[test]
+    fn test_parse_messages() {
+        let mut test_location = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        test_location.push("tests/test_data/linux/journal/user-1000@e755452aab34485787b6d73f3035fb8c-000000000000068d-0005ff8ae923c73b.journal");
+
+        let mut reader = file_reader(&test_location.display().to_string()).unwrap();
+        let mut buff = [0; 264];
+        let _ = reader.read(&mut buff).unwrap();
+
+        let (_, header) = JournalHeader::parse_header(&buff).unwrap();
+        let object = ObjectHeader::parse_header(&mut reader, header.entry_array_offset).unwrap();
+        assert_eq!(object.obj_type, ObjectType::EntryArray);
+        let is_compact = if header.incompatible_flags.contains(&IncompatFlags::Compact) {
+            true
+        } else {
+            false
+        };
+
+        let (_, result) =
+            EntryArray::walk_all_entries(&mut reader, &object.payload, &is_compact).unwrap();
+        assert_eq!(result.entries.len(), 4);
+        assert_eq!(result.entries[2].realtime, 1688346965580106);
+
+        let messages = EntryArray::parse_messages(&result.entries);
+        assert_eq!(
+            messages[2].message,
+            "Started grub-boot-success.timer - Mark boot as successful after the user session has run 2 minutes."
+        );
+        assert_eq!(messages[1].boot_id, "05a969ef57fe4934900b598c83f62d76");
+        assert_eq!(messages[3].executable, "/usr/lib/systemd/systemd");
+    }
+
+    #[test]
+    fn test_get_priority() {
+        let test = [0, 1, 2, 3, 4, 5, 6, 7];
+        for entry in test {
+            let result = EntryArray::get_priority(&entry);
+            assert!(result != Priority::None);
+        }
+    }
+
+    #[test]
+    fn test_get_facility() {
+        let test: Vec<u32> = (0..23).collect();
+        for entry in test {
+            let result = EntryArray::get_facility(&entry);
+            assert!(result != Facility::None);
+        }
     }
 }

--- a/forensics/src/artifacts/os/linux/journals/objects/data.rs
+++ b/forensics/src/artifacts/os/linux/journals/objects/data.rs
@@ -25,7 +25,7 @@ impl DataObject {
     /// Parse Data object in `Journal`
     pub(crate) fn parse_data_object<'a>(
         data: &'a [u8],
-        is_compact: bool,
+        is_compact: &bool,
         compress_type: &ObjectFlag,
     ) -> nom::IResult<&'a [u8], DataObject> {
         let (input, hash) = nom_unsigned_eight_bytes(data, Endian::Le)?;
@@ -46,7 +46,7 @@ impl DataObject {
             tail_entry_array_n_entries: 0,
             message: String::new(),
         };
-        if is_compact {
+        if *is_compact {
             let (remaining_input, tail_entry_array_offset) =
                 nom_unsigned_four_bytes(input, Endian::Le)?;
             let (remaining_input, tail_entry_array_n_entries) =
@@ -126,7 +126,7 @@ mod tests {
         ];
 
         let (_, result) =
-            DataObject::parse_data_object(&test_data, true, &ObjectFlag::None).unwrap();
+            DataObject::parse_data_object(&test_data, &true, &ObjectFlag::None).unwrap();
         assert_eq!(result._entry_array_offset, 3740720);
         assert_eq!(result._hash, 6767068781486187566);
         assert_eq!(result._next_field_offset, 0);

--- a/forensics/src/artifacts/os/linux/journals/objects/entry.rs
+++ b/forensics/src/artifacts/os/linux/journals/objects/entry.rs
@@ -21,7 +21,7 @@ impl Entry {
     pub(crate) fn parse_entry<'a>(
         reader: &mut File,
         data: &'a [u8],
-        is_compact: bool,
+        is_compact: &bool,
     ) -> nom::IResult<&'a [u8], Entry> {
         let (input, seqnum) = nom_unsigned_eight_bytes(data, Endian::Le)?;
         let (input, realtime) = nom_unsigned_eight_bytes(input, Endian::Le)?;
@@ -40,7 +40,7 @@ impl Entry {
         };
         let min_size = 4;
         while !input.is_empty() && input.len() >= min_size {
-            let (_hash, offset) = if !is_compact {
+            let (_hash, offset) = if !*is_compact {
                 let (remaining_input, offset) = nom_unsigned_eight_bytes(input, Endian::Le)?;
                 let (remaining_input, hash) =
                     nom_unsigned_eight_bytes(remaining_input, Endian::Le)?;
@@ -107,7 +107,7 @@ mod tests {
             57, 0, 32, 6, 57, 0, 192, 6, 57, 0, 104, 7, 57, 0, 8, 8, 57, 0, 176, 8, 57, 0, 112, 9,
             57, 0, 48, 10, 57, 0, 216, 10, 57, 0, 136, 11, 57, 0, 24, 12, 57, 0,
         ];
-        let (_, result) = Entry::parse_entry(&mut reader, &test_data, true).unwrap();
+        let (_, result) = Entry::parse_entry(&mut reader, &test_data, &true).unwrap();
         assert_eq!(result._boot_id, 0x762DF6838C590B903449FE57EF69A905);
         assert_eq!(result.seqnum, 1677);
         assert_eq!(result._monotonic, 69830830);

--- a/forensics/src/output/formats/json.rs
+++ b/forensics/src/output/formats/json.rs
@@ -3,7 +3,7 @@ use crate::{
     artifacts::os::systeminfo::info::get_info_metadata,
     structs::toml::Output,
     utils::{
-        compression::compress::compress_gzip_data,
+        compression::compress::compress_gzip_bytes,
         logging::collection_status,
         output::final_output,
         time::{time_now, unixepoch_to_iso},
@@ -70,7 +70,8 @@ pub(crate) fn raw_json(
 ) -> Result<(), FormatError> {
     let mut collection_data = Vec::new();
     if output.compress {
-        let compressed_results = compress_gzip_data(serde_data);
+        let compressed_results =
+            compress_gzip_bytes(&serde_json::to_vec(serde_data).unwrap_or_default());
         collection_data = match compressed_results {
             Ok(result) => result,
             Err(err) => {

--- a/forensics/src/utils/compression/compress.rs
+++ b/forensics/src/utils/compression/compress.rs
@@ -2,27 +2,9 @@ use super::error::CompressionError;
 use crate::filesystem::files::read_file;
 use flate2::{Compression, write::GzEncoder};
 use log::{error, warn};
-use serde_json::Value;
 use std::{fs::File, io::Write};
 use walkdir::WalkDir;
 use zip::{ZipWriter, write::SimpleFileOptions};
-
-/// Compress provided data with GZIP
-pub(crate) fn compress_gzip_data(serde_data: &Value) -> Result<Vec<u8>, CompressionError> {
-    let mut gz = GzEncoder::new(Vec::new(), Compression::default());
-    let _ = serde_json::to_writer(&mut gz, serde_data);
-    let finish_status = gz.finish();
-
-    let data = match finish_status {
-        Ok(results) => results,
-        Err(err) => {
-            error!("[compression] Could not finish gzip compressing data: {err:?}");
-            return Err(CompressionError::GzipFinish);
-        }
-    };
-
-    Ok(data)
-}
 
 /// Compress provided bytes with GZIP
 pub(crate) fn compress_gzip_bytes(data: &[u8]) -> Result<Vec<u8>, CompressionError> {
@@ -120,19 +102,11 @@ pub(crate) fn compress_output_zip(directory: &str, zip_name: &str) -> Result<(),
 
 #[cfg(test)]
 mod tests {
-    use super::compress_gzip_data;
     use crate::{
         filesystem::files::read_file,
         utils::compression::compress::{compress_gzip_bytes, compress_output_zip},
     };
     use std::{fs::remove_file, path::PathBuf};
-
-    #[test]
-    fn test_compress_gzip_data() {
-        let data = "compressme";
-        let results = compress_gzip_data(&serde_json::to_value(data).unwrap()).unwrap();
-        assert_eq!(results.len(), 32)
-    }
 
     #[test]
     fn test_compress_gzip_bytes() {


### PR DESCRIPTION
This PR reduces memory usage when parsing Linux journal files.
Artemis should now use ~50MBs (previously ~300MB-800MB) of memory when parsing the journal log files.

Also improved the speed the when compressing json output