### PR TITLE
Registry update

### DIFF
--- a/.changes/unreleased/Changed-20250716-210837.yaml
+++ b/.changes/unreleased/Changed-20250716-210837.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: Reduced memory usage for Registry parser
+time: 2025-07-16T21:08:37.376718384-04:00

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -951,9 +951,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -961,9 +961,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
 dependencies = [
  "anstream",
  "anstyle",
@@ -973,9 +973,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -4828,9 +4828,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.35.2"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3ffa3e4ff2b324a57f7aeb3c349656c7b127c3c189520251a648102a92496e"
+checksum = "aab138f5c1bb35231de19049060a87977ad23e04f2303e953bc5c2947ac7dec4"
 dependencies = [
  "libc",
  "memchr",
@@ -5112,9 +5112,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f271e09bde39ab52250160a67e88577e0559ad77e9085de6e9051a2c4353f8f8"
+checksum = "ed0aee96c12fa71097902e0bb061a5e1ebd766a6636bb605ba401c45c1650eac"
 dependencies = [
  "indexmap 2.10.0",
  "serde",
@@ -5153,9 +5153,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5c1c469eda89749d2230d8156a5969a69ffe0d6d01200581cdc6110674d293e"
+checksum = "97200572db069e74c512a14117b296ba0a80a30123fbbb5aa1f4a348f639ca30"
 dependencies = [
  "winnow",
 ]
@@ -6155,9 +6155,9 @@ dependencies = [
 
 [[package]]
 name = "yara-x"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c4ec27026699304f05bd83042bf478bc6af3864384d77c543a4d34c31eaf303"
+checksum = "ad19e8ae5b6542e06cdf9ffd62690231b7b9b14ae717a8d94b772713d04beefb"
 dependencies = [
  "aho-corasick",
  "annotate-snippets",
@@ -6217,9 +6217,9 @@ dependencies = [
 
 [[package]]
 name = "yara-x-macros"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fb388d6c26ff141122e7faef88d83b768fa7264a0c178e30e53f83290e0e911"
+checksum = "88535b229ed05a4fce90def2b855fbec9c82463b02ec64db2312ea0702ed9288"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -6229,9 +6229,9 @@ dependencies = [
 
 [[package]]
 name = "yara-x-parser"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace120867d29e4fb736fdc133ec526bfbb0d9f86a18d985d7aabc9228c454bcd"
+checksum = "7f5eea847933138566f4905487f8ef0d7a335d129852e96877ef3890b08178ce"
 dependencies = [
  "ascii_tree",
  "bitflags 2.9.1",
@@ -6247,9 +6247,9 @@ dependencies = [
 
 [[package]]
 name = "yara-x-proto"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d53636c657d4b84c9a0fa239373bad27e7d35139d2e2b5c5003a695d978dca"
+checksum = "a70cba12d8c2ec2c4fc0113cd1924d3de49dde57ab0784ca293d9287cb7e34d9"
 dependencies = [
  "protobuf",
  "protobuf-codegen",
@@ -6407,9 +6407,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ab361742de920c5535880f89bbd611ee62002bf11341d16a5f057bb8ba6899"
+checksum = "9aed4ac33e8eb078c89e6cbb1d5c4c7703ec6d299fc3e7c3695af8f8b423468b"
 dependencies = [
  "arbitrary",
  "crc32fast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ description = "A cross platform forensic parser"
 serde = { version = "1.0.219", features = ["derive"] }
 log = "0.4.27"
 serde_json = "1.0.140"
-toml = "0.9.0"
+toml = "0.9.2"
 base64 = "0.22.1"
 tokio = { version = "1.46.1", features = ["full"] }
 flate2 = "1.1.2"
@@ -34,6 +34,6 @@ reqwest = { version = "0.12.22", features = [
     "native-tls-vendored",
     "multipart",
 ] }
-sysinfo = "0.35.2"
+sysinfo = "0.36.0"
 uuid = { version = "1.17.0", features = ["v4"] }
 rusqlite = { version = "0.37.0", features = ["bundled", "serde_json"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -11,7 +11,7 @@ description = { workspace = true }
 base64 = { workspace = true }
 log = { workspace = true }
 forensics = { path = "../forensics", default-features = false }
-clap = { version = "4.5.40", features = ["std", "help", "derive"] }
+clap = { version = "4.5.41", features = ["std", "help", "derive"] }
 
 # Artemis features
 [features]

--- a/forensics/Cargo.toml
+++ b/forensics/Cargo.toml
@@ -33,7 +33,7 @@ walkdir = "2.5.0"
 home = "0.5.11"
 chrono = "0.4.41"
 simplelog = "0.12.2"
-zip = { version = "4.2.0", default-features = false }
+zip = { version = "4.3.0", default-features = false }
 jsonwebtoken = "9.3.1"
 rusty-s3 = "0.7.0"
 quick-xml = { version = "0.38.0", default-features = false }
@@ -51,7 +51,7 @@ macos-unifiedlogs = "0.3.2"
 plist = "1.7.4"
 aes = "0.8.4"
 cbc = "0.1.2"
-yara-x = { version = "1.3.0", optional = true, default-features = false, features = [
+yara-x = { version = "1.4.0", optional = true, default-features = false, features = [
     "constant-folding",
     "exact-atoms",
     "fast-regexp",

--- a/forensics/src/artifacts/os/windows/amcache/parser.rs
+++ b/forensics/src/artifacts/os/windows/amcache/parser.rs
@@ -63,7 +63,7 @@ fn amcache_file(drive: char) -> Result<Vec<Amcache>, AmcacheError> {
 }
 
 /**
- * `Amcache` is typically stored at the Registry file `C:\Windows\appcompat\Promgrams\Amcache.hve`
+ * `Amcache` is typically stored at the Registry file `C:\Windows\appcompat\Programs\Amcache.hve`
  * Parse the raw Registry file and get the entries related to file execution
  */
 fn parse_amcache(path: &str) -> Result<Vec<Amcache>, AmcacheError> {

--- a/forensics/src/artifacts/os/windows/bits/files.rs
+++ b/forensics/src/artifacts/os/windows/bits/files.rs
@@ -89,7 +89,7 @@ pub(crate) fn parse_file<'a>(
             54, 218, 86, 119, 111, 81, 90, 67, 172, 172, 68, 162, 72, 255, 243, 77,
         ];
         let (remaining_input, _) = take_until(delimiter.as_slice())(input)?;
-        let (remaining_input, _delimilter_data) =
+        let (remaining_input, _delimiter_data) =
             nom_unsigned_sixteen_bytes(remaining_input, Endian::Le)?;
         let (remaining_input, number_files) = nom_unsigned_four_bytes(remaining_input, Endian::Le)?;
         file_info.files_transferred = number_files;

--- a/forensics/src/artifacts/os/windows/eventlogs/combine.rs
+++ b/forensics/src/artifacts/os/windows/eventlogs/combine.rs
@@ -734,7 +734,7 @@ fn add_event_string(
 
     let mut event_value = serde_json::from_value(value.clone()).unwrap_or(value.to_string());
     if event_value.contains('%') {
-        // To avoid false postives in our regex from replacement event values. Remove % values
+        // To avoid false positives in our regex from replacement event values. Remove % values
         event_value = event_value.replace('%', "TEMP_ARTEMIS_VALUE");
     }
 

--- a/forensics/src/artifacts/os/windows/ole/sat.rs
+++ b/forensics/src/artifacts/os/windows/ole/sat.rs
@@ -1,7 +1,7 @@
 use crate::utils::nom_helper::{Endian, nom_signed_four_bytes};
 use nom::bytes::complete::take;
 
-/// Using data from the header. Find and assemble all data assicated with Sector Allocation Table (SAT)
+/// Using data from the header. Find and assemble all data associated with Sector Allocation Table (SAT)
 pub(crate) fn assemble_sat_data<'a>(
     data: &'a [u8],
     sat_sectors: &[u32],

--- a/forensics/src/artifacts/os/windows/registry/cell.rs
+++ b/forensics/src/artifacts/os/windows/registry/cell.rs
@@ -273,8 +273,6 @@ mod tests {
             start_time: 0,
         };
         let _ = walk_registry(&buffer, 216, &mut params, 4, &mut None).unwrap();
-
-        assert_eq!(params.registry_list.len(), 10);
     }
 
     #[test]

--- a/forensics/src/artifacts/os/windows/registry/cell.rs
+++ b/forensics/src/artifacts/os/windows/registry/cell.rs
@@ -71,7 +71,7 @@ pub(crate) fn walk_registry<'a>(
     }
     params.offset_tracker.insert(offset, offset);
     let (list_data, _) = take(offset)(reg_data)?;
-    // Get the size of the list and check if its allocated (negative numbers = allocated, postive number = unallocated)
+    // Get the size of the list and check if its allocated (negative numbers = allocated, positive number = unallocated)
     let (list_data, (allocated, size)) = is_allocated(list_data)?;
     if !allocated {
         return Ok((reg_data, ()));
@@ -118,7 +118,7 @@ pub(crate) fn walk_values(
     // Go to the value list offset
     let (list_data, _) = take(offset)(reg_data)?;
 
-    // Get the size of the list and check if its allocated (negative numbers = allocated, postive number = unallocated)
+    // Get the size of the list and check if its allocated (negative numbers = allocated, positive number = unallocated)
     let (list_data, (allocated, size)) = is_allocated(list_data)?;
     if !allocated {
         return Ok((reg_data, Vec::new()));
@@ -149,7 +149,7 @@ pub(crate) fn walk_values(
         // Go to the value key offset
         let (vk_data, _) = take(vk_offset as u32)(reg_data)?;
 
-        // Get the size of the valeu key and check if its allocated (negative numbers = allocated, postive number = unallocated)
+        // Get the size of the value key and check if its allocated (negative numbers = allocated, positive number = unallocated)
         let (vk_data, (allocated, size)) = is_allocated(vk_data)?;
         if !allocated {
             value_count += 1;
@@ -183,12 +183,12 @@ pub(crate) fn walk_values(
     Ok((reg_data, key_values))
 }
 
-/// Check if a cell is allocated. Negative number = allocated, postive number = unallocated
+/// Check if a cell is allocated. Negative number = allocated, positive number = unallocated
 pub(crate) fn is_allocated(data: &[u8]) -> nom::IResult<&[u8], (bool, u32)> {
     let (list_data, mut list_size) = nom_signed_four_bytes(data, Endian::Le)?;
     let cell_allocated = 0;
 
-    // If the size is a postive number then the cell is unallocated (deleted)
+    // If the size is a positive number then the cell is unallocated (deleted)
     // We currently do not parse deleted cells
     if list_size >= cell_allocated {
         return Ok((list_data, (false, 0)));

--- a/forensics/src/artifacts/os/windows/registry/hbin.rs
+++ b/forensics/src/artifacts/os/windows/registry/hbin.rs
@@ -57,7 +57,7 @@ impl HiveBin {
         let mut all_cells_data = input;
 
         while !all_cells_data.is_empty() {
-            // Get the size of the list and check if its allocated (negative numbers = allocated, postive number = unallocated)
+            // Get the size of the list and check if its allocated (negative numbers = allocated, positive number = unallocated)
             let (input, (allocated, size)) = is_allocated(all_cells_data)?;
 
             // Size includes the size itself. We nommed that away

--- a/forensics/src/artifacts/os/windows/registry/hbin.rs
+++ b/forensics/src/artifacts/os/windows/registry/hbin.rs
@@ -4,6 +4,7 @@ use crate::{
         cell::{CellType, get_cell_type, is_allocated},
         keys::nk::NameKey,
     },
+    structs::toml::Output,
     utils::nom_helper::{Endian, nom_unsigned_eight_bytes, nom_unsigned_four_bytes},
 };
 use common::windows::RegistryData;
@@ -48,6 +49,7 @@ impl HiveBin {
         hive_data: &'a [u8],
         params: &mut Params,
         minor_version: u32,
+        output: &mut Option<&mut Output>,
     ) -> nom::IResult<&'a [u8], Vec<RegistryData>> {
         let skip_header: usize = 32;
         // We already parsed the header data. We can skip it
@@ -81,7 +83,7 @@ impl HiveBin {
                 continue;
             }
             // We only need the ROOT key
-            NameKey::parse_name_key(reg_data, cell_data, params, minor_version)?;
+            NameKey::parse_name_key(reg_data, cell_data, params, minor_version, output)?;
             break;
         }
 
@@ -140,9 +142,11 @@ mod tests {
             offset_tracker: HashMap::new(),
             filter: false,
             registry_path: String::from("test\\test"),
+            start_time: 0,
         };
 
-        let (_, result) = HiveBin::parse_hive_cells(&buffer, &buffer, &mut params, 4).unwrap();
+        let (_, result) =
+            HiveBin::parse_hive_cells(&buffer, &buffer, &mut params, 4, &mut None).unwrap();
         assert_eq!(result.len(), 666)
     }
 }

--- a/forensics/src/artifacts/os/windows/registry/lists/lf.rs
+++ b/forensics/src/artifacts/os/windows/registry/lists/lf.rs
@@ -18,14 +18,12 @@ impl Leaf {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, path::PathBuf};
-
-    use regex::Regex;
-
     use crate::{
         artifacts::os::windows::registry::{hbin::HiveBin, lists::lf::Leaf, parser::Params},
         filesystem::files::read_file,
     };
+    use regex::Regex;
+    use std::{collections::HashMap, path::PathBuf};
 
     #[test]
     fn parse_leaf() {

--- a/forensics/src/artifacts/os/windows/registry/lists/lf.rs
+++ b/forensics/src/artifacts/os/windows/registry/lists/lf.rs
@@ -1,5 +1,5 @@
 use super::lh::HashLeaf;
-use crate::artifacts::os::windows::registry::parser::Params;
+use crate::{artifacts::os::windows::registry::parser::Params, structs::toml::Output};
 
 pub(crate) type Leaf = HashLeaf;
 
@@ -10,8 +10,9 @@ impl Leaf {
         lf_data: &'a [u8],
         params: &mut Params,
         minor_version: u32,
+        output: &mut Option<&mut Output>,
     ) -> nom::IResult<&'a [u8], ()> {
-        Leaf::parse_hash_leaf(reg_data, lf_data, params, minor_version)
+        Leaf::parse_hash_leaf(reg_data, lf_data, params, minor_version, output)
     }
 }
 
@@ -51,9 +52,10 @@ mod tests {
             offset_tracker: HashMap::new(),
             filter: false,
             registry_path: String::from("path/NTUSER.dat"),
+            start_time: 0,
         };
 
-        let (_, result) = Leaf::parse_leaf(&buffer, &test_data, &mut params, 4).unwrap();
+        let (_, result) = Leaf::parse_leaf(&buffer, &test_data, &mut params, 4, &mut None).unwrap();
         assert_eq!(result, ())
     }
 }

--- a/forensics/src/artifacts/os/windows/registry/lists/lh.rs
+++ b/forensics/src/artifacts/os/windows/registry/lists/lh.rs
@@ -1,5 +1,6 @@
 use crate::{
     artifacts::os::windows::registry::{cell::walk_registry, parser::Params},
+    structs::toml::Output,
     utils::nom_helper::{Endian, nom_unsigned_four_bytes, nom_unsigned_two_bytes},
 };
 
@@ -15,6 +16,7 @@ impl HashLeaf {
         lh_data: &'a [u8],
         params: &mut Params,
         minor_version: u32,
+        output: &mut Option<&mut Output>,
     ) -> nom::IResult<&'a [u8], ()> {
         let (input, sig) = nom_unsigned_two_bytes(lh_data, Endian::Le)?;
         let (mut input, number_entries) = nom_unsigned_two_bytes(input, Endian::Le)?;
@@ -36,7 +38,7 @@ impl HashLeaf {
                 continue;
             }
 
-            walk_registry(reg_data, offset, params, minor_version)?;
+            walk_registry(reg_data, offset, params, minor_version, output)?;
         }
         Ok((reg_data, ()))
     }
@@ -76,9 +78,11 @@ mod tests {
             offset_tracker: HashMap::new(),
             filter: false,
             registry_path: String::from("path/NTUSER.dat"),
+            start_time: 0,
         };
 
-        let (_, result) = HashLeaf::parse_hash_leaf(&buffer, &test_data, &mut params, 4).unwrap();
+        let (_, result) =
+            HashLeaf::parse_hash_leaf(&buffer, &test_data, &mut params, 4, &mut None).unwrap();
         assert_eq!(result, ())
     }
 }

--- a/forensics/src/artifacts/os/windows/registry/lists/ri.rs
+++ b/forensics/src/artifacts/os/windows/registry/lists/ri.rs
@@ -1,6 +1,5 @@
 use super::li::LeafItem;
-use crate::artifacts::os::windows::registry::parser::Params;
-
+use crate::{artifacts::os::windows::registry::parser::Params, structs::toml::Output};
 pub(crate) type RefItem = LeafItem;
 
 impl RefItem {
@@ -10,8 +9,9 @@ impl RefItem {
         ri_data: &'a [u8],
         params: &mut Params,
         minor_version: u32,
+        output: &mut Option<&mut Output>,
     ) -> nom::IResult<&'a [u8], ()> {
-        RefItem::parse_leaf_item(reg_data, ri_data, params, minor_version)
+        RefItem::parse_leaf_item(reg_data, ri_data, params, minor_version, output)
     }
 }
 
@@ -43,10 +43,11 @@ mod tests {
             offset_tracker: HashMap::new(),
             filter: false,
             registry_path: String::from("path/NTUSER.dat"),
+            start_time: 0,
         };
 
         let (_, result) =
-            RefItem::parse_reference_item(&buffer, &test_data, &mut params, 4).unwrap();
+            RefItem::parse_reference_item(&buffer, &test_data, &mut params, 4, &mut None).unwrap();
         assert_eq!(result, ())
     }
 }

--- a/forensics/src/filesystem/ntfs/raw_files.rs
+++ b/forensics/src/filesystem/ntfs/raw_files.rs
@@ -409,7 +409,7 @@ pub(crate) fn get_user_registry_files(
 
     let mut user_reg_files: Vec<UserRegistryFiles> = Vec::new();
 
-    // Remove any possible false postives
+    // Remove any possible false positives
     for entries in ntfs_options.filelist {
         let ntuser_depth = 4;
         let mut reg_file = UserRegistryFiles {


### PR DESCRIPTION
Updated Registry parser to output results while parsing instead of parsing the entire Registry and then output the results.
Should reduce memory usage dramatically