### PR TITLE
Reparse tag support

### DIFF
--- a/.changes/unreleased/Added-20250808-000643.yaml
+++ b/.changes/unreleased/Added-20250808-000643.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Support for extracting REPARSE_POINT tags
+time: 2025-08-08T00:06:43.43453895-04:00

--- a/.packages/artemis.control
+++ b/.packages/artemis.control
@@ -1,5 +1,5 @@
 Package: artemis
-Version: 0.15.0
+Version: 0.16.0
 Priority: optional
 Architecture: amd64
 Section: admin

--- a/.packages/artemis.spec
+++ b/.packages/artemis.spec
@@ -2,7 +2,7 @@ Name: artemis
 Release: 1
 Summary: A cross platform forensic parser
 License: MIT
-Version: 0.15.0
+Version: 0.16.0
 Group: Application/Security
 URL: https://puffycid.github.io/artemis-api
 BugURL: https://github.com/puffyCid/artemis

--- a/.packages/artemis.wxs
+++ b/.packages/artemis.wxs
@@ -1,5 +1,5 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
-    <Package Id="io.github.puffycid.Artemis" Name="Artemis" Manufacturer="PuffyCid" Version="0.15.0" Compressed="yes" Codepage="UTF-8" InstallerVersion="500" Language="1033" ProductCode="*" Scope="perMachine" ShortNames="no" UpgradeStrategy="majorUpgrade">
+    <Package Id="io.github.puffycid.Artemis" Name="Artemis" Manufacturer="PuffyCid" Version="0.16.0" Compressed="yes" Codepage="UTF-8" InstallerVersion="500" Language="1033" ProductCode="*" Scope="perMachine" ShortNames="no" UpgradeStrategy="majorUpgrade">
         <StandardDirectory Id="ProgramFiles64Folder">
             <Directory Id="INSTALLDIR" Name="Artemis">
                 <Component Id="ArtemisFolder" Guid="4ebcd58d-5734-4a5f-abe5-d1538f72df49">

--- a/.packages/artemis_ci.spec
+++ b/.packages/artemis_ci.spec
@@ -2,7 +2,7 @@ Name: artemis
 Release: 1
 Summary: A cross platform forensic parser
 License: MIT
-Version: 0.15.0
+Version: 0.16.0
 Group: Application/Security
 URL: https://puffycid.github.io/artemis-api
 BugURL: https://github.com/puffyCid/artemis

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "artemis"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -1004,7 +1004,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "common"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "plist",
  "serde",
@@ -1318,7 +1318,7 @@ dependencies = [
 
 [[package]]
 name = "daemon"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -1867,7 +1867,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "forensics"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "aes",
  "base64 0.22.1",
@@ -5016,7 +5016,7 @@ dependencies = [
 
 [[package]]
 name = "timeline"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ lto = true
 codegen-units = 1
 
 [workspace.package]
-version = "0.15.0"
+version = "0.16.0"
 homepage = "https://puffycid.github.io/artemis-api"
 repository = "https://github.com/puffycid/artemis"
 license = "MIT"

--- a/forensics/src/artifacts/os/windows/shimcache/os/shim.rs
+++ b/forensics/src/artifacts/os/windows/shimcache/os/shim.rs
@@ -62,19 +62,19 @@ fn detect_format<'a>(
             win81_format(data, key_path, path)
         } else {
             error!("[shimcache] Unknown Shimcache Win8 entrytype. Sig is: {entry_sig}");
-            return Err(nom::Err::Failure(nom::error::Error::new(
+            Err(nom::Err::Failure(nom::error::Error::new(
                 &[],
                 ErrorKind::Fail,
-            )));
+            )))
         }
     } else if win10_size == sig || win10_creator_size == sig {
         win10_format(data, key_path, path)
     } else {
         error!("[shimcache] Unknown Shimcache type. Sig is: {sig}");
-        return Err(nom::Err::Failure(nom::error::Error::new(
+        Err(nom::Err::Failure(nom::error::Error::new(
             &[],
             ErrorKind::Fail,
-        )));
+        )))
     }
 }
 

--- a/forensics/src/filesystem/ntfs/attributes.rs
+++ b/forensics/src/filesystem/ntfs/attributes.rs
@@ -100,7 +100,7 @@ pub(crate) fn get_raw_file_size(
 }
 
 /// Read the attribute data. Handles both resident and non-resident data.
-fn read_attribute_data(
+pub(crate) fn read_attribute_data(
     value: &mut NtfsAttributeValue<'_, '_>,
     fs: &mut BufReader<SectorReader<File>>,
     entry_attr: &NtfsAttribute<'_, '_>,


### PR DESCRIPTION
This PR adds support for extracting REPARSE_POINT tag for files that have the REPARSE_POINT attribute. This tag can provide a bit more context on the file type. Ex: symobliclink or OneDrive remote file