### PR TITLE
Get Windows Service State

### DIFF
--- a/.changes/unreleased/Dependencies-20260301-140641.yaml
+++ b/.changes/unreleased/Dependencies-20260301-140641.yaml
@@ -1,0 +1,3 @@
+kind: Dependencies
+body: Added windows-sys crate
+time: 2026-03-01T14:06:41.1169341-05:00

--- a/.changes/unreleased/Fixed-20260301-140704.yaml
+++ b/.changes/unreleased/Fixed-20260301-140704.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Issue where windows service state was not correct
+time: 2026-03-01T14:07:04.8074523-05:00

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1828,6 +1828,7 @@ dependencies = [
  "uuid",
  "vergen",
  "walkdir",
+ "windows-sys 0.61.2",
  "xml2json-rs",
  "xz2",
  "yara-x",

--- a/common/src/windows.rs
+++ b/common/src/windows.rs
@@ -782,6 +782,7 @@ pub struct ServicesData {
     pub error_control: ServiceError,
     pub reg_path: String,
     pub evidence: String,
+    pub state: ServiceState,
 }
 
 #[derive(Debug, PartialEq, Serialize, Default)]

--- a/forensics/Cargo.toml
+++ b/forensics/Cargo.toml
@@ -88,6 +88,7 @@ futures-lite = { version = "2.6.1", default-features = false }
 # Windows API Dependencies
 [target.'cfg(target_os = "windows")'.dependencies]
 ntapi = "0.4.3"
+windows-sys = { version = "0.61.2", default-features = false, features = ["Win32_System_Services"] }
 
 # Dependencies for tests
 [dev-dependencies]

--- a/forensics/src/artifacts/os/windows/services/mod.rs
+++ b/forensics/src/artifacts/os/windows/services/mod.rs
@@ -3,3 +3,5 @@ mod options;
 pub(crate) mod parser;
 mod registry;
 mod service;
+#[cfg(target_os = "windows")]
+pub(crate) mod state;

--- a/forensics/src/artifacts/os/windows/services/options/name.rs
+++ b/forensics/src/artifacts/os/windows/services/options/name.rs
@@ -5,9 +5,7 @@ use crate::{
         nom_helper::{Endian, nom_unsigned_four_bytes},
     },
 };
-use common::windows::{
-    Action, FailureActions, ServiceError, ServiceState, ServiceType, SidType, StartMode,
-};
+use common::windows::{Action, FailureActions, ServiceError, ServiceType, SidType, StartMode};
 use log::error;
 
 /// Get Error Control type for Service
@@ -18,20 +16,6 @@ pub(crate) fn error_control(value: &str) -> ServiceError {
         "2" => ServiceError::Severe,
         "3" => ServiceError::Critical,
         _ => ServiceError::Unknown,
-    }
-}
-
-/// Get Service State type for Service
-pub(crate) fn service_state(value: &str) -> ServiceState {
-    match value {
-        "1" => ServiceState::Stopped,
-        "2" => ServiceState::StartPending,
-        "3" => ServiceState::StopPending,
-        "4" => ServiceState::Running,
-        "5" => ServiceState::ContinuePending,
-        "6" => ServiceState::PausePending,
-        "7" => ServiceState::Paused,
-        _ => ServiceState::Unknown,
     }
 }
 
@@ -156,8 +140,8 @@ fn parse_failure_actions(data: &[u8]) -> nom::IResult<&[u8], (Vec<FailureActions
 mod tests {
     use super::{error_control, failure_actions};
     use crate::artifacts::os::windows::services::options::name::{
-        ServiceError, ServiceState, ServiceType, SidType, StartMode, parse_failure_actions,
-        service_state, service_type, sid_type, start_mode,
+        ServiceError, ServiceType, SidType, StartMode, parse_failure_actions, service_type,
+        sid_type, start_mode,
     };
 
     #[test]
@@ -200,13 +184,6 @@ mod tests {
         let test = "1";
         let result = start_mode(test);
         assert_eq!(result, StartMode::System);
-    }
-
-    #[test]
-    fn test_service_state() {
-        let test = "1";
-        let result = service_state(test);
-        assert_eq!(result, ServiceState::Stopped);
     }
 
     #[test]

--- a/forensics/src/artifacts/os/windows/services/service.rs
+++ b/forensics/src/artifacts/os/windows/services/service.rs
@@ -3,6 +3,8 @@ use super::{
     options::name::{error_control, failure_actions, service_type, sid_type, start_mode},
     registry::get_services_data,
 };
+#[cfg(target_os = "windows")]
+use crate::artifacts::os::windows::services::state::service_state;
 use common::windows::{KeyValue, RegistryData, ServicesData};
 
 /// Parse Services data from provided Registry file
@@ -37,9 +39,13 @@ pub(crate) fn parse_services(path: &str) -> Result<Vec<ServicesData>, ServicesEr
         service_group.push(entry);
     }
 
-    // Get last service
+    // Get last service collection
     let last_service = collect_service(&service_group, &current_service, path);
     services.push(last_service);
+
+    // If we are on Windows platform. We can check for the service state
+    #[cfg(target_os = "windows")]
+    service_state(&mut services);
 
     Ok(services)
 }

--- a/forensics/src/artifacts/os/windows/services/state.rs
+++ b/forensics/src/artifacts/os/windows/services/state.rs
@@ -1,0 +1,130 @@
+use common::windows::{ServiceState, ServicesData};
+use log::warn;
+use std::{
+    ffi::{OsString, c_void},
+    iter::once,
+    os::windows::ffi::OsStrExt,
+    ptr::null_mut,
+};
+use windows_sys::Win32::System::Services::{
+    CloseServiceHandle, OpenSCManagerW, OpenServiceW, QueryServiceStatusEx,
+    SC_MANAGER_ENUMERATE_SERVICE, SC_STATUS_PROCESS_INFO, SERVICE_QUERY_STATUS,
+    SERVICE_STATUS_PROCESS,
+};
+
+pub(crate) fn service_state(services: &mut [ServicesData]) {
+    #[allow(unsafe_code)]
+    let service_manager =
+        unsafe { OpenSCManagerW(null_mut(), null_mut(), SC_MANAGER_ENUMERATE_SERVICE) };
+    if service_manager.is_null() {
+        return;
+    }
+    for entry in services {
+        let wide_string = OsString::from(&entry.name);
+        let ut16_bytes: Vec<u16> = wide_string.encode_wide().chain(once(0)).collect();
+        #[allow(unsafe_code)]
+        let service =
+            unsafe { OpenServiceW(service_manager, ut16_bytes.as_ptr(), SERVICE_QUERY_STATUS) };
+        if service.is_null() {
+            warn!("[services] Cannot get service state for: {}", entry.name);
+            continue;
+        }
+
+        let mut state = SERVICE_STATUS_PROCESS {
+            dwServiceType: 0,
+            dwCurrentState: 0,
+            dwControlsAccepted: 0,
+            dwWin32ExitCode: 0,
+            dwServiceSpecificExitCode: 0,
+            dwCheckPoint: 0,
+            dwWaitHint: 0,
+            dwProcessId: 0,
+            dwServiceFlags: 0,
+        };
+
+        let mut result_len = 0;
+        let size = size_of::<SERVICE_STATUS_PROCESS>() as u32;
+        #[allow(unsafe_code)]
+        let status = unsafe {
+            QueryServiceStatusEx(
+                service,
+                SC_STATUS_PROCESS_INFO,
+                (&mut state as *mut SERVICE_STATUS_PROCESS).cast::<u8>(),
+                size,
+                &mut result_len,
+            )
+        };
+
+        close_handle(service);
+        if status == 0 {
+            continue;
+        }
+        entry.state = state_value(state.dwCurrentState);
+    }
+
+    close_handle(service_manager);
+}
+
+fn close_handle(handle: *mut c_void) -> i32 {
+    #[allow(unsafe_code)]
+    unsafe {
+        CloseServiceHandle(handle)
+    }
+}
+
+/// Get Service State type for Service
+fn state_value(value: u32) -> ServiceState {
+    match value {
+        1 => ServiceState::Stopped,
+        2 => ServiceState::StartPending,
+        3 => ServiceState::StopPending,
+        4 => ServiceState::Running,
+        5 => ServiceState::ContinuePending,
+        6 => ServiceState::PausePending,
+        7 => ServiceState::Paused,
+        _ => ServiceState::Unknown,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::artifacts::os::windows::services::state::{
+        close_handle, service_state, state_value,
+    };
+    use common::windows::{ServiceState, ServicesData};
+    use std::ptr::null_mut;
+    use windows_sys::Win32::System::Services::{OpenSCManagerW, SC_MANAGER_ENUMERATE_SERVICE};
+
+    #[test]
+    fn test_service_state() {
+        let mut test = vec![
+            ServicesData {
+                name: String::from("ACPI"),
+                ..Default::default()
+            },
+            ServicesData {
+                name: String::from("AppID"),
+                ..Default::default()
+            },
+        ];
+        service_state(&mut test);
+        for entry in test {
+            assert_ne!(entry.state, ServiceState::Unknown);
+        }
+    }
+
+    #[test]
+    fn test_state_value() {
+        let test = [1, 2, 3, 4, 5, 6, 7];
+        for entry in test {
+            assert_ne!(state_value(entry), ServiceState::Unknown);
+        }
+    }
+
+    #[test]
+    fn test_close_handle() {
+        #[allow(unsafe_code)]
+        let test = unsafe { OpenSCManagerW(null_mut(), null_mut(), SC_MANAGER_ENUMERATE_SERVICE) };
+        close_handle(test);
+    }
+}


### PR DESCRIPTION
Final PR to fix #353.

Windows Service state only exists in memory. In order to get the state we need to use the Windows API.
This PR adds `windows-sys` crate which is a popular Rust library to interact with the Windows API.

In the future this could allow adding more Windows API support for acquiring data.

When Windows services are parsed on non-Windows platforms. The service state is not checked.