### PR TITLE
Make cli args consistent

### DIFF
--- a/.changes/unreleased/Changed-20260416-210120.yaml
+++ b/.changes/unreleased/Changed-20260416-210120.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: Made all cli arguements consistent. --alt-file when you want to provide an alternative file. --alt-dir when you want to provide an alternative directory. Removed --alt-path.
+time: 2026-04-16T21:01:20.4914938-04:00

--- a/.changes/unreleased/Changed-20260417-211103.yaml
+++ b/.changes/unreleased/Changed-20260417-211103.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: Made shortcut and jumplists artifacts accept globs are arguements
+time: 2026-04-17T21:11:03.8123224-04:00

--- a/cli/src/collector/commands.rs
+++ b/cli/src/collector/commands.rs
@@ -168,9 +168,9 @@ pub(crate) enum CommandArgs {
     },
     /// windows: Parse Shortcuts
     Shortcuts {
-        /// Path to directory containing Shortcut files
+        /// Glob to directory containing Shortcut files
         #[arg(long)]
-        path: String,
+        dir: String,
     },
     /// windows: Parse UsnJrnl
     Usnjrnl {
@@ -225,9 +225,9 @@ pub(crate) enum CommandArgs {
     },
     /// windows: Parse Jumplists
     Jumplists {
-        /// Alternative full path to Jumplist file
+        /// Alternative glob to Jumplist file
         #[arg(long, default_value = None)]
-        alt_file: Option<String>,
+        alt_dir: Option<String>,
     },
     /// windows: Parse RecycleBin
     Recyclebin {

--- a/cli/src/collector/commands.rs
+++ b/cli/src/collector/commands.rs
@@ -281,7 +281,7 @@ pub(crate) enum CommandArgs {
     UsersMacos {
         /// Alternative path to users
         #[arg(long, default_value = None)]
-        alt_file: Option<String>,
+        alt_dir: Option<String>,
     },
     /// macos: Parse FsEvents entries
     Fsevents {
@@ -311,7 +311,7 @@ pub(crate) enum CommandArgs {
     GroupsMacos {
         /// Alternative path to groups
         #[arg(long, default_value = None)]
-        alt_file: Option<String>,
+        alt_dir: Option<String>,
     },
     /// macos: Parse the Unified Logs
     Unifiedlogs {

--- a/cli/src/collector/commands.rs
+++ b/cli/src/collector/commands.rs
@@ -179,7 +179,7 @@ pub(crate) enum CommandArgs {
         alt_drive: Option<char>,
         /// Alternative path to UsnJrnl
         #[arg(long, default_value = None)]
-        alt_path: Option<String>,
+        alt_file: Option<String>,
         /// Alternative path to MFT
         #[arg(long, default_value = None)]
         alt_mft: Option<String>,
@@ -281,7 +281,7 @@ pub(crate) enum CommandArgs {
     UsersMacos {
         /// Alternative path to users
         #[arg(long, default_value = None)]
-        alt_path: Option<String>,
+        alt_file: Option<String>,
     },
     /// macos: Parse FsEvents entries
     Fsevents {
@@ -293,7 +293,7 @@ pub(crate) enum CommandArgs {
     Emond {
         /// Alternative path to Emond
         #[arg(long, default_value = None)]
-        alt_path: Option<String>,
+        alt_dir: Option<String>,
     },
     /// macos: Parse LoginItems
     Loginitems {
@@ -311,7 +311,7 @@ pub(crate) enum CommandArgs {
     GroupsMacos {
         /// Alternative path to groups
         #[arg(long, default_value = None)]
-        alt_path: Option<String>,
+        alt_file: Option<String>,
     },
     /// macos: Parse the Unified Logs
     Unifiedlogs {
@@ -330,9 +330,9 @@ pub(crate) enum CommandArgs {
     },
     /// macos: Parse the Spotlight database
     Spotlight {
-        /// Alternative path to a Spotlight database
+        /// Alternative path to a Spotlight database directory
         #[arg(long, default_value = None)]
-        alt_path: Option<String>,
+        alt_dir: Option<String>,
         /// Include additional known Spotlight database locations
         #[arg(long)]
         include_additional: bool,
@@ -341,13 +341,13 @@ pub(crate) enum CommandArgs {
     SudologsLinux {
         /// Alternative Sudo log directory to use
         #[arg(long, default_value = None)]
-        alt_path: Option<String>,
+        alt_dir: Option<String>,
     },
     /// linux: Parse systemd Journal files
     Journal {
         /// Alternative Journal log directory to use
         #[arg(long, default_value = None)]
-        alt_path: Option<String>,
+        alt_dir: Option<String>,
     },
     /// linux: Parse Logon files
     Logons {

--- a/cli/src/collector/system.rs
+++ b/cli/src/collector/system.rs
@@ -139,9 +139,9 @@ fn setup_artifact(artifact: &CommandArgs) -> Artifacts {
             collect.artifact_name = String::from("files");
         }
         CommandArgs::Systeminfo {} => collect.artifact_name = String::from("systeminfo"),
-        CommandArgs::Emond { alt_path } => {
+        CommandArgs::Emond { alt_dir } => {
             let options = EmondOptions {
-                alt_path: alt_path.clone(),
+                alt_dir: alt_dir.clone(),
             };
             collect.emond = Some(options);
             collect.artifact_name = String::from("emond");
@@ -160,9 +160,9 @@ fn setup_artifact(artifact: &CommandArgs) -> Artifacts {
             collect.execpolicy = Some(options);
             collect.artifact_name = String::from("execpolicy");
         }
-        CommandArgs::GroupsMacos { alt_path } => {
+        CommandArgs::GroupsMacos { alt_file } => {
             let options = MacosGroupsOptions {
-                alt_path: alt_path.clone(),
+                alt_file: alt_file.clone(),
             };
             collect.groups_macos = Some(options);
             collect.artifact_name = String::from("groups-macos");
@@ -181,9 +181,9 @@ fn setup_artifact(artifact: &CommandArgs) -> Artifacts {
             collect.loginitems = Some(options);
             collect.artifact_name = String::from("loginitems");
         }
-        CommandArgs::UsersMacos { alt_path } => {
+        CommandArgs::UsersMacos { alt_file } => {
             let options = MacosUsersOptions {
-                alt_path: alt_path.clone(),
+                alt_file: alt_file.clone(),
             };
             collect.users_macos = Some(options);
             collect.artifact_name = String::from("users-macos");
@@ -207,19 +207,19 @@ fn setup_artifact(artifact: &CommandArgs) -> Artifacts {
             collect.artifact_name = String::from("unifiedlogs");
         }
         CommandArgs::Spotlight {
-            alt_path,
+            alt_dir,
             include_additional,
         } => {
             let options = SpotlightOptions {
-                alt_path: alt_path.clone(),
+                alt_dir: alt_dir.clone(),
                 include_additional: Some(*include_additional),
             };
             collect.spotlight = Some(options);
             collect.artifact_name = String::from("spotlight");
         }
-        CommandArgs::Journal { alt_path } => {
+        CommandArgs::Journal { alt_dir } => {
             let options = JournalOptions {
-                alt_path: alt_path.clone(),
+                alt_dir: alt_dir.clone(),
             };
             collect.journal = Some(options);
             collect.artifact_name = String::from("journal");
@@ -231,9 +231,9 @@ fn setup_artifact(artifact: &CommandArgs) -> Artifacts {
             collect.logons = Some(options);
             collect.artifact_name = String::from("logons");
         }
-        CommandArgs::SudologsLinux { alt_path } => {
+        CommandArgs::SudologsLinux { alt_dir } => {
             let options = LinuxSudoOptions {
-                alt_path: alt_path.clone(),
+                alt_dir: alt_dir.clone(),
             };
             collect.sudologs_linux = Some(options);
             collect.artifact_name = String::from("sudologs-linux");
@@ -436,12 +436,12 @@ fn setup_artifact(artifact: &CommandArgs) -> Artifacts {
         }
         CommandArgs::Usnjrnl {
             alt_drive,
-            alt_path,
+            alt_file,
             alt_mft,
         } => {
             let options = UsnJrnlOptions {
                 alt_drive: *alt_drive,
-                alt_path: alt_path.clone(),
+                alt_file: alt_file.clone(),
                 alt_mft: alt_mft.clone(),
             };
             collect.usnjrnl = Some(options);
@@ -573,7 +573,7 @@ mod tests {
         run_collector(&command, out);
 
         let command = Commands::Acquire {
-            artifact: Some(UsersMacos { alt_path: None }),
+            artifact: Some(UsersMacos { alt_file: None }),
             format: String::from("json"),
             output_dir: String::from("./tmp"),
             compress: false,
@@ -608,7 +608,7 @@ mod tests {
         run_collector(&command, out);
 
         let command = Commands::Acquire {
-            artifact: Some(GroupsMacos { alt_path: None }),
+            artifact: Some(GroupsMacos { alt_file: None }),
             format: String::from("json"),
             output_dir: String::from("./tmp"),
             compress: false,
@@ -641,7 +641,7 @@ mod tests {
         run_collector(&command, out);
 
         let command = Commands::Acquire {
-            artifact: Some(Emond { alt_path: None }),
+            artifact: Some(Emond { alt_dir: None }),
             format: String::from("json"),
             output_dir: String::from("./tmp"),
             compress: false,
@@ -673,7 +673,7 @@ mod tests {
     fn test_run_collector_spotlight() {
         let command = Commands::Acquire {
             artifact: Some(Spotlight {
-                alt_path: None,
+                alt_dir: None,
                 include_additional: false,
             }),
             format: String::from("json"),
@@ -707,7 +707,7 @@ mod tests {
 
         let command = Commands::Acquire {
             artifact: Some(Journal {
-                alt_path: Some(String::from(".")),
+                alt_dir: Some(String::from(".")),
             }),
             format: String::from("json"),
             output_dir: String::from("./tmp"),
@@ -719,7 +719,7 @@ mod tests {
         run_collector(&command, out);
 
         let command = Commands::Acquire {
-            artifact: Some(SudologsLinux { alt_path: None }),
+            artifact: Some(SudologsLinux { alt_dir: None }),
             format: String::from("json"),
             compress: false,
             output_dir: String::from("./tmp"),

--- a/cli/src/collector/system.rs
+++ b/cli/src/collector/system.rs
@@ -295,9 +295,9 @@ fn setup_artifact(artifact: &CommandArgs) -> Artifacts {
             collect.eventlogs = Some(options);
             collect.artifact_name = String::from("eventlogs");
         }
-        CommandArgs::Jumplists { alt_file } => {
+        CommandArgs::Jumplists { alt_dir } => {
             let options = JumplistsOptions {
-                alt_file: alt_file.clone(),
+                alt_dir: alt_dir.clone(),
             };
             collect.jumplists = Some(options);
             collect.artifact_name = String::from("jumplists");
@@ -397,8 +397,8 @@ fn setup_artifact(artifact: &CommandArgs) -> Artifacts {
             collect.shimdb = Some(options);
             collect.artifact_name = String::from("shimdb");
         }
-        CommandArgs::Shortcuts { path } => {
-            let options = ShortcutOptions { path: path.clone() };
+        CommandArgs::Shortcuts { dir } => {
+            let options = ShortcutOptions { dir: dir.clone() };
             collect.shortcuts = Some(options);
             collect.artifact_name = String::from("shortcuts");
         }
@@ -939,7 +939,7 @@ mod tests {
 
     #[test]
     fn test_setup_artifact_windows() {
-        let result = setup_artifact(&Jumplists { alt_file: None });
+        let result = setup_artifact(&Jumplists { alt_dir: None });
         assert_eq!(result.artifact_name, "jumplists");
     }
 }

--- a/cli/src/collector/system.rs
+++ b/cli/src/collector/system.rs
@@ -160,9 +160,9 @@ fn setup_artifact(artifact: &CommandArgs) -> Artifacts {
             collect.execpolicy = Some(options);
             collect.artifact_name = String::from("execpolicy");
         }
-        CommandArgs::GroupsMacos { alt_file } => {
+        CommandArgs::GroupsMacos { alt_dir } => {
             let options = MacosGroupsOptions {
-                alt_file: alt_file.clone(),
+                alt_dir: alt_dir.clone(),
             };
             collect.groups_macos = Some(options);
             collect.artifact_name = String::from("groups-macos");
@@ -181,9 +181,9 @@ fn setup_artifact(artifact: &CommandArgs) -> Artifacts {
             collect.loginitems = Some(options);
             collect.artifact_name = String::from("loginitems");
         }
-        CommandArgs::UsersMacos { alt_file } => {
+        CommandArgs::UsersMacos { alt_dir } => {
             let options = MacosUsersOptions {
-                alt_file: alt_file.clone(),
+                alt_dir: alt_dir.clone(),
             };
             collect.users_macos = Some(options);
             collect.artifact_name = String::from("users-macos");
@@ -573,7 +573,7 @@ mod tests {
         run_collector(&command, out);
 
         let command = Commands::Acquire {
-            artifact: Some(UsersMacos { alt_file: None }),
+            artifact: Some(UsersMacos { alt_dir: None }),
             format: String::from("json"),
             output_dir: String::from("./tmp"),
             compress: false,
@@ -608,7 +608,7 @@ mod tests {
         run_collector(&command, out);
 
         let command = Commands::Acquire {
-            artifact: Some(GroupsMacos { alt_file: None }),
+            artifact: Some(GroupsMacos { alt_dir: None }),
             format: String::from("json"),
             output_dir: String::from("./tmp"),
             compress: false,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -232,7 +232,7 @@ mod tests {
             javascript: None,
             command: Some(Commands::Acquire {
                 artifact: Some(Shortcuts {
-                    path: String::from("C:\\"),
+                    dir: String::from("C:\\*"),
                 }),
                 format: String::from("json"),
                 output_dir: String::from("./tmp"),

--- a/forensics/benches/jumplists_benchmark.rs
+++ b/forensics/benches/jumplists_benchmark.rs
@@ -19,7 +19,7 @@ fn bench_custom_jumplists(c: &mut Criterion) {
     );
 
     let options = JumplistsOptions {
-        alt_file: Some(test_location.display().to_string()),
+        alt_dir: Some(test_location.display().to_string()),
     };
 
     let out = Output {
@@ -56,7 +56,7 @@ fn bench_automatic_jumplists(c: &mut Criterion) {
     );
 
     let options = JumplistsOptions {
-        alt_file: Some(test_location.display().to_string()),
+        alt_dir: Some(test_location.display().to_string()),
     };
 
     let out = Output {

--- a/forensics/src/artifacts/os/linux/artifacts.rs
+++ b/forensics/src/artifacts/os/linux/artifacts.rs
@@ -153,7 +153,7 @@ mod tests {
             &mut output,
             false,
             &JournalOptions {
-                alt_path: Some(String::from("./tmp")),
+                alt_dir: Some(String::from("./tmp")),
             },
         )
         .unwrap();
@@ -183,7 +183,7 @@ mod tests {
             &mut output,
             false,
             &LinuxSudoOptions {
-                alt_path: Some(String::from("./tmp")),
+                alt_dir: Some(String::from("./tmp")),
             },
         )
         .unwrap();

--- a/forensics/src/artifacts/os/linux/journals/parser.rs
+++ b/forensics/src/artifacts/os/linux/journals/parser.rs
@@ -34,8 +34,8 @@ pub(crate) fn grab_journal(
 ) -> Result<(), JournalError> {
     let start_time = time::time_now();
 
-    let paths = if let Some(alt_path) = &options.alt_path {
-        vec![alt_path.clone()]
+    let paths = if let Some(alt_dir) = &options.alt_dir {
+        vec![alt_dir.clone()]
     } else {
         let persist = "/var/log/journal/";
         let tmp = "/run/systemd/journal";
@@ -105,7 +105,7 @@ mod tests {
     #[test]
     fn test_grab_journal() {
         let mut output = output_options("grab_journal", "local", "./tmp", false);
-        grab_journal(&mut output, false, &JournalOptions { alt_path: None }).unwrap();
+        grab_journal(&mut output, false, &JournalOptions { alt_dir: None }).unwrap();
     }
 
     #[test]

--- a/forensics/src/artifacts/os/linux/sudo/logs.rs
+++ b/forensics/src/artifacts/os/linux/sudo/logs.rs
@@ -10,8 +10,8 @@ use common::linux::Journal;
 
 /// Grab sudo log entries in the Journal files
 pub(crate) fn grab_sudo_logs(options: &LinuxSudoOptions) -> Result<Vec<Journal>, JournalError> {
-    let paths = if let Some(alt_path) = &options.alt_path {
-        vec![alt_path.clone()]
+    let paths = if let Some(alt_dir) = &options.alt_dir {
+        vec![alt_dir.clone()]
     } else {
         let persist = "/var/log/journal/";
         let tmp = "/run/systemd/journal";

--- a/forensics/src/artifacts/os/linux/sudo/logs.rs
+++ b/forensics/src/artifacts/os/linux/sudo/logs.rs
@@ -74,7 +74,7 @@ mod tests {
 
     #[test]
     fn test_grab_sudo_logs() {
-        let result = grab_sudo_logs(&LinuxSudoOptions { alt_path: None }).unwrap();
+        let result = grab_sudo_logs(&LinuxSudoOptions { alt_dir: None }).unwrap();
         assert!(!result.is_empty());
     }
 

--- a/forensics/src/artifacts/os/macos/accounts/groups.rs
+++ b/forensics/src/artifacts/os/macos/accounts/groups.rs
@@ -8,8 +8,8 @@ use log::{error, warn};
 
 /// Get users on a macOS system. Requires root
 pub(crate) fn grab_groups(options: &MacosGroupsOptions) -> Vec<OpendirectoryGroups> {
-    let path = if let Some(alt_path) = &options.alt_path {
-        alt_path
+    let path = if let Some(alt_file) = &options.alt_file {
+        alt_file
     } else {
         // Need root permissions to access files in dslocal directories
         "/var/db/dslocal/nodes/Default/groups"
@@ -47,7 +47,7 @@ mod tests {
 
     #[test]
     fn test_grab_groups() {
-        let results = grab_groups(&MacosGroupsOptions { alt_path: None });
+        let results = grab_groups(&MacosGroupsOptions { alt_file: None });
         assert!(results.len() > 10);
 
         for data in results {

--- a/forensics/src/artifacts/os/macos/accounts/groups.rs
+++ b/forensics/src/artifacts/os/macos/accounts/groups.rs
@@ -8,8 +8,8 @@ use log::{error, warn};
 
 /// Get users on a macOS system. Requires root
 pub(crate) fn grab_groups(options: &MacosGroupsOptions) -> Vec<OpendirectoryGroups> {
-    let path = if let Some(alt_file) = &options.alt_file {
-        alt_file
+    let path = if let Some(alt_dir) = &options.alt_dir {
+        alt_dir
     } else {
         // Need root permissions to access files in dslocal directories
         "/var/db/dslocal/nodes/Default/groups"
@@ -47,7 +47,7 @@ mod tests {
 
     #[test]
     fn test_grab_groups() {
-        let results = grab_groups(&MacosGroupsOptions { alt_file: None });
+        let results = grab_groups(&MacosGroupsOptions { alt_dir: None });
         assert!(results.len() > 10);
 
         for data in results {

--- a/forensics/src/artifacts/os/macos/accounts/users.rs
+++ b/forensics/src/artifacts/os/macos/accounts/users.rs
@@ -8,8 +8,8 @@ use log::{error, warn};
 
 /// Get users on a macOS system. Requires root
 pub(crate) fn grab_users(options: &MacosUsersOptions) -> Vec<OpendirectoryUsers> {
-    let path = if let Some(alt_file) = &options.alt_file {
-        alt_file
+    let path = if let Some(alt_dir) = &options.alt_dir {
+        alt_dir
     } else {
         // Need root permissions to access files in dslocal directories
         "/var/db/dslocal/nodes/Default/users"
@@ -41,7 +41,7 @@ mod tests {
 
     #[test]
     fn test_grab_users() {
-        let results = grab_users(&MacosUsersOptions { alt_file: None });
+        let results = grab_users(&MacosUsersOptions { alt_dir: None });
         for data in results {
             if data.uid.len() == 1 && data.uid[0] == "0" {
                 assert_eq!(data.real_name[0], "System Administrator");

--- a/forensics/src/artifacts/os/macos/accounts/users.rs
+++ b/forensics/src/artifacts/os/macos/accounts/users.rs
@@ -8,8 +8,8 @@ use log::{error, warn};
 
 /// Get users on a macOS system. Requires root
 pub(crate) fn grab_users(options: &MacosUsersOptions) -> Vec<OpendirectoryUsers> {
-    let path = if let Some(alt_path) = &options.alt_path {
-        alt_path
+    let path = if let Some(alt_file) = &options.alt_file {
+        alt_file
     } else {
         // Need root permissions to access files in dslocal directories
         "/var/db/dslocal/nodes/Default/users"
@@ -41,7 +41,7 @@ mod tests {
 
     #[test]
     fn test_grab_users() {
-        let results = grab_users(&MacosUsersOptions { alt_path: None });
+        let results = grab_users(&MacosUsersOptions { alt_file: None });
         for data in results {
             if data.uid.len() == 1 && data.uid[0] == "0" {
                 assert_eq!(data.real_name[0], "System Administrator");

--- a/forensics/src/artifacts/os/macos/artifacts.rs
+++ b/forensics/src/artifacts/os/macos/artifacts.rs
@@ -315,7 +315,7 @@ mod tests {
     fn test_emond() {
         let mut output = output_options("emond_test", "local", "./tmp", false);
 
-        let status = emond(&mut output, false, &EmondOptions { alt_path: None }).unwrap();
+        let status = emond(&mut output, false, &EmondOptions { alt_dir: None }).unwrap();
         assert_eq!(status, ());
     }
 
@@ -324,7 +324,7 @@ mod tests {
         let mut output = output_options("users_test", "local", "./tmp", false);
 
         let status =
-            users_macos(&mut output, false, &&MacosUsersOptions { alt_path: None }).unwrap();
+            users_macos(&mut output, false, &&MacosUsersOptions { alt_dir: None }).unwrap();
         assert_eq!(status, ());
     }
 
@@ -333,7 +333,7 @@ mod tests {
         let mut output = output_options("groups_test", "local", "./tmp", false);
 
         let status =
-            groups_macos(&mut output, false, &&MacosGroupsOptions { alt_path: None }).unwrap();
+            groups_macos(&mut output, false, &&MacosGroupsOptions { alt_dir: None }).unwrap();
         assert_eq!(status, ());
     }
 
@@ -401,7 +401,7 @@ mod tests {
             &mut output,
             false,
             &SpotlightOptions {
-                alt_path: None,
+                alt_dir: None,
                 include_additional: None,
             },
         )

--- a/forensics/src/artifacts/os/macos/emond/parser.rs
+++ b/forensics/src/artifacts/os/macos/emond/parser.rs
@@ -22,8 +22,8 @@ use plist::Value;
 
 /// Parse Emond rules on macOS
 pub(crate) fn grab_emond(options: &EmondOptions) -> Result<Vec<EmondData>, PlistError> {
-    if let Some(alt_path) = &options.alt_path {
-        return parse_emond_rules(alt_path);
+    if let Some(alt_dir) = &options.alt_dir {
+        return parse_emond_rules(alt_dir);
     }
 
     let paths = get_emond_rules_paths()?;
@@ -97,6 +97,6 @@ mod tests {
 
     #[test]
     fn test_grab_emond() {
-        let _ = grab_emond(&EmondOptions { alt_path: None }).unwrap();
+        let _ = grab_emond(&EmondOptions { alt_dir: None }).unwrap();
     }
 }

--- a/forensics/src/artifacts/os/macos/spotlight/parser.rs
+++ b/forensics/src/artifacts/os/macos/spotlight/parser.rs
@@ -26,8 +26,8 @@ pub(crate) fn grab_spotlight(
     output: &mut Output,
     filter: bool,
 ) -> Result<(), SpotlightError> {
-    let paths = if let Some(alt_path) = &options.alt_path {
-        vec![format!("{alt_path}/*")]
+    let paths = if let Some(alt_dir) = &options.alt_dir {
+        vec![format!("{alt_dir}/*")]
     } else {
         let mut additional_stores = false;
         if let Some(extra) = &options.include_additional {
@@ -82,7 +82,7 @@ mod tests {
 
         grab_spotlight(
             &SpotlightOptions {
-                alt_path: None,
+                alt_dir: None,
                 include_additional: Some(true),
             },
             &mut output,

--- a/forensics/src/artifacts/os/windows/artifacts.rs
+++ b/forensics/src/artifacts/os/windows/artifacts.rs
@@ -258,7 +258,7 @@ pub(crate) fn shortcuts(
 ) -> Result<(), WinArtifactError> {
     let start_time = time::time_now();
 
-    let artifact_result = grab_lnk_directory(&options.path);
+    let artifact_result = grab_lnk_directory(&options.dir);
     let entries = match artifact_result {
         Ok(result) => result,
         Err(err) => {
@@ -719,10 +719,10 @@ mod tests {
     #[test]
     fn test_shortcuts() {
         let mut test_location = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        test_location.push("tests/test_data/windows/lnk/win11");
+        test_location.push("tests/test_data/windows/lnk/win11/*");
 
         let options = ShortcutOptions {
-            path: test_location.display().to_string(),
+            dir: test_location.display().to_string(),
         };
         let mut output = output_options("shortcuts_temp", "json", "./tmp", false);
 
@@ -799,7 +799,7 @@ mod tests {
 
     #[test]
     fn test_jumplists() {
-        let options = JumplistsOptions { alt_file: None };
+        let options = JumplistsOptions { alt_dir: None };
         let mut output = output_options("jumplists_temp", "json", "./tmp", false);
 
         let status = jumplists(&options, &mut output, false).unwrap();

--- a/forensics/src/artifacts/os/windows/artifacts.rs
+++ b/forensics/src/artifacts/os/windows/artifacts.rs
@@ -707,7 +707,7 @@ mod tests {
     fn test_usnjrnl() {
         let options = UsnJrnlOptions {
             alt_drive: None,
-            alt_path: None,
+            alt_file: None,
             alt_mft: None,
         };
         let mut output = output_options("usn_temp", "json", "./tmp", false);

--- a/forensics/src/artifacts/os/windows/jumplists/parser.rs
+++ b/forensics/src/artifacts/os/windows/jumplists/parser.rs
@@ -13,10 +13,7 @@
  * Other parsers:
  * `https://ericzimmerman.github.io/#!index.md`
  */
-use super::{
-    error::JumplistError,
-    jumplist::{get_jumplist_path, get_jumplists},
-};
+use super::{error::JumplistError, jumplist::get_jumplists};
 use crate::{
     filesystem::metadata::glob_paths, structs::artifacts::os::windows::JumplistsOptions,
     utils::environment::get_systemdrive,
@@ -28,21 +25,22 @@ use log::error;
 pub(crate) fn grab_jumplists(
     options: &JumplistsOptions,
 ) -> Result<Vec<JumplistEntry>, JumplistError> {
-    if let Some(file) = &options.alt_file {
-        return grab_jumplist_file(file);
-    }
-    let systemdrive_result = get_systemdrive();
-    let drive = match systemdrive_result {
-        Ok(result) => result,
-        Err(err) => {
-            error!("[jumplist] Could not get systemdrive: {err:?}");
-            return Err(JumplistError::Systemdrive);
-        }
-    };
+    let path = if let Some(file) = &options.alt_dir {
+        file.clone()
+    } else {
+        let systemdrive_result = get_systemdrive();
+        let drive = match systemdrive_result {
+            Ok(result) => result,
+            Err(err) => {
+                error!("[jumplist] Could not get systemdrive: {err:?}");
+                return Err(JumplistError::Systemdrive);
+            }
+        };
 
-    let path = format!(
-        "{drive}:\\Users\\*\\AppData\\Roaming\\Microsoft\\Windows\\Recent\\*Destinations\\*"
-    );
+        format!(
+            "{drive}:\\Users\\*\\AppData\\Roaming\\Microsoft\\Windows\\Recent\\*Destinations\\*"
+        )
+    };
 
     let glob_results = glob_paths(&path);
     let glob_paths = match glob_results {
@@ -56,36 +54,31 @@ pub(crate) fn grab_jumplists(
     get_jumplists(&glob_paths)
 }
 
-/// Parse single `Jumplist` file. Supports both Custom and Automatic `Jumplist` files
-fn grab_jumplist_file(path: &str) -> Result<Vec<JumplistEntry>, JumplistError> {
-    get_jumplist_path(path)
-}
-
 #[cfg(test)]
 #[cfg(target_os = "windows")]
 mod tests {
     use super::grab_jumplists;
-    use crate::{
-        artifacts::os::windows::jumplists::parser::grab_jumplist_file,
-        structs::artifacts::os::windows::JumplistsOptions,
-    };
+    use crate::structs::artifacts::os::windows::JumplistsOptions;
     use common::windows::ListType;
     use std::path::PathBuf;
 
     #[test]
     fn test_grab_jumplists() {
-        let options = JumplistsOptions { alt_file: None };
+        let options = JumplistsOptions { alt_dir: None };
         let _ = grab_jumplists(&options).unwrap();
     }
 
     #[test]
-    fn test_grab_jumplist_file() {
+    fn test_grab_jumplist_alt_dir() {
         let mut test_location = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_location.push(
             "tests\\test_data\\windows\\jumplists\\win10\\custom\\1ced32d74a95c7bc.customDestinations-ms",
         );
+        let options = JumplistsOptions {
+            alt_dir: Some(test_location.display().to_string()),
+        };
 
-        let result = grab_jumplist_file(&test_location.display().to_string()).unwrap();
+        let result = grab_jumplists(&options).unwrap();
         assert_eq!(result.len(), 8);
         assert_eq!(result[0].jumplist_type, ListType::Custom);
         assert_eq!(result[0].lnk_info.created, "2019-10-21T05:48:39.000Z");

--- a/forensics/src/artifacts/os/windows/shortcuts/parser.rs
+++ b/forensics/src/artifacts/os/windows/shortcuts/parser.rs
@@ -15,13 +15,13 @@
  * `https://github.com/Velocidex/velociraptor`
  */
 use super::{error::LnkError, header::LnkHeader, shortcut::get_shortcut_data};
-use crate::filesystem::files::{list_files, read_file};
+use crate::filesystem::{files::read_file, metadata::glob_paths};
 use common::windows::ShortcutInfo;
 use log::error;
 
 /// `Shortcut` files can be location anywhere. Provide a directory and parse any `lnk` (`Shortcut`) files
 pub(crate) fn grab_lnk_directory(path: &str) -> Result<Vec<ShortcutInfo>, LnkError> {
-    let files_results = list_files(path);
+    let files_results = glob_paths(path);
     let files = match files_results {
         Ok(results) => results,
         Err(err) => {
@@ -32,10 +32,13 @@ pub(crate) fn grab_lnk_directory(path: &str) -> Result<Vec<ShortcutInfo>, LnkErr
 
     let mut shortcut_info = Vec::new();
     for file in files {
-        let result = grab_lnk_file(&file);
+        if !file.is_file {
+            continue;
+        }
+        let result = grab_lnk_file(&file.full_path);
         match result {
             Ok(info) => shortcut_info.push(info),
-            Err(_err) => error!("[shortcuts] Failed to parse file: {file}"),
+            Err(_err) => error!("[shortcuts] Failed to parse file: {}", file.full_path),
         }
     }
     Ok(shortcut_info)
@@ -267,7 +270,7 @@ mod tests {
     #[test]
     fn test_grab_lnk_directory() {
         let mut test_location = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        test_location.push("tests/test_data/windows/lnk/win11");
+        test_location.push("tests/test_data/windows/lnk/win11/*");
         let result = grab_lnk_directory(&test_location.display().to_string()).unwrap();
 
         assert_eq!(result.len(), 5);

--- a/forensics/src/artifacts/os/windows/usnjrnl/parser.rs
+++ b/forensics/src/artifacts/os/windows/usnjrnl/parser.rs
@@ -34,7 +34,7 @@ pub(crate) fn grab_usnjrnl(
     if let Some(alt) = options.alt_drive {
         return parse_usnjrnl_data(alt, &format!("{alt}:\\$MFT"), output, filter, start_time);
     }
-    if let Some(path) = &options.alt_path {
+    if let Some(path) = &options.alt_file {
         return get_usnjrnl_path_stream(path, &options.alt_mft, output, filter, start_time);
     }
     let systemdrive_result = get_systemdrive();
@@ -62,7 +62,7 @@ pub(crate) fn grab_usnjrnl_path(
     if let Some(alt) = options.alt_drive {
         return get_usnjrnl_path(alt, &format!("{alt}:\\$MFT"));
     }
-    if let Some(path) = &options.alt_path {
+    if let Some(path) = &options.alt_file {
         return get_usnjrnl_alt_path(path, &options.alt_mft);
     }
     let systemdrive_result = get_systemdrive();
@@ -99,7 +99,7 @@ mod tests {
     fn test_grab_usnjrnl() {
         let params = UsnJrnlOptions {
             alt_drive: None,
-            alt_path: None,
+            alt_file: None,
             alt_mft: None,
         };
         let mut output = output_options("usnjrnl_temp", "local", "./tmp", false);
@@ -113,7 +113,7 @@ mod tests {
         test_location.push("tests\\test_data\\windows\\usnjrnl\\win11\\usnjrnl.raw");
         let params = UsnJrnlOptions {
             alt_drive: None,
-            alt_path: Some(test_location.display().to_string()),
+            alt_file: Some(test_location.display().to_string()),
             alt_mft: None,
         };
         let results = grab_usnjrnl_path(&params).unwrap();
@@ -126,7 +126,7 @@ mod tests {
         test_location.push("tests\\test_data\\dfir\\windows\\usnjrnl\\win11\\$J");
         let params = UsnJrnlOptions {
             alt_drive: None,
-            alt_path: Some(test_location.display().to_string()),
+            alt_file: Some(test_location.display().to_string()),
             alt_mft: None,
         };
         let results = grab_usnjrnl_path(&params).unwrap();

--- a/forensics/src/runtime/linux/sudo.rs
+++ b/forensics/src/runtime/linux/sudo.rs
@@ -13,10 +13,10 @@ pub(crate) fn js_get_sudologs_linux(
 ) -> JsResult<JsValue> {
     let path = string_arg(args, 0)?;
 
-    let mut options = LinuxSudoOptions { alt_path: None };
+    let mut options = LinuxSudoOptions { alt_dir: None };
 
     if !path.is_empty() {
-        options.alt_path = Some(path);
+        options.alt_dir = Some(path);
     }
 
     let sudo_results = grab_sudo_logs(&options);

--- a/forensics/src/runtime/macos/accounts.rs
+++ b/forensics/src/runtime/macos/accounts.rs
@@ -17,7 +17,7 @@ pub(crate) fn js_users_macos(
         Some(string_arg(args, 0)?)
     };
 
-    let users = grab_users(&MacosUsersOptions { alt_path: path });
+    let users = grab_users(&MacosUsersOptions { alt_file: path });
     let results = serde_json::to_value(&users).unwrap_or_default();
     let value = JsValue::from_json(&results, context)?;
 
@@ -35,7 +35,7 @@ pub(crate) fn js_groups_macos(
     } else {
         Some(string_arg(args, 0)?)
     };
-    let groups = grab_groups(&MacosGroupsOptions { alt_path: path });
+    let groups = grab_groups(&MacosGroupsOptions { alt_file: path });
 
     let results = serde_json::to_value(&groups).unwrap_or_default();
     let value = JsValue::from_json(&results, context)?;

--- a/forensics/src/runtime/macos/accounts.rs
+++ b/forensics/src/runtime/macos/accounts.rs
@@ -17,7 +17,7 @@ pub(crate) fn js_users_macos(
         Some(string_arg(args, 0)?)
     };
 
-    let users = grab_users(&MacosUsersOptions { alt_file: path });
+    let users = grab_users(&MacosUsersOptions { alt_dir: path });
     let results = serde_json::to_value(&users).unwrap_or_default();
     let value = JsValue::from_json(&results, context)?;
 
@@ -35,7 +35,7 @@ pub(crate) fn js_groups_macos(
     } else {
         Some(string_arg(args, 0)?)
     };
-    let groups = grab_groups(&MacosGroupsOptions { alt_file: path });
+    let groups = grab_groups(&MacosGroupsOptions { alt_dir: path });
 
     let results = serde_json::to_value(&groups).unwrap_or_default();
     let value = JsValue::from_json(&results, context)?;

--- a/forensics/src/runtime/macos/emond.rs
+++ b/forensics/src/runtime/macos/emond.rs
@@ -16,7 +16,7 @@ pub(crate) fn js_emond(
         Some(string_arg(args, 0)?)
     };
 
-    let options = EmondOptions { alt_path: path };
+    let options = EmondOptions { alt_dir: path };
 
     let emond = match grab_emond(&options) {
         Ok(result) => result,

--- a/forensics/src/runtime/windows/jumplists.rs
+++ b/forensics/src/runtime/windows/jumplists.rs
@@ -15,7 +15,7 @@ pub(crate) fn js_jumplists(
     } else {
         Some(string_arg(args, 0)?)
     };
-    let options = JumplistsOptions { alt_file: path };
+    let options = JumplistsOptions { alt_dir: path };
     let jumplist = match grab_jumplists(&options) {
         Ok(result) => result,
         Err(err) => {

--- a/forensics/src/runtime/windows/usnjrnl.rs
+++ b/forensics/src/runtime/windows/usnjrnl.rs
@@ -29,7 +29,7 @@ pub(crate) fn js_usnjrnl(
 
     let options = UsnJrnlOptions {
         alt_drive: drive,
-        alt_path: path,
+        alt_file: path,
         alt_mft: mft_path,
     };
     let jrnl = match grab_usnjrnl_path(&options) {

--- a/forensics/src/structs/artifacts/os/linux.rs
+++ b/forensics/src/structs/artifacts/os/linux.rs
@@ -2,12 +2,12 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct JournalOptions {
-    pub alt_path: Option<String>,
+    pub alt_dir: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct LinuxSudoOptions {
-    pub alt_path: Option<String>,
+    pub alt_dir: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/forensics/src/structs/artifacts/os/macos.rs
+++ b/forensics/src/structs/artifacts/os/macos.rs
@@ -13,12 +13,12 @@ pub struct MacosSudoOptions {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct MacosUsersOptions {
-    pub alt_file: Option<String>,
+    pub alt_dir: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct MacosGroupsOptions {
-    pub alt_file: Option<String>,
+    pub alt_dir: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/forensics/src/structs/artifacts/os/macos.rs
+++ b/forensics/src/structs/artifacts/os/macos.rs
@@ -13,17 +13,17 @@ pub struct MacosSudoOptions {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct MacosUsersOptions {
-    pub alt_path: Option<String>,
+    pub alt_file: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct MacosGroupsOptions {
-    pub alt_path: Option<String>,
+    pub alt_file: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct EmondOptions {
-    pub alt_path: Option<String>,
+    pub alt_dir: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -48,6 +48,6 @@ pub struct LoginitemsOptions {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct SpotlightOptions {
-    pub alt_path: Option<String>,
+    pub alt_dir: Option<String>,
     pub include_additional: Option<bool>,
 }

--- a/forensics/src/structs/artifacts/os/windows.rs
+++ b/forensics/src/structs/artifacts/os/windows.rs
@@ -67,8 +67,8 @@ pub struct AmcacheOptions {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ShortcutOptions {
-    /**Path to directory containing `Shortcut (lnk)` files */
-    pub path: String,
+    /**Glob path to directory containing `Shortcut (lnk)` files */
+    pub dir: String,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -121,7 +121,7 @@ pub struct ServicesOptions {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct JumplistsOptions {
-    pub alt_file: Option<String>,
+    pub alt_dir: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/forensics/src/structs/artifacts/os/windows.rs
+++ b/forensics/src/structs/artifacts/os/windows.rs
@@ -74,7 +74,7 @@ pub struct ShortcutOptions {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct UsnJrnlOptions {
     pub alt_drive: Option<char>,
-    pub alt_path: Option<String>,
+    pub alt_file: Option<String>,
     pub alt_mft: Option<String>,
 }
 

--- a/forensics/tests/test_data/linux/journal.toml
+++ b/forensics/tests/test_data/linux/journal.toml
@@ -13,4 +13,4 @@ output = "local"
 artifact_name = "journal"
 [artifacts.journal]
 # Optional
-# alt_path = ""
+# alt_dir = ""

--- a/forensics/tests/test_data/linux/sudologs.toml
+++ b/forensics/tests/test_data/linux/sudologs.toml
@@ -12,4 +12,4 @@ output = "local"
 [[artifacts]]
 artifact_name = "sudologs-linux"
 [artifacts.sudologs_linux]
-# alt_path = ""
+# alt_dir = ""

--- a/forensics/tests/test_data/macos/spotlight.toml
+++ b/forensics/tests/test_data/macos/spotlight.toml
@@ -13,7 +13,7 @@ output = "local"
 artifact_name = "spotlight"
 [artifacts.spotlight]
 # Optional
-# alt_path = ""
+# alt_dir = ""
 # Include additional known Spotlight paths such as
 #     /Users/*/Library/Caches/com.apple.helpd/index.spotlightV*/*
 #     /Users/*/Library/Metadata/CoreSpotlight/index.spotlightV*/*

--- a/forensics/tests/test_data/windows/benchmarks/bits.toml
+++ b/forensics/tests/test_data/windows/benchmarks/bits.toml
@@ -12,4 +12,4 @@ output = "local"
 artifact_name = "bits"
 [artifacts.bits]
 carve = true
-#alt_path = "C:\\ProgramData\\Microsoft\\Network\\Downloader\\qmgr.db" # Optional
+# alt_file = "C:\\ProgramData\\Microsoft\\Network\\Downloader\\qmgr.db" # Optional

--- a/forensics/tests/test_data/windows/bits.toml
+++ b/forensics/tests/test_data/windows/bits.toml
@@ -13,4 +13,4 @@ output = "local"
 artifact_name = "bits"
 [artifacts.bits]
 carve = true
-#alt_path = "C:\\ProgramData\\Microsoft\\Network\\Downloader\\qmgr.db" # Optional
+#alt_file = "C:\\ProgramData\\Microsoft\\Network\\Downloader\\qmgr.db" # Optional

--- a/forensics/tests/test_data/windows/jumplists.toml
+++ b/forensics/tests/test_data/windows/jumplists.toml
@@ -12,4 +12,4 @@ output = "local"
 [[artifacts]]
 artifact_name = "jumplists"
 [artifacts.jumplists]
-# alt_file = "C:\\Aritfacts\\CustomJumplist" # Optional
+# alt_dir = "C:\\Aritfacts\\CustomJumplist\\*" # Optional

--- a/forensics/tests/test_data/windows/mft.toml
+++ b/forensics/tests/test_data/windows/mft.toml
@@ -14,4 +14,4 @@ artifact_name = "mft"
 [artifacts.mft]
 # Optional
 # alt_drive = 'C'
-# alt_path = ""
+# alt_file = ""

--- a/forensics/tests/test_data/windows/search.toml
+++ b/forensics/tests/test_data/windows/search.toml
@@ -12,4 +12,4 @@ output = "local"
 [[artifacts]]
 artifact_name = "search"
 [artifacts.search]
-#alt_path = "C:\\ProgramData\\Microsoft\\Search\\Data\\Applications\\Windows\\Windows.edb" # Optional
+# alt_file = "C:\\ProgramData\\Microsoft\\Search\\Data\\Applications\\Windows\\Windows.edb" # Optional

--- a/forensics/tests/test_data/windows/shortcuts.toml
+++ b/forensics/tests/test_data/windows/shortcuts.toml
@@ -12,4 +12,9 @@ output = "local"
 [[artifacts]]
 artifact_name = "shortcuts"
 [artifacts.shortcuts]
-path = "C:\\ProgramData\\Microsoft\\Windows\\Start Menu\\Programs\\Startup"
+dir = "C:\\ProgramData\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\*"
+
+[[artifacts]]
+artifact_name = "shortcuts"
+[artifacts.shortcuts]
+dir = "C:\\Users\\*\\AppData\\Roaming\\Microsoft\\Windows\\Recent\\*"

--- a/forensics/tests/test_data/windows/srum.toml
+++ b/forensics/tests/test_data/windows/srum.toml
@@ -12,4 +12,4 @@ output = "local"
 [[artifacts]]
 artifact_name = "srum"
 [artifacts.srum]
-#alt_path = "C:\\Windows\\System32\\srum\\SRUDB.dat" # Optional
+# alt_file = "C:\\Windows\\System32\\srum\\SRUDB.dat" # Optional

--- a/forensics/tests/test_data/windows/usnjrnl.toml
+++ b/forensics/tests/test_data/windows/usnjrnl.toml
@@ -14,5 +14,5 @@ artifact_name = "usnjrnl"
 [artifacts.usnjrnl]
 # Optional
 # alt_drive = 'C'
-# alt_path = ""
+# alt_file = ""
 # alt_mft = ""


### PR DESCRIPTION
Small update to make cli args consistent

- --alt-file to provide alternative file
- --alt-dir to provide alternative directory

Removed --alt-path option