### PR TITLE
More tests

### DIFF
--- a/.changes/unreleased/Changed-20260430-214606.yaml
+++ b/.changes/unreleased/Changed-20260430-214606.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: Made output consistent when an artifact has no results. Now if artemis parses an artifact that has no data, it will just output runtime log and a JSON report. Previously artemis would output an empty result with runtime metadata
+time: 2026-04-30T21:46:06.8359461-04:00

--- a/.changes/unreleased/Dependencies-20260430-215205.yaml
+++ b/.changes/unreleased/Dependencies-20260430-215205.yaml
@@ -1,0 +1,3 @@
+kind: Dependencies
+body: Updated all dependencies to latest version
+time: 2026-04-30T21:52:05.3188259-04:00

--- a/.justfile
+++ b/.justfile
@@ -108,6 +108,9 @@ end2end:
   cargo test --release --test journal_tester
   cargo test --release --test jumplists_tester
   cargo test --release --test qcow_tester
+  cargo test --release --test shimcache_tester
+  cargo test --release --test shimdb_tester
+  cargo test --release --test shortcuts_tester
 
 # Just build the artemis binary
 [group('workspace')]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -710,21 +710,15 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -946,9 +940,9 @@ checksum = "417bef24afe1460300965a25ff4a24b8b45ad011948302ec221e8a0a81eb2c79"
 
 [[package]]
 name = "cpubits"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef0c543070d296ea414df2dd7625d1b24866ce206709d8a4a424f28377f5861"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -1315,9 +1309,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "dataview"
@@ -2392,9 +2386,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
 dependencies = [
  "typenum",
 ]
@@ -2749,27 +2743,32 @@ dependencies = [
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
- "jni-sys 0.3.1",
+ "jni-macros",
+ "jni-sys",
  "log",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror 2.0.18",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link",
 ]
 
 [[package]]
-name = "jni-sys"
-version = "0.3.1"
+name = "jni-macros"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
- "jni-sys 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.1",
+ "simd_cesu8",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2803,9 +2802,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3631,13 +3630,13 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plist"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
 dependencies = [
  "base64",
  "indexmap",
- "quick-xml 0.38.4",
+ "quick-xml 0.39.2",
  "serde",
  "time",
 ]
@@ -3837,15 +3836,6 @@ name = "quick-xml"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11bafc859c6815fbaffbbbf4229ecb767ac913fecb27f9ad4343662e9ef099ea"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.38.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
  "memchr",
 ]
@@ -4120,9 +4110,9 @@ checksum = "cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6"
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64",
  "bytes",
@@ -4336,9 +4326,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.39"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -4362,9 +4352,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -4372,9 +4362,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
@@ -4691,6 +4681,16 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version 0.4.1",
+ "simdutf8",
+]
 
 [[package]]
 name = "simdutf8"
@@ -5057,9 +5057,9 @@ checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
 
 [[package]]
 name = "thin-vec"
-version = "0.2.16"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "259cdf8ed4e4aca6f1e9d011e10bd53f524a2d0637d7b28450f6c64ac298c4c6"
+checksum = "b0f7e269b48f0a7dd0146680fa24b50cc67fc0373f086a5b2f99bd084639b482"
 
 [[package]]
 name = "thiserror"
@@ -5590,9 +5590,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5603,9 +5603,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5613,9 +5613,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5623,9 +5623,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5636,9 +5636,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -5904,9 +5904,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6082,15 +6082,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -6114,21 +6105,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -6175,12 +6151,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -6193,12 +6163,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -6208,12 +6172,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6241,12 +6199,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -6256,12 +6208,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6277,12 +6223,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -6292,12 +6232,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6694,9 +6628,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "8.5.1"
+version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcab981e19633ebcf0b001ddd37dd802996098bc1864f90b7c5d970ce76c1d59"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
  "crc32fast",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ base64 = "0.22.1"
 tokio = { version = "1.52.1", features = ["full"] }
 flate2 = "1.1.9"
 glob = "0.3.3"
-reqwest = { version = "0.13.2", features = [
+reqwest = { version = "0.13.3", features = [
     "json",
     "blocking",
     "multipart",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -11,5 +11,5 @@ repository = { workspace = true }
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }
-plist = "1.8.0"
+plist = "1.9.0"
 ext4-fs = "0.1.5"

--- a/common/src/windows.rs
+++ b/common/src/windows.rs
@@ -857,7 +857,7 @@ pub enum Action {
     Unknown,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ShimcacheEntry {
     pub entry: u32,
     pub path: String,
@@ -866,14 +866,14 @@ pub struct ShimcacheEntry {
     pub evidence: String,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ShimData {
     pub indexes: Vec<TagData>,
     pub db_data: DatabaseData,
     pub evidence: String,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct DatabaseData {
     pub sdb_version: String,
     pub compile_time: String,
@@ -885,7 +885,7 @@ pub struct DatabaseData {
     pub list_data: Vec<TagData>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct TagData {
     pub data: HashMap<String, String>, //key: TAG_SHIM_TAGID, value: "0x11", binary: base64, string
     pub list_data: Vec<HashMap<String, String>>,

--- a/forensics/Cargo.toml
+++ b/forensics/Cargo.toml
@@ -36,7 +36,7 @@ walkdir = "2.5.0"
 home = "0.5.12"
 chrono = "0.4.44"
 simplelog = "0.12.2"
-zip = { version = "8.5.1", default-features = false, features = ["deflate"] }
+zip = { version = "8.6.0", default-features = false, features = ["deflate"] }
 jsonwebtoken = { version = "10.3.0", features = ["aws_lc_rs"] }
 rusty-s3 = "0.9.1"
 quick-xml = { version = "0.39.2", default-features = false, features = [
@@ -53,7 +53,7 @@ ruzstd = "0.8.2"
 lz4_flex = "0.13.0"
 xz2 = { version = "0.1.7", default-features = false, features = ["static"] }
 macos-unifiedlogs = "0.5.1"
-plist = "1.8.0"
+plist = "1.9.0"
 aes = "0.9.0"
 cbc = "0.2.0"
 yara-x = { version = "1.15.0", optional = true, default-features = false, features = [

--- a/forensics/src/artifacts/os/windows/artifacts.rs
+++ b/forensics/src/artifacts/os/windows/artifacts.rs
@@ -1,19 +1,13 @@
-use super::jumplists::parser::grab_jumplists;
-use super::mft::parser::grab_mft;
-use super::ntfs::parser::ntfs_filelist;
-use super::outlook::parser::grab_outlook;
-use super::recyclebin::parser::grab_recycle_bin;
-use super::registry::parser::parse_registry;
-use super::search::parser::grab_search;
-use super::services::parser::grab_services;
-use super::tasks::parser::grab_tasks;
-use super::wmi::parser::grab_wmi_persist;
 use super::{
     accounts::parser::grab_users, amcache::parser::grab_amcache, bits::parser::grab_bits,
-    error::WinArtifactError, eventlogs::parser::grab_eventlogs, prefetch::parser::grab_prefetch,
+    error::WinArtifactError, eventlogs::parser::grab_eventlogs, jumplists::parser::grab_jumplists,
+    mft::parser::grab_mft, ntfs::parser::ntfs_filelist, outlook::parser::grab_outlook,
+    prefetch::parser::grab_prefetch, recyclebin::parser::grab_recycle_bin,
+    registry::parser::parse_registry, search::parser::grab_search, services::parser::grab_services,
     shellbags::parser::grab_shellbags, shimcache::parser::grab_shimcache,
     shimdb::parser::grab_shimdb, shortcuts::parser::grab_lnk_directory, srum::parser::grab_srum,
-    userassist::parser::grab_userassist, usnjrnl::parser::grab_usnjrnl,
+    tasks::parser::grab_tasks, userassist::parser::grab_userassist, usnjrnl::parser::grab_usnjrnl,
+    wmi::parser::grab_wmi_persist,
 };
 use crate::artifacts::output::output_artifact;
 use crate::structs::artifacts::os::windows::{
@@ -37,7 +31,7 @@ pub(crate) fn prefetch(
     let start_time = time::time_now();
 
     let pf_results = grab_prefetch(options);
-    let pf_data = match pf_results {
+    let entries = match pf_results {
         Ok(results) => results,
         Err(err) => {
             error!("[forensics] Artemis failed to parse Prefetch: {err:?}");
@@ -45,7 +39,11 @@ pub(crate) fn prefetch(
         }
     };
 
-    let serde_data_result = serde_json::to_value(pf_data);
+    if entries.is_empty() {
+        return Ok(());
+    }
+
+    let serde_data_result = serde_json::to_value(entries);
     let mut serde_data = match serde_data_result {
         Ok(results) => results,
         Err(err) => {
@@ -111,7 +109,7 @@ pub(crate) fn shimdb(
 ) -> Result<(), WinArtifactError> {
     let start_time = time::time_now();
     let shimdb_results = grab_shimdb(options);
-    let sdb_data = match shimdb_results {
+    let entries = match shimdb_results {
         Ok(results) => results,
         Err(err) => {
             error!("[forensics] Artemis failed to parse Shimdb: {err:?}");
@@ -119,7 +117,11 @@ pub(crate) fn shimdb(
         }
     };
 
-    let serde_data_result = serde_json::to_value(sdb_data);
+    if entries.is_empty() {
+        return Ok(());
+    }
+
+    let serde_data_result = serde_json::to_value(entries);
     let mut serde_data = match serde_data_result {
         Ok(results) => results,
         Err(err) => {
@@ -141,7 +143,7 @@ pub(crate) fn userassist(
     let start_time = time::time_now();
 
     let assist_results = grab_userassist(options);
-    let assist_data = match assist_results {
+    let entries = match assist_results {
         Ok(results) => results,
         Err(err) => {
             error!("[forensics] Artemis failed to parse UserAssist: {err:?}");
@@ -149,7 +151,11 @@ pub(crate) fn userassist(
         }
     };
 
-    let serde_data_result = serde_json::to_value(assist_data);
+    if entries.is_empty() {
+        return Ok(());
+    }
+
+    let serde_data_result = serde_json::to_value(entries);
     let mut serde_data = match serde_data_result {
         Ok(results) => results,
         Err(err) => {
@@ -170,7 +176,7 @@ pub(crate) fn shimcache(
     let start_time = time::time_now();
 
     let shim_results = grab_shimcache(options);
-    let shim_data = match shim_results {
+    let entries = match shim_results {
         Ok(results) => results,
         Err(err) => {
             error!("[forensics] Artemis failed to parse Shimcache: {err:?}");
@@ -178,7 +184,11 @@ pub(crate) fn shimcache(
         }
     };
 
-    let serde_data_result = serde_json::to_value(shim_data);
+    if entries.is_empty() {
+        return Ok(());
+    }
+
+    let serde_data_result = serde_json::to_value(entries);
     let mut serde_data = match serde_data_result {
         Ok(results) => results,
         Err(err) => {
@@ -206,6 +216,10 @@ pub(crate) fn shellbags(
             error!("[forensics] Artemis failed to parse Shellbags: {err:?}");
             return Err(WinArtifactError::Shellbag);
         }
+    }
+
+    if entries.is_empty() {
+        return Ok(());
     }
 
     let serde_data_result = serde_json::to_value(entries);
@@ -238,6 +252,10 @@ pub(crate) fn amcache(
         }
     }
 
+    if entries.is_empty() {
+        return Ok(());
+    }
+
     let serde_data_result = serde_json::to_value(entries);
     let mut serde_data = match serde_data_result {
         Ok(results) => results,
@@ -266,6 +284,10 @@ pub(crate) fn shortcuts(
             return Err(WinArtifactError::Shortcuts);
         }
     };
+
+    if entries.is_empty() {
+        return Ok(());
+    }
 
     let serde_data_result = serde_json::to_value(entries);
     let mut serde_data = match serde_data_result {
@@ -309,6 +331,10 @@ pub(crate) fn bits(
             return Err(WinArtifactError::Bits);
         }
     };
+
+    if entries.is_empty() {
+        return Ok(());
+    }
 
     let serde_data_result = serde_json::to_value(entries);
     let mut serde_data = match serde_data_result {
@@ -366,6 +392,11 @@ pub(crate) fn users_windows(
             return Err(WinArtifactError::Users);
         }
     };
+
+    if entries.is_empty() {
+        return Ok(());
+    }
+
     let serde_data_result = serde_json::to_value(entries);
     let mut serde_data = match serde_data_result {
         Ok(results) => results,
@@ -401,7 +432,7 @@ pub(crate) fn services(
     let start_time = time::time_now();
 
     let service_results = grab_services(options);
-    let service_data = match service_results {
+    let entries = match service_results {
         Ok(results) => results,
         Err(err) => {
             error!("[forensics] Artemis failed to parse Services: {err:?}");
@@ -409,7 +440,11 @@ pub(crate) fn services(
         }
     };
 
-    let serde_data_result = serde_json::to_value(service_data);
+    if entries.is_empty() {
+        return Ok(());
+    }
+
+    let serde_data_result = serde_json::to_value(entries);
     let mut serde_data = match serde_data_result {
         Ok(results) => results,
         Err(err) => {
@@ -431,7 +466,7 @@ pub(crate) fn jumplists(
     let start_time = time::time_now();
 
     let jumplist_result = grab_jumplists(options);
-    let jumplist_data = match jumplist_result {
+    let entries = match jumplist_result {
         Ok(results) => results,
         Err(err) => {
             error!("[forensics] Artemis failed to parse Jumplists: {err:?}");
@@ -439,7 +474,11 @@ pub(crate) fn jumplists(
         }
     };
 
-    let serde_data_result = serde_json::to_value(jumplist_data);
+    if entries.is_empty() {
+        return Ok(());
+    }
+
+    let serde_data_result = serde_json::to_value(entries);
     let mut serde_data = match serde_data_result {
         Ok(results) => results,
         Err(err) => {
@@ -461,7 +500,7 @@ pub(crate) fn recycle_bin(
     let start_time = time::time_now();
 
     let bin_result = grab_recycle_bin(options);
-    let bin_data = match bin_result {
+    let entries = match bin_result {
         Ok(results) => results,
         Err(err) => {
             error!("[forensics] Artemis failed to parse Recycle Bin: {err:?}");
@@ -469,7 +508,11 @@ pub(crate) fn recycle_bin(
         }
     };
 
-    let serde_data_result = serde_json::to_value(bin_data);
+    if entries.is_empty() {
+        return Ok(());
+    }
+
+    let serde_data_result = serde_json::to_value(entries);
     let mut serde_data = match serde_data_result {
         Ok(results) => results,
         Err(err) => {
@@ -491,7 +534,7 @@ pub(crate) fn wmi_persist(
     let start_time = time::time_now();
 
     let wmi_result = grab_wmi_persist(options);
-    let wmi_data = match wmi_result {
+    let entries = match wmi_result {
         Ok(results) => results,
         Err(err) => {
             error!("[forensics] Artemis failed to parse WMI Persistence: {err:?}");
@@ -499,7 +542,11 @@ pub(crate) fn wmi_persist(
         }
     };
 
-    let serde_data_result = serde_json::to_value(wmi_data);
+    if entries.is_empty() {
+        return Ok(());
+    }
+
+    let serde_data_result = serde_json::to_value(entries);
     let mut serde_data = match serde_data_result {
         Ok(results) => results,
         Err(err) => {

--- a/forensics/tests/shimcache_tester.rs
+++ b/forensics/tests/shimcache_tester.rs
@@ -1,13 +1,76 @@
+use common::windows::ShimcacheEntry;
+use std::path::PathBuf;
+use std::{
+    fs::File,
+    io::{BufRead, BufReader},
+};
+
 #[test]
 #[cfg(target_os = "windows")]
 fn test_shimcache_parser() {
-    use std::path::PathBuf;
-
     use forensics::core::parse_toml_file;
+    use glob::glob;
+    use std::fs::read;
 
     let mut test_location = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     test_location.push("tests/test_data/windows/shimcache.toml");
 
-    let results = parse_toml_file(&test_location.display().to_string()).unwrap();
-    assert_eq!(results, ())
+    parse_toml_file(&test_location.display().to_string()).unwrap();
+    let mut output_location = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    output_location.push("tmp/shimcache_collection/*");
+
+    let results = glob(output_location.to_str().unwrap()).unwrap();
+    for result in results {
+        let value = &result.unwrap();
+        if value.to_str().unwrap().contains("report_") {
+            let bytes = read(value).unwrap();
+            let text = String::from_utf8(bytes).unwrap();
+            if text.contains("\"total_output_files\":0,") {
+                panic!("missing Shimcache??");
+            }
+            continue;
+        }
+        let output_file = value.to_str().unwrap();
+
+        if output_file.contains("\\shimcache_") && output_file.ends_with(".jsonl") {
+            validate_output(value);
+        }
+        if value.extension().unwrap() == "log" && !value.to_str().unwrap().contains("status_") {
+            check_errors(value);
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn validate_output(output: &PathBuf) {
+    // Output is in JSONL based on the TOML file above!
+    let file = File::open(output).unwrap();
+    let reader = BufReader::new(file);
+    for (_, line) in reader.lines().enumerate() {
+        let value = line.unwrap();
+        println!("{value}");
+        let info: ShimcacheEntry = serde_json::from_str(&value).unwrap();
+        if info.last_modified.is_empty() && info.path.is_empty() {
+            println!("Missing timestamp and path?");
+            panic!("{info:?}");
+        }
+        assert!(!info.key_path.is_empty())
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn check_errors(output: &PathBuf) {
+    let file = File::open(output).unwrap();
+    let reader = BufReader::new(file);
+
+    let mut count = 0;
+    for (_, line) in reader.lines().enumerate() {
+        let value = line.unwrap();
+        println!("{value}");
+        count += 1;
+    }
+
+    if count != 0 {
+        panic!("error count: {count}");
+    }
 }

--- a/forensics/tests/shimdb_tester.rs
+++ b/forensics/tests/shimdb_tester.rs
@@ -11,7 +11,6 @@ fn test_shimdb_parser() {
     use forensics::core::parse_toml_file;
     use glob::glob;
     use std::fs::read;
-    use std::path::PathBuf;
 
     let mut test_location = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     test_location.push("tests/test_data/windows/shimdb.toml");

--- a/forensics/tests/shimdb_tester.rs
+++ b/forensics/tests/shimdb_tester.rs
@@ -1,13 +1,77 @@
+use common::windows::ShimData;
+use std::path::PathBuf;
+use std::{
+    fs::File,
+    io::{BufRead, BufReader},
+};
+
 #[test]
 #[cfg(target_os = "windows")]
 fn test_shimdb_parser() {
-    use std::path::PathBuf;
-
     use forensics::core::parse_toml_file;
+    use glob::glob;
+    use std::fs::read;
+    use std::path::PathBuf;
 
     let mut test_location = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     test_location.push("tests/test_data/windows/shimdb.toml");
 
-    let results = parse_toml_file(&test_location.display().to_string()).unwrap();
-    assert_eq!(results, ())
+    parse_toml_file(&test_location.display().to_string()).unwrap();
+    let mut output_location = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    output_location.push("tmp/sdb_collection/*");
+
+    let results = glob(output_location.to_str().unwrap()).unwrap();
+    for result in results {
+        let value = &result.unwrap();
+        if value.to_str().unwrap().contains("report_") {
+            let bytes = read(value).unwrap();
+            let text = String::from_utf8(bytes).unwrap();
+            if text.contains("\"total_output_files\":0,") {
+                panic!("missing ShimDB??");
+            }
+            continue;
+        }
+        let output_file = value.to_str().unwrap();
+
+        if output_file.contains("\\shimdb_") && output_file.ends_with(".jsonl") {
+            validate_output(value);
+        }
+        if value.extension().unwrap() == "log" && !value.to_str().unwrap().contains("status_") {
+            check_errors(value);
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn validate_output(output: &PathBuf) {
+    // Output is in JSONL based on the TOML file above!
+    let file = File::open(output).unwrap();
+    let reader = BufReader::new(file);
+    for (_, line) in reader.lines().enumerate() {
+        let value = line.unwrap();
+        println!("{value}");
+        let info: ShimData = serde_json::from_str(&value).unwrap();
+        if info.db_data.name.is_empty() {
+            println!("No DB name?");
+            panic!("{:?}", info.db_data);
+        }
+        assert_ne!(info.db_data.compile_time, "1970-01-01T00:00:00.000Z");
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn check_errors(output: &PathBuf) {
+    let file = File::open(output).unwrap();
+    let reader = BufReader::new(file);
+
+    let mut count = 0;
+    for (_, line) in reader.lines().enumerate() {
+        let value = line.unwrap();
+        println!("{value}");
+        count += 1;
+    }
+
+    if count != 0 {
+        panic!("error count: {count}");
+    }
 }

--- a/forensics/tests/shortcuts_tester.rs
+++ b/forensics/tests/shortcuts_tester.rs
@@ -1,13 +1,82 @@
+use common::windows::ShortcutInfo;
+use std::path::PathBuf;
+use std::{
+    fs::File,
+    io::{BufRead, BufReader},
+};
+
 #[test]
 #[cfg(target_os = "windows")]
 fn test_shortcuts_parser() {
-    use std::path::PathBuf;
-
     use forensics::core::parse_toml_file;
+    use glob::glob;
+    use std::fs::read;
 
     let mut test_location = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     test_location.push("tests/test_data/windows/shortcuts.toml");
 
-    let results = parse_toml_file(&test_location.display().to_string()).unwrap();
-    assert_eq!(results, ())
+    parse_toml_file(&test_location.display().to_string()).unwrap();
+    let mut output_location = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    output_location.push("tmp/shortcuts_collection/*");
+
+    let results = glob(output_location.to_str().unwrap()).unwrap();
+    for result in results {
+        let value = &result.unwrap();
+        if value.to_str().unwrap().contains("report_") {
+            let bytes = read(value).unwrap();
+            let text = String::from_utf8(bytes).unwrap();
+            // Some systems may not have any Shortcut files in common locations
+            if text.contains("\"total_output_files\":0,") && text.contains("failed") {
+                panic!("missing Shortcuts??");
+            }
+            continue;
+        }
+        let output_file = value.to_str().unwrap();
+
+        if output_file.contains("\\shortcuts_") && output_file.ends_with(".jsonl") {
+            validate_output(value);
+        }
+        if value.extension().unwrap() == "log" && !value.to_str().unwrap().contains("status_") {
+            check_errors(value);
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn validate_output(output: &PathBuf) {
+    // Output is in JSONL based on the TOML file above!
+    let file = File::open(output).unwrap();
+    let reader = BufReader::new(file);
+    for (_, line) in reader.lines().enumerate() {
+        let value = line.unwrap();
+        println!("{value}");
+        let info: ShortcutInfo = serde_json::from_str(&value).unwrap();
+        if info.created.is_empty() && info.path.is_empty() {
+            println!("Missing timestamp and path?");
+            panic!("{info:?}");
+        }
+        assert!(!info.path.is_empty())
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn check_errors(output: &PathBuf) {
+    let file = File::open(output).unwrap();
+    let reader = BufReader::new(file);
+
+    let mut count = 0;
+    for (_, line) in reader.lines().enumerate() {
+        let value = line.unwrap();
+
+        // Common file encountered in Shortcut directories like Startup folder and Recent items
+        if value.contains("desktop.ini") {
+            continue;
+        }
+        println!("{value}");
+        count += 1;
+    }
+
+    if count != 0 {
+        panic!("error count: {count}");
+    }
 }

--- a/forensics/tests/test_data/windows/shimcache.toml
+++ b/forensics/tests/test_data/windows/shimcache.toml
@@ -1,8 +1,8 @@
 [output]
 name = "shimcache_collection"
 directory = "./tmp"
-format = "json"
-compress = true
+format = "jsonl"
+compress = false
 timeline = false
 endpoint_id = "6c51b123-1522-4572-9f2a-0bd5abd81b82"
 collection_id = 1

--- a/forensics/tests/test_data/windows/shimdb.toml
+++ b/forensics/tests/test_data/windows/shimdb.toml
@@ -2,7 +2,7 @@
 [output]
 name = "sdb_collection"
 directory = "./tmp"
-format = "json"
+format = "jsonl"
 compress = false
 timeline = false
 endpoint_id = "6c51b123-1522-4572-9f2a-0bd5abd81b82"

--- a/forensics/tests/test_data/windows/shortcuts.toml
+++ b/forensics/tests/test_data/windows/shortcuts.toml
@@ -2,7 +2,7 @@
 [output]
 name = "shortcuts_collection"
 directory = "./tmp"
-format = "json"
+format = "jsonl"
 compress = false
 timeline = false
 endpoint_id = "6c51b123-1522-4572-9f2a-0bd5abd81b82"


### PR DESCRIPTION
Added more end to end tests.

Also updated windows artifacts to be consistent when parsing an artifact that has no data.

Now if artemis parses a Windows artifact that is empty/no data. It will only output log file and JSON report.
Previously for some artifacts, artemis would output an empty result with runtime metadata.

Will update macOS and linux in follow up PRs