### PR TITLE
EventLogs fix

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -111,6 +111,7 @@ end2end:
   cargo test --release --test shimcache_tester
   cargo test --release --test shimdb_tester
   cargo test --release --test shortcuts_tester
+  cargo test --release --test wmipersist_tester
 
 # Just build the artemis binary
 [group('workspace')]

--- a/common/src/windows.rs
+++ b/common/src/windows.rs
@@ -1503,7 +1503,7 @@ pub enum Source {
     None,
 }
 
-#[derive(Debug, PartialEq, Eq, Serialize)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WmiPersist {
     pub class: String,
     pub values: BTreeMap<String, Value>,

--- a/forensics/src/artifacts/os/windows/eventlogs/combine.rs
+++ b/forensics/src/artifacts/os/windows/eventlogs/combine.rs
@@ -14,6 +14,7 @@ pub(crate) fn add_message_strings(
     log: &EventLogRecord,
     resources: &StringResource,
     param_regex: &Regex,
+    value_regex: &Regex,
     evidence: &str,
 ) -> Option<EventMessage> {
     let mut message = EventMessage {
@@ -186,8 +187,13 @@ pub(crate) fn add_message_strings(
             };
 
             message.template_message = table.message.clone();
-            message.message =
-                merge_strings_message_table(&log.data, table, param_regex, &param_message_table)?;
+            message.message = merge_strings_message_table(
+                &log.data,
+                table,
+                param_regex,
+                value_regex,
+                &param_message_table,
+            )?;
             clean_message(&mut message);
             return Some(message);
         }
@@ -224,6 +230,7 @@ pub(crate) fn add_message_strings(
                     &log.data,
                     table,
                     param_regex,
+                    value_regex,
                     &param_message_table,
                 )?;
                 clean_message(&mut message);
@@ -257,8 +264,13 @@ pub(crate) fn add_message_strings(
 
         // If we do not have any templates. Can just try messagetable only
         if event_definition.template.is_none() {
-            message.message =
-                merge_strings_message_table(&log.data, table, param_regex, &param_message_table)?;
+            message.message = merge_strings_message_table(
+                &log.data,
+                table,
+                param_regex,
+                value_regex,
+                &param_message_table,
+            )?;
             clean_message(&mut message);
             return Some(message);
         }
@@ -270,6 +282,7 @@ pub(crate) fn add_message_strings(
             table,
             event_definition,
             param_regex,
+            value_regex,
             &param_message_table,
         )?;
         break;
@@ -579,6 +592,7 @@ fn merge_strings(
     table: &MessageTable,
     manifest: &Definition,
     param_regex: &Regex,
+    value_regex: &Regex,
     parameter_message: &HashMap<u32, MessageTable>,
 ) -> Option<String> {
     let mut data = log.as_object()?.get("Event")?;
@@ -647,7 +661,8 @@ fn merge_strings(
         // If element list is too small, then we use the list of values from the event data
         if element_list.len() < (param_num - adjust_id) {
             let value = data_values.get(param_num - adjust_id)?;
-            clean_message = add_event_string(value, clean_message, param, parameter_message)?;
+            clean_message =
+                add_event_string(value, clean_message, param, value_regex, parameter_message)?;
             continue;
         }
 
@@ -677,7 +692,8 @@ fn merge_strings(
             // Event Viewer can resolve these enums somehow (Ex: IntendedPackageState - Installed). Currently we cannot
             // Other EventLog parsers also cannot seem to resolve either
 
-            clean_message = add_event_string(value, clean_message, param, parameter_message)?;
+            clean_message =
+                add_event_string(value, clean_message, param, value_regex, parameter_message)?;
             continue;
         }
 
@@ -686,7 +702,8 @@ fn merge_strings(
             // If we fail to find the attribute name. Return the parameter (%1)
             // Sometimes happens if we try to mix eventlogs and template strings from different systems
             let value = event_data.get(&attribute.value).unwrap_or(&default);
-            clean_message = add_event_string(value, clean_message, param, parameter_message)?;
+            clean_message =
+                add_event_string(value, clean_message, param, value_regex, parameter_message)?;
         }
     }
 
@@ -698,10 +715,12 @@ fn add_event_string(
     value: &Value,
     mut message: String,
     param: &str,
+    value_regex: &Regex,
     parameter_message: &HashMap<u32, MessageTable>,
 ) -> Option<String> {
-    // Sometimes EventLog data values are a string of raw IDs (ex: "%%1538\r\n%%1539")
+    // Sometimes EventLog data values are a string of multiple raw parameter IDs (ex: "%%1538\r\n%%1539")
     // Below is an example EventLog message rendered by artemis (from Github CI runner)
+    // We use regex to loop through them all and replace each instance with the corresponding string from the MessageTable
     /*Ex:
         An operation was attempted on a privileged object.
 
@@ -735,35 +754,45 @@ fn add_event_string(
 
             Privileges:		SeTakeOwnershipPrivilege
     */
-    if value
-        .as_str()
-        .is_some_and(|s| s.starts_with("%%") && !s.contains("\r\n"))
-    {
+    if value.as_str().is_some_and(|s| s.starts_with("%%")) {
         if parameter_message.is_empty() {
             warn!("[eventlogs] Got parameter message id {value:?} but no parameter message table");
             return Some(message);
         }
 
-        let num_result = value.as_str()?.get(2..)?.parse();
-        if let Err(status) = num_result {
-            warn!("[eventlogs] Could not get parameter message id: {status:?}. Value: {value:?}");
-            return Some(message);
-        }
-
-        let param_message_id: u32 = num_result.unwrap_or_default();
-
-        let param_message_value = if let Some(result) = parameter_message.get(&param_message_id) {
-            result
-        } else {
-            // Try one more time
-            let adjust = 0xffff;
-            match parameter_message.get(&(param_message_id & adjust)) {
-                Some(result) => result,
-                None => return Some(message),
+        // Unwrap is safe since we check to make sure its a string above
+        let mut raw_param_id = value.as_str().unwrap().to_string();
+        // Use our Regex to match on all parameter IDs in the evtx data
+        // Replace each one from with a MessageTable string
+        for found in value_regex.find_iter(value.as_str().unwrap()) {
+            let match_value = found.as_str();
+            if !match_value.starts_with("%%") {
+                continue;
             }
-        };
 
-        message = message.replacen(param, &param_message_value.message, 1);
+            let num_result = match_value.get(2..)?.parse();
+            if let Err(status) = num_result {
+                warn!(
+                    "[eventlogs] Could not get parameter message id: {status:?}. Value: {value:?}"
+                );
+                return Some(message);
+            }
+            let param_message_id: u32 = num_result.unwrap_or_default();
+            let param_message_value = if let Some(result) = parameter_message.get(&param_message_id)
+            {
+                result
+            } else {
+                // Try one more time
+                let adjust = 0xffff;
+                match parameter_message.get(&(param_message_id & adjust)) {
+                    Some(result) => result,
+                    None => return Some(message),
+                }
+            };
+
+            raw_param_id = raw_param_id.replace(match_value, &param_message_value.message);
+        }
+        message = message.replacen(param, &raw_param_id, 1);
         return Some(message);
     }
 
@@ -803,6 +832,7 @@ fn merge_strings_message_table(
     log: &Value,
     table: &MessageTable,
     param_regex: &Regex,
+    value_regex: &Regex,
     parameter_message: &HashMap<u32, MessageTable>,
 ) -> Option<String> {
     let mut clean_message = clean_table(&table.message);
@@ -884,7 +914,8 @@ fn merge_strings_message_table(
         }
 
         let value = values.get(param_num - adjust_id)?;
-        clean_message = add_event_string(value, clean_message, param, parameter_message)?;
+        clean_message =
+            add_event_string(value, clean_message, param, value_regex, parameter_message)?;
     }
 
     Some(clean_message)
@@ -1015,10 +1046,12 @@ mod tests {
             "system_missing.json",
             "configuration.json",
             "powershell.json",
+            "parameter_value.json",
         ];
 
         let resources = get_resources().unwrap();
         let params = create_regex(r"(%\d!.*?!)|(%\d+)").unwrap();
+        let value_regex = create_regex(r"%%\d+").unwrap();
 
         for sample in samples {
             test_location.push(sample);
@@ -1028,7 +1061,8 @@ mod tests {
             test_location.pop();
             let evidence = "test";
 
-            let message = add_message_strings(&log, &resources, &params, evidence).unwrap();
+            let message =
+                add_message_strings(&log, &resources, &params, &value_regex, evidence).unwrap();
 
             assert!(!message.message.contains("%%"));
             assert!(!message.message.contains("TEMP_ARTEMIS_VALUE"));
@@ -1260,6 +1294,13 @@ mod tests {
                 "powershell.json" => {
                     assert!(!message.message.contains("TEMP_ARTEMIS_VALUE"));
                 }
+                "parameter_value.json" => {
+                    assert!(
+                        message
+                            .message
+                            .contains("Success Added\r\n, Failure added\r\n\r\n")
+                    )
+                }
                 _ => panic!("should not have an unknown sample?"),
             }
         }
@@ -1417,7 +1458,8 @@ mod tests {
     fn test_add_event_string() {
         let value = Value::String(String::from("love"));
         let test = String::from("i really %1 windows eventlogs! /s");
-        let result = add_event_string(&value, test, "%1", &HashMap::new()).unwrap();
+        let value_regex = create_regex(r"%%\d+").unwrap();
+        let result = add_event_string(&value, test, "%1", &value_regex, &HashMap::new()).unwrap();
         assert_eq!(result, "i really love windows eventlogs! /s");
     }
 

--- a/forensics/src/artifacts/os/windows/eventlogs/combine.rs
+++ b/forensics/src/artifacts/os/windows/eventlogs/combine.rs
@@ -790,7 +790,7 @@ fn add_event_string(
                 }
             };
 
-            raw_param_id = raw_param_id.replace(match_value, &param_message_value.message);
+            raw_param_id = raw_param_id.replacen(match_value, &param_message_value.message, 1);
         }
         message = message.replacen(param, &raw_param_id, 1);
         return Some(message);

--- a/forensics/src/artifacts/os/windows/eventlogs/parser.rs
+++ b/forensics/src/artifacts/os/windows/eventlogs/parser.rs
@@ -82,6 +82,7 @@ pub(crate) fn parse_eventlogs(
     let mut eventlog_records = Vec::new();
     // Regex always correct
     let param_regex = create_regex(r"(%\d!.*?!)|(%\d+)").unwrap();
+    let value_regex = create_regex(r"%%\d+").unwrap();
 
     for record in evt_parser.records_json_value().skip(offset) {
         match record {
@@ -109,7 +110,7 @@ pub(crate) fn parse_eventlogs(
         let mut raw_messages = Vec::new();
         for record in eventlog_records {
             let message = if let Some(result) =
-                add_message_strings(&record, resource, &param_regex, path)
+                add_message_strings(&record, resource, &param_regex, &value_regex, path)
             {
                 result
             } else {
@@ -296,7 +297,7 @@ fn read_eventlogs(
     let limit = 1000;
     // Regex always correct
     let param_regex = create_regex(r"(%\d!.*?!)|(%\d+)").unwrap();
-
+    let value_regex = create_regex(r"%%\d+").unwrap();
     for record in evt_parser.records_json_value() {
         match record {
             Ok(data) => {
@@ -320,7 +321,7 @@ fn read_eventlogs(
                 let mut raw_messages = Vec::new();
                 for record in eventlog_records {
                     let message = if let Some(result) =
-                        add_message_strings(&record, resource, &param_regex, path)
+                        add_message_strings(&record, resource, &param_regex, &value_regex, path)
                     {
                         result
                     } else {
@@ -370,7 +371,7 @@ fn read_eventlogs(
             let mut raw_messages = Vec::new();
             for record in eventlog_records {
                 let message = if let Some(result) =
-                    add_message_strings(&record, resource, &param_regex, path)
+                    add_message_strings(&record, resource, &param_regex, &value_regex, path)
                 {
                     result
                 } else {

--- a/forensics/tests/tasks_tester.rs
+++ b/forensics/tests/tasks_tester.rs
@@ -47,6 +47,7 @@ fn validate_output(output: &PathBuf) {
         let info: TaskInfo = serde_json::from_str(&value).unwrap();
         assert!(!info.name.is_empty());
         if !info.action.contains("VSIXConfigurationUpdater") && !info.path.contains("S-1-5-21-") {
+            println!("{info:?}");
             assert!(!info.registry_tree_path.is_empty());
             assert!(!info.id.is_empty());
         }

--- a/forensics/tests/tasks_tester.rs
+++ b/forensics/tests/tasks_tester.rs
@@ -46,8 +46,10 @@ fn validate_output(output: &PathBuf) {
         let value = line.unwrap();
         let info: TaskInfo = serde_json::from_str(&value).unwrap();
         assert!(!info.name.is_empty());
-        if !info.action.contains("VSIXConfigurationUpdater") && !info.path.contains("S-1-5-21-") {
-            println!("{info:?}");
+        if !info.action.contains("VSIXConfigurationUpdater")
+            && !info.path.contains("S-1-5-21-")
+            && !info.action.contains("hosted-compute-agent")
+        {
             assert!(!info.registry_tree_path.is_empty());
             assert!(!info.id.is_empty());
         }

--- a/forensics/tests/test_data/windows/eventlogs/samples/parameter_value.json
+++ b/forensics/tests/test_data/windows/eventlogs/samples/parameter_value.json
@@ -1,0 +1,58 @@
+{
+    "event_record_id": 12339,
+    "timestamp": "2026-04-29T14:21:54.0035284Z",
+    "data": {
+        "Event": {
+            "#attributes": {
+                "xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"
+            },
+            "System": {
+                "Provider": {
+                    "#attributes": {
+                        "Name": "Microsoft-Windows-Security-Auditing",
+                        "Guid": "54849625-5478-4994-A5BA-3E3B0328C30D"
+                    }
+                },
+                "EventID": 4719,
+                "Version": 1,
+                "Level": 0,
+                "Task": 13568,
+                "Opcode": 0,
+                "Keywords": "0x8020000000000000",
+                "TimeCreated": {
+                    "#attributes": {
+                        "SystemTime": "2026-04-29T14:21:54.003528Z"
+                    }
+                },
+                "EventRecordID": 12339,
+                "Correlation": {
+                    "#attributes": {
+                        "ActivityID": "8C78F194-D7F3-0001-05F2-788CF3D7DC01"
+                    }
+                },
+                "Execution": {
+                    "#attributes": {
+                        "ProcessID": 716,
+                        "ThreadID": 828
+                    }
+                },
+                "Channel": "Security",
+                "Computer": "DESKTOP-O8964S4",
+                "Security": null
+            },
+            "EventData": {
+                "SubjectUserSid": "S-1-5-21-2716651203-721773598-1236239514-1001",
+                "SubjectUserName": "RaptorSniper",
+                "SubjectDomainName": "DESKTOP-O8964S4",
+                "SubjectLogonId": "0x2b53c",
+                "CategoryId": "%%8280",
+                "SubcategoryId": "%%14339",
+                "SubcategoryGuid": "0CCE9242-69AE-11D9-BED3-505054503030",
+                "AuditPolicyChanges": "%%8449, %%8451",
+                "ClientProcessId": 4280,
+                "ClientProcessStartKey": 16607023625928910
+            }
+        }
+    },
+    "evidence": "Security_6g.evtx"
+}

--- a/forensics/tests/test_data/windows/wmi.toml
+++ b/forensics/tests/test_data/windows/wmi.toml
@@ -2,7 +2,7 @@
 [output]
 name = "wmipersist_collection"
 directory = "./tmp"
-format = "json"
+format = "jsonl"
 compress = false
 timeline = false
 endpoint_id = "6c51b123-1522-4572-9f2a-0bd5abd81b82"

--- a/forensics/tests/wmipersist_tester.rs
+++ b/forensics/tests/wmipersist_tester.rs
@@ -41,8 +41,6 @@ fn test_wmipersist_parser() {
     }
 }
 
-
-
 #[cfg(target_os = "windows")]
 fn validate_output(output: &PathBuf) {
     // Output is in JSONL based on the TOML file above!

--- a/forensics/tests/wmipersist_tester.rs
+++ b/forensics/tests/wmipersist_tester.rs
@@ -67,6 +67,10 @@ fn check_errors(output: &PathBuf) {
     for (_, line) in reader.lines().enumerate() {
         let value = line.unwrap();
         println!("{value}");
+
+        if (!value.contains("ERROR")) {
+            continue;
+        }
         count += 1;
     }
 

--- a/forensics/tests/wmipersist_tester.rs
+++ b/forensics/tests/wmipersist_tester.rs
@@ -13,7 +13,7 @@ fn test_wmipersist_parser() {
     use std::fs::read;
 
     let mut test_location = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    test_location.push("tests/test_data/windows/amcache.toml");
+    test_location.push("tests/test_data/windows/wmi.toml");
 
     parse_toml_file(&test_location.display().to_string()).unwrap();
     let mut output_location = PathBuf::from(env!("CARGO_MANIFEST_DIR"));

--- a/forensics/tests/wmipersist_tester.rs
+++ b/forensics/tests/wmipersist_tester.rs
@@ -1,13 +1,78 @@
+use common::windows::WmiPersist;
+use std::path::PathBuf;
+use std::{
+    fs::File,
+    io::{BufRead, BufReader},
+};
+
 #[test]
 #[cfg(target_os = "windows")]
 fn test_wmipersist_parser() {
-    use std::path::PathBuf;
-
     use forensics::core::parse_toml_file;
+    use glob::glob;
+    use std::fs::read;
 
     let mut test_location = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    test_location.push("tests/test_data/windows/wmi.toml");
+    test_location.push("tests/test_data/windows/amcache.toml");
 
-    let results = parse_toml_file(&test_location.display().to_string()).unwrap();
-    assert_eq!(results, ())
+    parse_toml_file(&test_location.display().to_string()).unwrap();
+    let mut output_location = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    output_location.push("tmp/wmipersist_collection/*");
+
+    let results = glob(output_location.to_str().unwrap()).unwrap();
+    for result in results {
+        let value = &result.unwrap();
+        if value.to_str().unwrap().contains("report_") {
+            let bytes = read(value).unwrap();
+            let text = String::from_utf8(bytes).unwrap();
+            if text.contains("\"total_output_files\":0,") {
+                panic!("missing WMI Persist??");
+            }
+            continue;
+        }
+        let output_file = value.to_str().unwrap();
+
+        if output_file.contains("\\wmipersist_") && output_file.ends_with(".jsonl") {
+            validate_output(value);
+        }
+        if value.extension().unwrap() == "log" && !value.to_str().unwrap().contains("status_") {
+            check_errors(value);
+        }
+    }
+}
+
+
+
+#[cfg(target_os = "windows")]
+fn validate_output(output: &PathBuf) {
+    // Output is in JSONL based on the TOML file above!
+    let file = File::open(output).unwrap();
+    let reader = BufReader::new(file);
+    for (_, line) in reader.lines().enumerate() {
+        let value = line.unwrap();
+        println!("{value}");
+        let info: WmiPersist = serde_json::from_str(&value).unwrap();
+        if info.consumer.is_empty() {
+            println!("{:?}", info.consumer);
+            panic!("no names?")
+        }
+        assert!(!info.class.is_empty())
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn check_errors(output: &PathBuf) {
+    let file = File::open(output).unwrap();
+    let reader = BufReader::new(file);
+
+    let mut count = 0;
+    for (_, line) in reader.lines().enumerate() {
+        let value = line.unwrap();
+        println!("{value}");
+        count += 1;
+    }
+
+    if count != 0 {
+        panic!("error count: {count}");
+    }
 }

--- a/forensics/tests/wmipersist_tester.rs
+++ b/forensics/tests/wmipersist_tester.rs
@@ -68,7 +68,7 @@ fn check_errors(output: &PathBuf) {
         let value = line.unwrap();
         println!("{value}");
 
-        if (!value.contains("ERROR")) {
+        if !value.contains("ERROR") {
             continue;
         }
         count += 1;


### PR DESCRIPTION
Small update to eventlog parser when encountering evtx values with _multiple_ raw parameter IDs, ex: `%%1889, %%18890`.

Now artemis properly identifies them and replaces them with the appropriate string from the MessageTable