### PR TITLE
Artemis feature flags

### DIFF
--- a/.changes/unreleased/Added-20260516-000903.yaml
+++ b/.changes/unreleased/Added-20260516-000903.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Time filtering support when timelining cli artifacts
+time: 2026-05-16T00:09:03.734842819-04:00

--- a/.changes/unreleased/Changed-20260516-000921.yaml
+++ b/.changes/unreleased/Changed-20260516-000921.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: Additional feature flags when compiling artemis
+time: 2026-05-16T00:09:21.219935104-04:00

--- a/.justfile
+++ b/.justfile
@@ -121,9 +121,14 @@ end2end:
 cli:
   cd cli && cargo build --release
 
-# Just build the artemis binary. But do not enable Yara-X
+# Just build the artemis binary. But do not enable Yara-X or remote support
 [group('workspace')]
 slim:
+  cd cli && cargo build --release --no-default-features --features boa
+
+# Build artemis binary with all features disabled
+[group('workspace')]
+tiny:
   cd cli && cargo build --release --no-default-features
 
 # Just build the artemis binary and enable profiling

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2834,9 +2834,9 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "10.3.0"
+version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -2847,6 +2847,7 @@ dependencies = [
  "serde_json",
  "signature",
  "simple_asn1",
+ "zeroize",
 ]
 
 [[package]]
@@ -6613,6 +6614,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3627,18 +3627,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,5 +41,5 @@ reqwest = { version = "0.13.3", features = [
 sysinfo = "0.39.0"
 uuid = { version = "1.23.1", features = ["v4"] }
 rusqlite = { version = "0.39.0", features = ["bundled", "serde_json"] }
-fastrand = { version = "2.4.1", default-features = false }
+fastrand = { version = "2.4.1", default-features = false, features = ["std"] }
 chrono = "0.4.44"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,5 +15,6 @@ clap = { version = "4.6.1", features = ["std", "help", "derive"] }
 
 # Artemis features
 [features]
-default = ["yarax"]
+default = ["yarax", "cloud"]
 yarax = ["forensics/yarax"]
+cloud = ["forensics/gcp", "forensics/aws", "forensics/azure", "forensics/api"]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,6 +15,7 @@ clap = { version = "4.6.1", features = ["std", "help", "derive"] }
 
 # Artemis features
 [features]
-default = ["yarax", "cloud"]
+default = ["yarax", "cloud", "boa"]
 yarax = ["forensics/yarax"]
 cloud = ["forensics/gcp", "forensics/aws", "forensics/azure", "forensics/api"]
+boa = ["forensics/boa"]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -67,6 +67,7 @@ fn parse_args(args: &Args) {
             }
         }
     } else if let Some(js) = &args.javascript {
+        #[cfg(feature = "boa")]
         if !js.is_empty() {
             let collection_results = forensics::core::parse_js_file(js);
             match collection_results {

--- a/forensics/Cargo.toml
+++ b/forensics/Cargo.toml
@@ -64,13 +64,6 @@ snap = "1.1.1"
 ext4-fs = "0.1.5"
 calf = "0.2.1"
 
-# JS API
-boa_engine = { version = "0.21.1", default-features = false }
-boa_gc = { version = "0.21.1", default-features = false }
-boa_runtime = { version = "0.21.1", default-features = false }
-futures-concurrency = { version = "7.7.1", default-features = false }
-futures-lite = { version = "2.6.1", default-features = false }
-
 
 # Optional Stuff
 url = { version = "2.5.8", optional = true }
@@ -97,6 +90,12 @@ rusty-s3 = { version = "0.9.1", optional = true }
 # GCP Support
 jsonwebtoken = { version = "10.3.0", optional = true, features = ["aws_lc_rs"] }
 
+# JS API
+boa_engine = { version = "0.21.1", default-features = false, optional = true }
+boa_gc = { version = "0.21.1", default-features = false, optional = true }
+boa_runtime = { version = "0.21.1", default-features = false, optional = true }
+futures-concurrency = { version = "7.7.1", default-features = false, optional = true }
+futures-lite = { version = "2.6.1", default-features = false, optional = true }
 
 # Windows API Dependencies
 [target.'cfg(target_os = "windows")'.dependencies]
@@ -115,13 +114,20 @@ vergen = { version = "9.1.0", features = ["build", "rustc"] }
 
 # Artemis features
 [features]
-default = []
+default = ["yarax", "boa"]
 yarax = ["network", "dep:yara-x"]
 aws = ["network", "dep:rusty-s3"]
 gcp = ["network", "dep:jsonwebtoken"]
 azure = ["network"]
 api = ["network"]
 network = ["dep:reqwest", "dep:url"]
+boa = [
+    "dep:boa_engine",
+    "dep:boa_gc",
+    "dep:boa_runtime",
+    "dep:futures-concurrency",
+    "dep:futures-lite",
+]
 
 
 # Some benchmarking

--- a/forensics/Cargo.toml
+++ b/forensics/Cargo.toml
@@ -16,7 +16,7 @@ serde_json = { workspace = true }
 toml = { workspace = true }
 base64 = { workspace = true }
 flate2 = { workspace = true }
-reqwest = { workspace = true }
+reqwest = { workspace = true, optional = true }
 glob = { workspace = true }
 sysinfo = { workspace = true }
 uuid = { workspace = true }
@@ -37,8 +37,6 @@ walkdir = "2.5.0"
 home = "0.5.12"
 simplelog = "0.12.2"
 zip = { version = "8.6.0", default-features = false, features = ["deflate"] }
-jsonwebtoken = { version = "10.3.0", features = ["aws_lc_rs"] }
-rusty-s3 = "0.9.1"
 quick-xml = { version = "0.39.3", default-features = false, features = [
     "escape-html",
 ] }
@@ -56,6 +54,26 @@ macos-unifiedlogs = "0.6.0"
 plist = "1.9.0"
 aes = "0.9.0"
 cbc = "0.2.0"
+csv = "1.4.0"
+common = { path = "../common" }
+timeline = { path = "../timeline" }
+sunlight = "0.1.5"
+miniz_oxide = { version = "0.9.1", features = ["std", "with-alloc"] }
+lumination = "0.1.3"
+snap = "1.1.1"
+ext4-fs = "0.1.5"
+calf = "0.2.1"
+
+# JS API
+boa_engine = { version = "0.21.1", default-features = false }
+boa_gc = { version = "0.21.1", default-features = false }
+boa_runtime = { version = "0.21.1", default-features = false }
+futures-concurrency = { version = "7.7.1", default-features = false }
+futures-lite = { version = "2.6.1", default-features = false }
+
+
+# Optional Stuff
+url = { version = "2.5.8", optional = true }
 yara-x = { version = "1.16.0", optional = true, default-features = false, features = [
     "constant-folding",
     "exact-atoms",
@@ -72,23 +90,13 @@ yara-x = { version = "1.16.0", optional = true, default-features = false, featur
     "time-module",
     "linkme",
 ] }
-csv = "1.4.0"
-url = "2.5.8"
-common = { path = "../common" }
-timeline = { path = "../timeline" }
-sunlight = "0.1.5"
-miniz_oxide = { version = "0.9.1", features = ["std", "with-alloc"] }
-lumination = "0.1.3"
-snap = "1.1.1"
-ext4-fs = "0.1.5"
-calf = "0.2.1"
 
-# JS API
-boa_engine = { version = "0.21.1", default-features = false }
-boa_gc = { version = "0.21.1", default-features = false }
-boa_runtime = { version = "0.21.1", default-features = false }
-futures-concurrency = { version = "7.7.1", default-features = false }
-futures-lite = { version = "2.6.1", default-features = false }
+# AWS Support
+rusty-s3 = { version = "0.9.1", optional = true }
+
+# GCP Support
+jsonwebtoken = { version = "10.3.0", optional = true, features = ["aws_lc_rs"] }
+
 
 # Windows API Dependencies
 [target.'cfg(target_os = "windows")'.dependencies]
@@ -107,8 +115,13 @@ vergen = { version = "9.1.0", features = ["build", "rustc"] }
 
 # Artemis features
 [features]
-default = ["yarax"]
-yarax = ["dep:yara-x"]
+default = []
+yarax = ["network", "dep:yara-x"]
+aws = ["network", "dep:rusty-s3"]
+gcp = ["network", "dep:jsonwebtoken"]
+azure = ["network"]
+api = ["network"]
+network = ["dep:reqwest", "dep:url"]
 
 
 # Some benchmarking

--- a/forensics/examples/script_tester.rs
+++ b/forensics/examples/script_tester.rs
@@ -8,6 +8,7 @@ fn main() {
 
     if args.len() == 2 {
         let path = &args[1];
+        #[cfg(feature = "boa")]
         if Path::new(path).is_file() {
             let status = forensics::core::parse_js_file(path).expect("failed script execution");
             if status != Value::Null {

--- a/forensics/src/artifacts/collection.rs
+++ b/forensics/src/artifacts/collection.rs
@@ -22,7 +22,6 @@ use crate::{
     runtime::run::execute_script,
     structs::toml::ArtemisToml,
     utils::{
-        logging::upload_logs,
         marker::{skip_artifact, update_marker},
         output::compress_final_output,
         report::{generate_artifact_report, generate_report},
@@ -30,6 +29,9 @@ use crate::{
     },
 };
 use log::{error, info, warn};
+
+#[cfg(feature = "network")]
+use crate::utils::logging::upload_logs;
 
 /// Parse the TOML collector and get artifacts
 pub(crate) fn collect(collector: &mut ArtemisToml) -> Result<(), CollectionError> {
@@ -684,7 +686,7 @@ pub(crate) fn collect(collector: &mut ArtemisToml) -> Result<(), CollectionError
 
     if collector.output.output != "local" {
         let output_dir = format!("{}/{}", collector.output.directory, collector.output.name);
-
+        #[cfg(feature = "network")]
         let _ = upload_logs(&output_dir, &mut collector.output);
     } else if collector.output.compress && collector.output.output == "local" {
         let _ = compress_final_output(&collector.output);

--- a/forensics/src/artifacts/collection.rs
+++ b/forensics/src/artifacts/collection.rs
@@ -19,7 +19,6 @@ use super::{
     },
 };
 use crate::{
-    runtime::run::execute_script,
     structs::toml::ArtemisToml,
     utils::{
         marker::{skip_artifact, update_marker},
@@ -30,6 +29,8 @@ use crate::{
 };
 use log::{error, info, warn};
 
+#[cfg(feature = "boa")]
+use crate::runtime::run::execute_script;
 #[cfg(feature = "network")]
 use crate::utils::logging::upload_logs;
 
@@ -241,6 +242,7 @@ pub(crate) fn collect(collector: &mut ArtemisToml) -> Result<(), CollectionError
                     }
                 }
             }
+            #[cfg(feature = "boa")]
             "script" => {
                 let script_data = &artifacts.script;
                 let script = match script_data {

--- a/forensics/src/artifacts/os/files/filelisting.rs
+++ b/forensics/src/artifacts/os/files/filelisting.rs
@@ -20,7 +20,6 @@ use crate::filesystem::metadata::get_timestamps;
 use crate::structs::toml::Output;
 use crate::utils::regex_options::{create_regex, regex_check};
 use crate::utils::time::time_now;
-use crate::utils::yara::{extract_rule, scan_file};
 use common::files::FileInfo;
 use common::files::Hashes;
 use log::{error, info, warn};
@@ -29,6 +28,9 @@ use serde_json::Value;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Error as ioError};
 use walkdir::{DirEntry, WalkDir};
+
+#[cfg(feature = "yarax")]
+use crate::utils::yara::{extract_rule, scan_file};
 
 pub(crate) struct FileArgs {
     pub(crate) start_directory: String,
@@ -70,6 +72,7 @@ pub(crate) fn get_filelist(
     args.exclude_directories.append(&mut firmlink_paths);
 
     let mut rule = String::new();
+    #[cfg(feature = "yarax")]
     if !args.yara.is_empty() {
         rule = match extract_rule(&args.yara) {
             Ok(result) => result,
@@ -105,6 +108,7 @@ pub(crate) fn get_filelist(
         }
 
         let mut scan = Vec::new();
+        #[cfg(feature = "yarax")]
         if !rule.is_empty() {
             if !entry.file_type().is_file() {
                 continue;

--- a/forensics/src/artifacts/os/windows/outlook/parser.rs
+++ b/forensics/src/artifacts/os/windows/outlook/parser.rs
@@ -27,13 +27,15 @@ use crate::{
     utils::{
         environment::get_systemdrive,
         time::{compare_timestamps, time_now},
-        yara::{scan_base64_bytes, scan_bytes},
     },
 };
 use common::windows::{OutlookAttachment, OutlookMessage};
 use log::error;
 use ntfs::NtfsFile;
 use std::io::BufReader;
+
+#[cfg(feature = "yarax")]
+use crate::utils::yara::{scan_base64_bytes, scan_bytes};
 
 /// Parse and grab Outlook messages based on options provided
 pub(crate) fn grab_outlook(
@@ -377,6 +379,7 @@ fn message_details<T: std::io::Seek + std::io::Read>(
         yara_hits: Vec::new(),
     };
 
+    #[cfg(feature = "yarax")]
     // Check if message body matches Yara rule
     if let Some(rule) = &options.yara_rule_message {
         let result = scan_bytes(message_result.body.as_bytes(), rule).unwrap_or_default();
@@ -420,6 +423,7 @@ fn message_details<T: std::io::Seek + std::io::Read>(
                 properties: attach_info.props,
             };
 
+            #[cfg(feature = "yarax")]
             // Check if attachment matches Yara rule
             if let Some(rule) = &options.yara_rule_attachment {
                 let result = scan_base64_bytes(&message_attach.data, rule).unwrap_or_default();

--- a/forensics/src/artifacts/output.rs
+++ b/forensics/src/artifacts/output.rs
@@ -1,11 +1,13 @@
 use crate::{
     artifacts::error::CollectionError,
     output::formats::{csv::csv_format, json::json_format, jsonl::jsonl_format},
-    runtime::run::filter_script,
     structs::toml::Output,
 };
 use log::error;
 use serde_json::Value;
+
+#[cfg(feature = "boa")]
+use crate::runtime::run::filter_script;
 
 /// Output forensic artifacts
 pub(crate) fn output_artifact(
@@ -15,6 +17,7 @@ pub(crate) fn output_artifact(
     start_time: u64,
     filter: bool,
 ) -> Result<(), CollectionError> {
+    #[cfg(feature = "boa")]
     if filter && let Some(script) = &output.filter_script.clone() {
         let args = vec![serde_data.to_string(), output_name.to_string()];
         if let Some(name) = &output.filter_name.clone() {
@@ -27,6 +30,7 @@ pub(crate) fn output_artifact(
                 }
             };
         }
+
         let filter_result = filter_script(output, &args, "UnknownFilterName", script);
         return match filter_result {
             Ok(_) => Ok(()),

--- a/forensics/src/core.rs
+++ b/forensics/src/core.rs
@@ -9,10 +9,13 @@ use crate::{
 use log::{LevelFilter, error, info};
 use serde_json::Value;
 use simplelog::{Config, SimpleLogger, WriteLogger};
+
+#[cfg(feature = "network")]
 use url::Url;
 
 /// Parse a TOML file at provided path
 pub fn parse_toml_file(path: &str) -> Result<(), TomlError> {
+    #[cfg(feature = "network")]
     if let Ok(url) = Url::parse(path)
         && path.starts_with("http")
     {

--- a/forensics/src/core.rs
+++ b/forensics/src/core.rs
@@ -1,5 +1,4 @@
 use crate::artifacts::collection::collect;
-use crate::runtime::run::raw_script;
 use crate::{
     error::TomlError,
     filesystem::files::{read_file, read_text_file},
@@ -10,6 +9,8 @@ use log::{LevelFilter, error, info};
 use serde_json::Value;
 use simplelog::{Config, SimpleLogger, WriteLogger};
 
+#[cfg(feature = "boa")]
+use crate::runtime::run::raw_script;
 #[cfg(feature = "network")]
 use url::Url;
 
@@ -57,6 +58,7 @@ pub fn parse_toml_data(data: &[u8]) -> Result<(), TomlError> {
     artemis_collection(&mut collection)
 }
 
+#[cfg(feature = "boa")]
 /// Execute a JavaScript file at provided path
 pub fn parse_js_file(path: &str) -> Result<Value, TomlError> {
     let _ = SimpleLogger::init(LevelFilter::Warn, Config::default());
@@ -96,7 +98,7 @@ pub fn artemis_collection(collection: &mut ArtemisToml) -> Result<(), TomlError>
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_js_file, parse_toml_data, parse_toml_file};
+    use super::{parse_toml_data, parse_toml_file};
     use crate::{
         core::{ArtemisToml, artemis_collection},
         filesystem::files::read_file,
@@ -162,7 +164,10 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "boa")]
     fn test_parse_js_file() {
+        use crate::core::parse_js_file;
+
         let mut test_location = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_location.push("tests/test_data/deno_scripts/vanilla.js");
         parse_js_file(&test_location.display().to_string()).unwrap();

--- a/forensics/src/lib.rs
+++ b/forensics/src/lib.rs
@@ -75,6 +75,7 @@ pub mod core;
 mod error;
 mod filesystem;
 mod output;
+#[cfg(feature = "boa")]
 mod runtime;
 pub mod structs;
 mod utils;

--- a/forensics/src/output/remote/mod.rs
+++ b/forensics/src/output/remote/mod.rs
@@ -1,6 +1,10 @@
+#[cfg(feature = "api")]
 pub(crate) mod api;
+#[cfg(feature = "aws")]
 pub(crate) mod aws;
+#[cfg(feature = "azure")]
 pub(crate) mod azure;
 mod data;
 mod error;
+#[cfg(feature = "gcp")]
 pub(crate) mod gcp;

--- a/forensics/src/runtime/mod.rs
+++ b/forensics/src/runtime/mod.rs
@@ -6,6 +6,7 @@ mod environment;
 mod error;
 mod filesystem;
 mod helper;
+#[cfg(feature = "network")]
 mod http;
 mod linux;
 mod macos;

--- a/forensics/src/runtime/setup.rs
+++ b/forensics/src/runtime/setup.rs
@@ -2,10 +2,10 @@ use super::{
     application::extensions::application_functions, compression::extensions::decompress_functions,
     decryption::extensions::decrypt_functions, encoding::extensions::encoding_functions,
     environment::extensions::env_functions, error::RuntimeError,
-    filesystem::extensions::filesystem_functions, http::extensions::http_functions,
-    linux::extensions::linux_functions, macos::extensions::macos_functions,
-    nom::extensions::nom_functions, system::extensions::system_functions,
-    time::extensions::time_functions, windows::extensions::windows_functions,
+    filesystem::extensions::filesystem_functions, linux::extensions::linux_functions,
+    macos::extensions::macos_functions, nom::extensions::nom_functions,
+    system::extensions::system_functions, time::extensions::time_functions,
+    windows::extensions::windows_functions,
 };
 use boa_engine::{
     Context, JsError, JsResult, JsValue, Source,
@@ -21,6 +21,9 @@ use log::{error, warn};
 use serde_json::Value;
 use std::{cell::RefCell, collections::VecDeque, rc::Rc};
 use tokio::task;
+
+#[cfg(feature = "network")]
+use super::http::extensions::http_functions;
 
 /// Execute non-async scripts
 pub(crate) fn run_script(script: &str, args: &[String]) -> Result<Value, RuntimeError> {
@@ -237,6 +240,7 @@ fn setup_runtime(context: &mut Context) {
     application_functions(context);
     linux_functions(context);
     nom_functions(context);
+    #[cfg(feature = "network")]
     http_functions(context);
     env_functions(context);
     decompress_functions(context);

--- a/forensics/src/utils/artemis_toml.rs
+++ b/forensics/src/utils/artemis_toml.rs
@@ -1,9 +1,11 @@
 use super::error::ArtemisError;
 use crate::structs::toml::ArtemisToml;
 use log::error;
+#[cfg(feature = "network")]
 use reqwest::blocking::Client;
 
 impl ArtemisToml {
+    #[cfg(feature = "network")]
     /// Parse a remotely hosted TOML file
     pub(crate) fn remote_artemis_toml(url: &str) -> Result<ArtemisToml, ArtemisError> {
         let client = match Client::builder().build() {
@@ -69,6 +71,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "network")]
     fn test_mock_remote_toml() {
         let mut test_location = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_location.push("tests/test_data/macos.toml");
@@ -90,6 +93,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "network")]
     fn test_remote_toml_github() {
         let value = ArtemisToml::remote_artemis_toml("https://raw.githubusercontent.com/puffyCid/artemis/refs/heads/main/forensics/tests/test_data/linux.toml").unwrap();
         assert_eq!(value.output.name, "linux_collection");
@@ -97,12 +101,14 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "network")]
     #[should_panic(expected = "BadToml")]
     fn test_remote_bad_toml_github() {
         let _ = ArtemisToml::remote_artemis_toml("https://raw.githubusercontent.com/puffyCid/artemis/refs/heads/main/forensics/tests/test_data/fake.toml").unwrap();
     }
 
     #[test]
+    #[cfg(feature = "network")]
     #[should_panic(expected = "Remote")]
     fn test_remote_bad_toml_domain() {
         let _ = ArtemisToml::remote_artemis_toml("https://raw.google.com/puffyCid/artemis/refs/heads/main/forensics/tests/test_data/fake.toml").unwrap();

--- a/forensics/src/utils/error.rs
+++ b/forensics/src/utils/error.rs
@@ -8,12 +8,16 @@ pub enum ArtemisError {
     CreateDirectory,
     LogFile,
     Local,
+    #[cfg(feature = "network")]
     Remote,
     Cleanup,
     ReadXml,
     UtfType,
+    #[cfg(feature = "yarax")]
     Encoding,
+    #[cfg(feature = "yarax")]
     YaraRule,
+    #[cfg(feature = "yarax")]
     YaraScan,
     BadTime,
     Protobuf,
@@ -30,12 +34,16 @@ impl fmt::Display for ArtemisError {
             ArtemisError::CreateDirectory => write!(f, "Could not create directory(ies)"),
             ArtemisError::LogFile => write!(f, "Could not create log file"),
             ArtemisError::Local => write!(f, "Failed output data to local directory"),
+            #[cfg(feature = "network")]
             ArtemisError::Remote => write!(f, "Failed output data to remote URL"),
             ArtemisError::Cleanup => write!(f, "Failed to delete artemis output files"),
             ArtemisError::ReadXml => write!(f, "Failed to read XML"),
             ArtemisError::UtfType => write!(f, "Failed to determine UTF XML type"),
+            #[cfg(feature = "yarax")]
             ArtemisError::Encoding => write!(f, "Failed to parse decoding/encoding"),
+            #[cfg(feature = "yarax")]
             ArtemisError::YaraRule => write!(f, "Failed to add rule"),
+            #[cfg(feature = "yarax")]
             ArtemisError::YaraScan => write!(f, "Failed to scan file"),
             ArtemisError::BadTime => write!(f, "Failed to parse rfc 33339 timestamp"),
             ArtemisError::Protobuf => write!(f, "Failed to parse protobuf bytes"),

--- a/forensics/src/utils/logging.rs
+++ b/forensics/src/utils/logging.rs
@@ -2,7 +2,6 @@ use super::{error::ArtemisError, uuid::generate_uuid};
 use crate::{
     artifacts::os::systeminfo::info::hostname,
     filesystem::files::{get_filename, list_files, read_text_file},
-    output::remote::api::api_upload,
     structs::toml::Output,
     utils::output::final_output,
 };
@@ -12,6 +11,9 @@ use std::{
     fs::{File, OpenOptions, create_dir_all, remove_dir, remove_file},
     io::Write,
 };
+
+#[cfg(feature = "api")]
+use crate::output::remote::api::api_upload;
 
 /// Create log output file and logging level based on TOML `Output` configuration
 pub(crate) fn create_log_file(output: &mut Output) -> Result<(File, LevelFilter), ArtemisError> {
@@ -98,6 +100,7 @@ pub(crate) fn collection_status(output: &Output, output_name: &str) -> Result<()
     Ok(())
 }
 
+#[cfg(feature = "network")]
 /// Upload artemis logs
 pub(crate) fn upload_logs(output_dir: &str, output: &mut Output) -> Result<(), ArtemisError> {
     let files_res = list_files(output_dir);
@@ -124,6 +127,7 @@ pub(crate) fn upload_logs(output_dir: &str, output: &mut Output) -> Result<(), A
         };
         // Not very elegant. But for now serialize the string for uploading
         let mut serde_data = json!(log_data);
+        #[cfg(feature = "api")]
         // For API uploads on the last log file we mark the upload as complete
         if output.output.to_lowercase() == "api" && peek.peek().is_none() {
             if let Err(err) = api_upload(
@@ -138,6 +142,7 @@ pub(crate) fn upload_logs(output_dir: &str, output: &mut Output) -> Result<(), A
             let _ = remove_file(log);
             break;
         }
+
         final_output(&mut serde_data, output, &get_filename(log), 0, true)?;
         let _ = remove_file(log);
     }
@@ -157,7 +162,7 @@ pub(crate) fn upload_logs(output_dir: &str, output: &mut Output) -> Result<(), A
 
 #[cfg(test)]
 mod tests {
-    use super::{collection_status, create_log_file, upload_logs};
+    use super::{collection_status, create_log_file};
     use crate::structs::toml::Output;
     use httpmock::{
         Method::{POST, PUT},
@@ -200,7 +205,9 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "network")]
     fn test_upload_logs() {
+        use crate::utils::logging::upload_logs;
         let server = MockServer::start();
         let port = server.port();
 
@@ -250,7 +257,10 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "api")]
     fn test_api_upload_logs() {
+        use crate::utils::logging::upload_logs;
+
         let server = MockServer::start();
         let port = server.port();
 

--- a/forensics/src/utils/mod.rs
+++ b/forensics/src/utils/mod.rs
@@ -13,4 +13,5 @@ pub(crate) mod report;
 pub(crate) mod strings;
 pub(crate) mod time;
 pub(crate) mod uuid;
+#[cfg(feature = "yarax")]
 pub(crate) mod yara;

--- a/forensics/src/utils/output.rs
+++ b/forensics/src/utils/output.rs
@@ -1,17 +1,21 @@
 use super::error::ArtemisError;
 use crate::output::local::output::local_output;
-use crate::output::remote::api::api_upload;
 use crate::utils::compression::compress::compress_output_zip;
 use crate::utils::logging::collection_status;
 use crate::utils::uuid::generate_uuid;
-use crate::{
-    filesystem::files::list_files,
-    output::remote::{aws::aws_upload, azure::azure_upload, gcp::gcp_upload},
-    structs::toml::Output,
-};
+use crate::{filesystem::files::list_files, structs::toml::Output};
 use log::{error, warn};
 use serde_json::Value;
 use std::fs::{remove_dir, remove_file};
+
+#[cfg(feature = "api")]
+use crate::output::remote::api::api_upload;
+#[cfg(feature = "aws")]
+use crate::output::remote::aws::aws_upload;
+#[cfg(feature = "azure")]
+use crate::output::remote::azure::azure_upload;
+#[cfg(feature = "gcp")]
+use crate::output::remote::gcp::gcp_upload;
 
 /// Output artifact data based on output type
 pub(crate) fn final_output(
@@ -38,6 +42,7 @@ pub(crate) fn final_output(
                 return Err(ArtemisError::Local);
             }
         },
+        #[cfg(feature = "gcp")]
         "gcp" => match gcp_upload(data, output, &filename, start_time, artifact_name) {
             Ok(_) => {}
             Err(err) => {
@@ -45,6 +50,7 @@ pub(crate) fn final_output(
                 return Err(ArtemisError::Remote);
             }
         },
+        #[cfg(feature = "aws")]
         "aws" => match aws_upload(data, output, &filename, start_time, artifact_name) {
             Ok(_) => {}
             Err(err) => {
@@ -52,6 +58,7 @@ pub(crate) fn final_output(
                 return Err(ArtemisError::Remote);
             }
         },
+        #[cfg(feature = "azure")]
         "azure" => match azure_upload(data, output, &filename, start_time, artifact_name) {
             Ok(_) => {}
             Err(err) => {
@@ -59,6 +66,7 @@ pub(crate) fn final_output(
                 return Err(ArtemisError::Remote);
             }
         },
+        #[cfg(feature = "api")]
         "api" => match api_upload(data, output, &filename, start_time, artifact_name) {
             Ok(_) => {}
             Err(err) => {

--- a/forensics/src/utils/yara.rs
+++ b/forensics/src/utils/yara.rs
@@ -6,81 +6,59 @@ use yara_x::{Compiler, Scanner};
 
 /// Decode the provided Yara rule
 pub(crate) fn extract_rule(encoded_rule: &str) -> Result<String, ArtemisError> {
-    #[cfg(not(feature = "yarax"))]
-    {
-        return Ok(String::new());
-    }
-
-    #[cfg(feature = "yarax")]
-    {
-        let rule = if encoded_rule.starts_with("http") {
-            remote_yara(encoded_rule)?
-        } else {
-            rule_decode(encoded_rule)?
-        };
-        Ok(rule)
-    }
+    let rule = if encoded_rule.starts_with("http") {
+        remote_yara(encoded_rule)?
+    } else {
+        rule_decode(encoded_rule)?
+    };
+    Ok(rule)
 }
 
 /// Scan a file using Yara-X
 pub(crate) fn scan_file(path: &str, rule: &str) -> Result<Vec<String>, ArtemisError> {
-    #[cfg(not(feature = "yarax"))]
-    {
-        return Ok(Vec::new());
-    }
-    #[cfg(feature = "yarax")]
-    {
-        let compile = compile_rule(rule)?;
+    let compile = compile_rule(rule)?;
 
-        let rules = compile.build();
-        let mut scanner = Scanner::new(&rules);
-        let results = scanner.scan_file(path);
-        let hits = match results {
-            Ok(result) => result,
-            Err(err) => {
-                error!("[forensics] Failed to scan file {path}: {err:?}",);
-                return Err(ArtemisError::YaraScan);
-            }
-        };
-        let mut matches = Vec::new();
-        for hit in hits.matching_rules() {
-            matches.push(hit.identifier().to_string());
+    let rules = compile.build();
+    let mut scanner = Scanner::new(&rules);
+    let results = scanner.scan_file(path);
+    let hits = match results {
+        Ok(result) => result,
+        Err(err) => {
+            error!("[forensics] Failed to scan file {path}: {err:?}",);
+            return Err(ArtemisError::YaraScan);
         }
-        Ok(matches)
+    };
+    let mut matches = Vec::new();
+    for hit in hits.matching_rules() {
+        matches.push(hit.identifier().to_string());
     }
+    Ok(matches)
 }
 
 /// Scan bytes using Yara-X
 pub(crate) fn scan_bytes(data: &[u8], encoded_rule: &str) -> Result<Vec<String>, ArtemisError> {
-    #[cfg(not(feature = "yarax"))]
-    {
-        return Ok(Vec::new());
-    }
-    #[cfg(feature = "yarax")]
-    {
-        let rule = if encoded_rule.starts_with("http") {
-            remote_yara(encoded_rule)?
-        } else {
-            rule_decode(encoded_rule)?
-        };
-        let compile = compile_rule(&rule)?;
+    let rule = if encoded_rule.starts_with("http") {
+        remote_yara(encoded_rule)?
+    } else {
+        rule_decode(encoded_rule)?
+    };
+    let compile = compile_rule(&rule)?;
 
-        let rules = compile.build();
-        let mut scanner = Scanner::new(&rules);
-        let results = scanner.scan(data);
-        let hits = match results {
-            Ok(result) => result,
-            Err(err) => {
-                error!("[forensics] Failed to scan bytes: {err:?}",);
-                return Err(ArtemisError::YaraScan);
-            }
-        };
-        let mut matches = Vec::new();
-        for hit in hits.matching_rules() {
-            matches.push(hit.identifier().to_string());
+    let rules = compile.build();
+    let mut scanner = Scanner::new(&rules);
+    let results = scanner.scan(data);
+    let hits = match results {
+        Ok(result) => result,
+        Err(err) => {
+            error!("[forensics] Failed to scan bytes: {err:?}",);
+            return Err(ArtemisError::YaraScan);
         }
-        Ok(matches)
+    };
+    let mut matches = Vec::new();
+    for hit in hits.matching_rules() {
+        matches.push(hit.identifier().to_string());
     }
+    Ok(matches)
 }
 
 /// Scan base64 encoded bytes using Yara-X
@@ -145,7 +123,6 @@ fn rule_decode(rule: &str) -> Result<String, ArtemisError> {
     Ok(extract_utf8_string(&rule_bytes))
 }
 
-#[cfg(feature = "yarax")]
 /// Attempt to compile the Yara rule
 fn compile_rule(rule: &str) -> Result<Compiler<'_>, ArtemisError> {
     let mut compile = Compiler::new();


### PR DESCRIPTION
Enables several feature flags when compiling artemis. All are enabled by default right now

- networking
- boajs
- cloud uploads

When all are enabled, artemis has about ~670 dependencies and is ~47MB in size.  
When all features are disabled, artemis has about ~290 dependencies and is ~12MB in size

`just cli` compiles artemis with default features
`just slim` compiles artemis with yara-x disabled
`just tiny` compiles artemis with all features disabled

The largest dependencies are:

- yara-x
- reqwest
- boajs