### PR TITLE
Include artifact options in artifact run reports

### DIFF
--- a/forensics/src/output2/filter/js.rs
+++ b/forensics/src/output2/filter/js.rs
@@ -122,7 +122,7 @@ mod tests {
 
         let mut manager = OutputManager::new(config).unwrap();
         let err = manager
-            .write_artifact("test", String::from("test"), &mut records)
+            .write_artifact("test", &String::from("test"), &mut records)
             .unwrap_err();
 
         assert!(

--- a/forensics/src/output2/manager.rs
+++ b/forensics/src/output2/manager.rs
@@ -119,14 +119,15 @@ impl OutputManager {
         output_file: String,
         record_count: usize,
     ) {
+        let hash = hash_artifact_options(&artifact_options).unwrap_or_default();
         // Only track unique artifacts per Artemis collection
         // If a user collects a process listing twice in a single Artemis collection
         // We only `Processes` artifact once instead of twice
-        if let Some(run) = self.artifact_runs.iter_mut().find(|run| {
-            run.name == artifact_name
-                && run.artifact_options_hash
-                    == hash_artifact_options(&artifact_options).unwrap_or_default()
-        }) {
+        if let Some(run) = self
+            .artifact_runs
+            .iter_mut()
+            .find(|run| run.name == artifact_name && run.artifact_options_hash == hash)
+        {
             run.add_output_file(output_file, record_count);
             return;
         }
@@ -253,7 +254,7 @@ mod tests {
             )
             .unwrap();
 
-        manage.write_failed_artifact("made_up_artifact", String::from("test"));
+        manage.write_failed_artifact("made_up_artifact", &String::from("test"));
 
         manage.finalize().unwrap();
 
@@ -363,7 +364,7 @@ mod tests {
             )
             .unwrap();
 
-        manage.write_failed_artifact("madeup", String::from("nothing matters"));
+        manage.write_failed_artifact("madeup", &String::from("nothing matters"));
         manage.finalize().unwrap();
 
         // 3 uploads:

--- a/forensics/src/output2/manager.rs
+++ b/forensics/src/output2/manager.rs
@@ -4,13 +4,14 @@ use crate::output2::{
     encoder::{artifact_encoder::Encoder, factory::build_encoder},
     error::OutputResult,
     record::RecordStream,
-    report::{ArtifactRunReport, CollectionReport},
+    report::{ArtifactRunReport, CollectionReport, hash_artifact_options},
     sink::{
         factory::{Sink, build_sink},
         output_handle::OutputHandle,
     },
 };
 use log::LevelFilter;
+use serde::Serialize;
 use simplelog::{Config, WriteLogger};
 
 #[cfg(feature = "boa")]
@@ -59,10 +60,10 @@ impl OutputManager {
     }
 
     /// Write a forensic artifact result
-    pub(crate) fn write_artifact(
+    pub(crate) fn write_artifact<T: Serialize>(
         &mut self,
         artifact_name: &str,
-        artifact_options_hash: String,
+        artifact_options: &T,
         records: &mut dyn RecordStream,
     ) -> OutputResult<()> {
         let handle = self.write(artifact_name, records)?;
@@ -72,7 +73,7 @@ impl OutputManager {
         }
         self.record_completed_artifact_output(
             artifact_name,
-            artifact_options_hash,
+            artifact_options,
             handle.location_string(),
             handle.record_count,
         );
@@ -81,17 +82,17 @@ impl OutputManager {
     }
 
     /// Write a failed artifact run
-    pub(crate) fn write_failed_artifact(
+    pub(crate) fn write_failed_artifact<T: Serialize>(
         &mut self,
         artifact_name: &str,
-        artifact_options_hash: String,
+        artifact_options: &T,
     ) {
         if !self.artifacts.iter().any(|name| name == artifact_name) {
             self.artifacts.push(artifact_name.to_string());
         }
         self.artifact_runs.push(ArtifactRunReport::new(
             artifact_name,
-            artifact_options_hash,
+            artifact_options,
             Vec::new(),
             0,
             "failed",
@@ -111,10 +112,10 @@ impl OutputManager {
     }
 
     /// Track artifact collected from Artemis execution
-    fn record_completed_artifact_output(
+    fn record_completed_artifact_output<T: Serialize>(
         &mut self,
         artifact_name: &str,
-        artifact_options_hash: String,
+        artifact_options: &T,
         output_file: String,
         record_count: usize,
     ) {
@@ -122,7 +123,9 @@ impl OutputManager {
         // If a user collects a process listing twice in a single Artemis collection
         // We only `Processes` artifact once instead of twice
         if let Some(run) = self.artifact_runs.iter_mut().find(|run| {
-            run.name == artifact_name && run.artifact_options_hash == artifact_options_hash
+            run.name == artifact_name
+                && run.artifact_options_hash
+                    == hash_artifact_options(&artifact_options).unwrap_or_default()
         }) {
             run.add_output_file(output_file, record_count);
             return;
@@ -130,7 +133,7 @@ impl OutputManager {
         // Track each artifact run event
         self.artifact_runs.push(ArtifactRunReport::new(
             artifact_name,
-            artifact_options_hash,
+            artifact_options,
             vec![output_file],
             record_count,
             "completed",
@@ -243,7 +246,11 @@ mod tests {
         ]);
 
         manage
-            .write_artifact("files", String::from("md5"), &mut records)
+            .write_artifact(
+                "files",
+                &json!({"start_path": "./tmp", "depth": 99}),
+                &mut records,
+            )
             .unwrap();
 
         manage.write_failed_artifact("made_up_artifact", String::from("test"));
@@ -292,7 +299,10 @@ mod tests {
         assert_eq!(report["total_output_files"], 1);
         assert_eq!(report["artifacts"][0], "files");
         assert_eq!(report["artifact_runs"][0]["name"], "files");
-        assert_eq!(report["artifact_runs"][0]["artifact_options_hash"], "md5");
+        assert_eq!(
+            report["artifact_runs"][0]["artifact_options_hash"],
+            "2297a2e4d2902655a171ae9b818ce092"
+        );
         assert_eq!(report["artifact_runs"][0]["output_count"], 1);
         assert_eq!(report["artifact_runs"][0]["record_count"], 2);
         assert_eq!(report["artifact_runs"][0]["status"], "completed");
@@ -346,7 +356,11 @@ mod tests {
         });
 
         manage
-            .write_artifact("files", String::from("md5"), &mut records)
+            .write_artifact(
+                "files",
+                &json!({"start_path": "./tmp", "depth": 99}),
+                &mut records,
+            )
             .unwrap();
 
         manage.write_failed_artifact("madeup", String::from("nothing matters"));
@@ -381,10 +395,14 @@ mod tests {
         let mut records = VecRecordStream::new(vec![Record::Json(JsonRecord::new(first))]);
 
         manage
-            .write_artifact("processes", String::from("md5"), &mut records)
+            .write_artifact(
+                "processes",
+                &json!({"start_path": "./tmp", "depth": 99}),
+                &mut records,
+            )
             .unwrap();
 
-        manage.write_failed_artifact("made_up_artifact", String::from("test"));
+        manage.write_failed_artifact("made_up_artifact", &String::from("test"));
 
         manage.finalize().unwrap();
 
@@ -426,7 +444,10 @@ mod tests {
         assert_eq!(report["total_output_files"], 1);
         assert_eq!(report["artifacts"][0], "processes");
         assert_eq!(report["artifact_runs"][0]["name"], "processes");
-        assert_eq!(report["artifact_runs"][0]["artifact_options_hash"], "md5");
+        assert_eq!(
+            report["artifact_runs"][0]["artifact_options_hash"],
+            "2297a2e4d2902655a171ae9b818ce092"
+        );
         assert_eq!(report["artifact_runs"][0]["output_count"], 1);
         assert_eq!(report["artifact_runs"][0]["record_count"], 1);
         assert_eq!(report["artifact_runs"][0]["status"], "completed");
@@ -470,10 +491,14 @@ mod tests {
         });
 
         manage
-            .write_artifact("files", String::from("md5"), &mut records)
+            .write_artifact(
+                "files",
+                &json!({"start_path": "./tmp", "depth": 99}),
+                &mut records,
+            )
             .unwrap();
 
-        manage.write_failed_artifact("madeup", String::from("nothing matters"));
+        manage.write_failed_artifact("madeup", &String::from("nothing matters"));
         manage.finalize().unwrap();
 
         // 3 uploads:
@@ -519,10 +544,14 @@ mod tests {
         });
 
         manage
-            .write_artifact("files", String::from("md5"), &mut records)
+            .write_artifact(
+                "files",
+                &json!({"start_path": "./tmp", "depth": 99}),
+                &mut records,
+            )
             .unwrap();
 
-        manage.write_failed_artifact("madeup", String::from("nothing matters"));
+        manage.write_failed_artifact("madeup", &String::from("nothing matters"));
         manage.finalize().unwrap();
 
         // 3 uploads:
@@ -563,7 +592,11 @@ mod tests {
         ]);
 
         manage
-            .write_artifact("files", String::from("md5"), &mut records)
+            .write_artifact(
+                "files",
+                &json!({"start_path": "./tmp", "depth": 99}),
+                &mut records,
+            )
             .unwrap();
 
         manage.finalize().unwrap();
@@ -632,7 +665,11 @@ mod tests {
         ]);
 
         manage
-            .write_artifact("files", String::from("md5"), &mut records)
+            .write_artifact(
+                "files",
+                &json!({"start_path": "./tmp", "depth": 99}),
+                &mut records,
+            )
             .unwrap();
 
         manage.finalize().unwrap();

--- a/forensics/src/output2/report.rs
+++ b/forensics/src/output2/report.rs
@@ -163,7 +163,7 @@ mod tests {
 
     #[test]
     fn test_artifact_run_report() {
-        let result = ArtifactRunReport::new("test", String::new(), Vec::new(), 10, "compleed");
+        let result = ArtifactRunReport::new("test", &String::new(), Vec::new(), 10, "compleed");
         assert!(!result.last_run.is_empty());
         assert_eq!(result.output_count, 0);
     }

--- a/forensics/src/output2/report.rs
+++ b/forensics/src/output2/report.rs
@@ -10,6 +10,7 @@ use crate::{
 };
 use common::{files::Hashes, system::SystemInfo};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 /// Report metadata for a single artifact run
 ///
@@ -21,6 +22,7 @@ pub(crate) struct ArtifactRunReport {
     pub(crate) name: String,
     /// Hash of the artifact run options
     pub(crate) artifact_options_hash: String,
+    pub(crate) artifact_options: Value,
     /// Timestamp when the artifact run completed
     pub(crate) last_run: String,
     /// Unix epoch when the artifact run completed
@@ -37,18 +39,20 @@ pub(crate) struct ArtifactRunReport {
 
 impl ArtifactRunReport {
     /// Create a new artifact run report from execution runtime
-    pub(crate) fn new(
+    pub(crate) fn new<T: Serialize>(
         name: &str,
-        artifact_options_hash: String,
+        artifact_options: &T,
         output_files: Vec<String>,
         record_count: usize,
         status: &str,
     ) -> Self {
         let last_run_epoch = time_now();
         let output_count = output_files.len();
+        let options = serde_json::to_value(artifact_options).unwrap_or_default();
         Self {
             name: name.to_string(),
-            artifact_options_hash,
+            artifact_options_hash: hash_artifact_options(artifact_options).unwrap_or_default(),
+            artifact_options: options,
             last_run: unixepoch_to_iso(last_run_epoch as i64),
             last_run_epoch,
             output_count,

--- a/forensics/src/output2/sink/factory.rs
+++ b/forensics/src/output2/sink/factory.rs
@@ -151,7 +151,7 @@ mod tests {
             test.as_object().unwrap().clone(),
         ))]);
         manager
-            .write_artifact("test", String::from("test"), &mut records)
+            .write_artifact("test", &String::from("test"), &mut records)
             .unwrap();
     }
 
@@ -168,7 +168,7 @@ mod tests {
             test.as_object().unwrap().clone(),
         ))]);
         manager
-            .write_artifact("test", String::from("test"), &mut records)
+            .write_artifact("test", &String::from("test"), &mut records)
             .unwrap();
         error!("hello");
         manager.finalize().unwrap();


### PR DESCRIPTION
Added artifact options in the the run reports in the new output workflow.

Old artifact run report:  
```json
    {
      "name": "files",
      "artifact_options_hash": "2297a2e4d2902655a171ae9b818ce092",
      "last_run": "2026-05-25T01:28:09.000Z",
      "last_run_epoch": 1779672489,
      "output_count": 1,
      "record_count": 2,
      "output_files": [
        "./tmp/manager_collection/files_35b933cc-2404-4a54-b5df-e4807241aaf6.jsonl"
      ],
      "status": "completed"
    }
```

now:  
```json
    {
      "name": "files",
      "artifact_options_hash": "2297a2e4d2902655a171ae9b818ce092",
      "artifact_options": { "start_path": "./tmp", "depth": 99 },
      "last_run": "2026-05-25T01:28:09.000Z",
      "last_run_epoch": 1779672489,
      "output_count": 1,
      "record_count": 2,
      "output_files": [
        "./tmp/manager_collection/files_35b933cc-2404-4a54-b5df-e4807241aaf6.jsonl"
      ],
      "status": "completed"
    }
```

now artemis includes the actual options instead of just the hash