### PR TITLE
XML output support

### DIFF
--- a/.changes/unreleased/Added-20260609-002006.yaml
+++ b/.changes/unreleased/Added-20260609-002006.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: XML output support
+time: 2026-06-09T00:20:06.942188102-04:00

--- a/.changes/unreleased/Changed-20260609-001959.yaml
+++ b/.changes/unreleased/Changed-20260609-001959.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: Major overhaul to the artemis output workflow
+time: 2026-06-09T00:19:59.686241118-04:00

--- a/cli/src/collector/system.rs
+++ b/cli/src/collector/system.rs
@@ -30,7 +30,7 @@ pub(crate) enum Commands {
     Acquire {
         #[command(subcommand)]
         artifact: Option<CommandArgs>,
-        /// Output format. JSON, JSONL, CSV, or Timeline.
+        /// Output format. JSON, JSONL, CSV, XML, or Timeline.
         #[arg(long, default_value_t = String::from("JSONL"))]
         format: String,
         /// Optional output directory for storing results
@@ -97,6 +97,7 @@ fn format_choice(format: &str) -> OutputFormat {
         "json" => OutputFormat::Json,
         "csv" => OutputFormat::Csv,
         "timeline" => OutputFormat::Timeline,
+        "xml" => OutputFormat::Xml,
         _ => OutputFormat::Jsonl,
     }
 }

--- a/forensics/src/output/encoder/artifact_encoder.rs
+++ b/forensics/src/output/encoder/artifact_encoder.rs
@@ -2,7 +2,7 @@ use crate::output::{
     context::ArtifactContext,
     encoder::{
         csv::CsvEncoder, json::JsonEncoder, jsonl::JsonlEncoder, text::TextEncoder,
-        timeline::TimelineEncoder,
+        timeline::TimelineEncoder, xml::XmlEncoder,
     },
     error::OutputResult,
     record::RecordStream,
@@ -24,6 +24,8 @@ pub(crate) enum Encoder {
     Timeline(TimelineEncoder),
     /// Plaintext encoder
     Text(TextEncoder),
+    /// XML encoder
+    Xml(XmlEncoder),
 }
 
 impl Encoder {
@@ -35,6 +37,7 @@ impl Encoder {
             Self::Jsonl(encoder) => encoder.extension(),
             Self::Timeline(encoder) => encoder.extension(),
             Self::Text(encoder) => encoder.extension(),
+            Self::Xml(encoder) => encoder.extension(),
         }
     }
 
@@ -48,6 +51,7 @@ impl Encoder {
             Self::Jsonl(encoder) => encoder.mime_type(),
             Self::Timeline(encoder) => encoder.mime_type(),
             Self::Text(encoder) => encoder.mime_type(),
+            Self::Xml(encoder) => encoder.mime_type(),
         }
     }
 
@@ -66,6 +70,7 @@ impl Encoder {
             Self::Jsonl(encoder) => encoder.encode(records, writer, context),
             Self::Timeline(encoder) => encoder.encode(records, writer, context),
             Self::Text(encoder) => encoder.encode(records, writer, context),
+            Self::Xml(encoder) => encoder.encode(records, writer, context),
         }
     }
 }

--- a/forensics/src/output/encoder/factory.rs
+++ b/forensics/src/output/encoder/factory.rs
@@ -1,7 +1,7 @@
 use crate::{
     output::encoder::{
         artifact_encoder::Encoder, csv::CsvEncoder, json::JsonEncoder, jsonl::JsonlEncoder,
-        text::TextEncoder, timeline::TimelineEncoder,
+        text::TextEncoder, timeline::TimelineEncoder, xml::XmlEncoder,
     },
     structs::toml::{OutputConfig, OutputFormat},
 };
@@ -14,6 +14,7 @@ pub(crate) fn build_encoder(config: &OutputConfig) -> Encoder {
         OutputFormat::Csv => Encoder::Csv(CsvEncoder),
         OutputFormat::Timeline => Encoder::Timeline(TimelineEncoder),
         OutputFormat::Text => Encoder::Text(TextEncoder),
+        OutputFormat::Xml => Encoder::Xml(XmlEncoder),
     }
 }
 

--- a/forensics/src/output/encoder/mod.rs
+++ b/forensics/src/output/encoder/mod.rs
@@ -6,3 +6,4 @@ mod jsonl;
 mod metadata;
 mod text;
 mod timeline;
+mod xml;

--- a/forensics/src/output/encoder/xml.rs
+++ b/forensics/src/output/encoder/xml.rs
@@ -1,0 +1,272 @@
+use crate::output::{
+    context::ArtifactContext,
+    encoder::{artifact_encoder::ArtifactEncoder, metadata::append_metadata},
+    error::OutputResult,
+    record::RecordStream,
+};
+use quick_xml::{
+    Writer,
+    events::{BytesDecl, BytesEnd, BytesStart, BytesText, Event},
+};
+use serde_json::{Map, Value};
+use std::io::Write;
+
+/// Encoder for XML files
+#[derive(Debug, PartialEq)]
+pub(crate) struct XmlEncoder;
+
+impl ArtifactEncoder for XmlEncoder {
+    fn extension(&self) -> &str {
+        "xml"
+    }
+
+    fn mime_type(&self) -> &str {
+        "application/xml"
+    }
+
+    fn encode(
+        &self,
+        records: &mut dyn RecordStream,
+        writer: &mut dyn Write,
+        context: &ArtifactContext,
+    ) -> OutputResult<usize> {
+        let mut count = 0;
+        let mut xml_writer = Writer::new(writer);
+
+        xml_writer.write_event(Event::Decl(BytesDecl::new("1.0", Some("UTF-8"), None)))?;
+        start_element(&mut xml_writer, "records")?;
+        while let Some(record) = records.next_record()? {
+            let mut value = record.into_value()?;
+            append_metadata(&mut value, context);
+            write_value(&mut xml_writer, "record", &value)?;
+            count += 1;
+        }
+
+        end_element(&mut xml_writer, "records")?;
+
+        Ok(count)
+    }
+}
+
+/// Write the starting XML element
+fn start_element<W: Write>(writer: &mut Writer<W>, name: &str) -> OutputResult<()> {
+    Ok(writer.write_event(Event::Start(BytesStart::new(name)))?)
+}
+
+/// Write the ending XML element
+fn end_element<W: Write>(writer: &mut Writer<W>, name: &str) -> OutputResult<()> {
+    Ok(writer.write_event(Event::End(BytesEnd::new(name)))?)
+}
+
+/// Write the XML element value
+fn write_value<W: Write>(writer: &mut Writer<W>, name: &str, value: &Value) -> OutputResult<()> {
+    let name = sanitize_element_name(name);
+    match value {
+        Value::Object(fields) => write_object(writer, &name, fields),
+        Value::Array(values) => write_array(writer, &name, values),
+        Value::String(value) => write_text_element(writer, &name, value),
+        Value::Number(value) => write_text_element(writer, &name, &value.to_string()),
+        Value::Bool(value) => write_text_element(writer, &name, &value.to_string()),
+        Value::Null => write_empty_element(writer, &name),
+    }
+}
+
+/// Ensure element name meets XML requirements
+fn sanitize_element_name(name: &str) -> String {
+    let mut element_name = String::new();
+    for (index, character) in name.chars().enumerate() {
+        if index == 0 && !is_xml_name_start(character) {
+            element_name.push('_');
+        }
+        if is_xml_name_char(character) {
+            element_name.push(character);
+            continue;
+        }
+
+        element_name.push('_');
+    }
+
+    if element_name.is_empty() {
+        element_name = String::from("field");
+    }
+
+    // Element names cannot start with "XML"
+    if element_name.to_ascii_lowercase().starts_with("xml") {
+        element_name.insert(0, '_');
+    }
+
+    element_name
+}
+
+/// Ensure XML name starts with approved starting character
+fn is_xml_name_start(ch: char) -> bool {
+    ch == '_' || ch.is_ascii_alphabetic()
+}
+
+/// Ensure element character is valid for XML
+fn is_xml_name_char(ch: char) -> bool {
+    is_xml_name_start(ch) || ch.is_ascii_digit() || ch == '-' || ch == '.'
+}
+
+/// Write objects to XML
+fn write_object<W: Write>(
+    writer: &mut Writer<W>,
+    name: &str,
+    fields: &Map<String, Value>,
+) -> OutputResult<()> {
+    start_element(writer, name)?;
+    for (key, value) in fields {
+        write_value(writer, key, value)?;
+    }
+
+    end_element(writer, name)?;
+
+    Ok(())
+}
+
+/// Write array to XML
+fn write_array<W: Write>(writer: &mut Writer<W>, name: &str, values: &[Value]) -> OutputResult<()> {
+    start_element(writer, name)?;
+
+    for value in values {
+        write_value(writer, name, value)?;
+    }
+
+    end_element(writer, name)?;
+
+    Ok(())
+}
+
+/// Write text values to XML
+fn write_text_element<W: Write>(
+    writer: &mut Writer<W>,
+    name: &str,
+    value: &str,
+) -> OutputResult<()> {
+    start_element(writer, name)?;
+
+    writer.write_event(Event::Text(BytesText::new(value)))?;
+    end_element(writer, name)?;
+
+    Ok(())
+}
+
+/// Write empty XML value
+fn write_empty_element<W: Write>(writer: &mut Writer<W>, name: &str) -> OutputResult<()> {
+    Ok(writer.write_event(Event::Empty(BytesStart::new(name)))?)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{io::Cursor, path::PathBuf};
+
+    use serde_json::json;
+
+    use crate::{
+        output::{
+            context::CollectionContext,
+            encoder::{artifact_encoder::ArtifactEncoder, xml::XmlEncoder},
+            record::{JsonRecord, Record, SingleRecordStream},
+        },
+        structs::toml::OutputConfig,
+    };
+
+    #[test]
+    fn test_xml_encoder() {
+        let output = OutputConfig::default();
+
+        let context = CollectionContext::new(&output, PathBuf::from("./tmp")).artifact(
+            "files",
+            &output.start_time_filter,
+            &output.end_time_filter,
+        );
+        let test = json!({
+            "path": "/tmp/one.txt",
+            "size": 1234,
+            "is_file": true,
+            "tags": ["one", "maybe"],
+            "nested": {
+                "key": "rust"
+            }
+        });
+
+        let mut writer = Cursor::new(Vec::new());
+        let count = XmlEncoder
+            .encode(
+                &mut SingleRecordStream::new(Record::Json(JsonRecord::new(
+                    test.as_object().unwrap().clone(),
+                ))),
+                &mut writer,
+                &context,
+            )
+            .unwrap();
+
+        let xml = String::from_utf8(writer.into_inner()).unwrap();
+        assert_eq!(count, 1);
+        assert!(xml.starts_with(r#"<?xml version="1.0" encoding="UTF-8"?>"#));
+        assert!(xml.contains("<records>"));
+        assert!(xml.contains("<record>"));
+        assert!(xml.contains("<path>/tmp/one.txt</path>"));
+        assert!(xml.contains("<size>1234</size>"));
+        assert!(xml.contains("<is_file>true</is_file>"));
+        assert!(xml.contains("<tags><tags>one</tags><tags>maybe</tags></tags>"));
+        assert!(xml.contains("<nested><key>rust</key></nested>"));
+        assert!(xml.contains("<collection_metadata>"));
+        assert!(xml.contains("<artifact_name>files</artifact_name>"));
+        assert!(xml.ends_with("</records>"));
+    }
+
+    #[test]
+    fn test_xml_encoder_escape_text() {
+        let output = OutputConfig::default();
+        let context = CollectionContext::new(&output, PathBuf::from("./tmp")).artifact(
+            "files",
+            &output.start_time_filter,
+            &output.end_time_filter,
+        );
+        let value = json!({
+            "path": "/tmp/a&b<c>.txt"
+        });
+        let mut writer = Cursor::new(Vec::new());
+        XmlEncoder
+            .encode(
+                &mut SingleRecordStream::new(Record::Json(JsonRecord::new(
+                    value.as_object().unwrap().clone(),
+                ))),
+                &mut writer,
+                &context,
+            )
+            .unwrap();
+        let xml = String::from_utf8(writer.into_inner()).unwrap();
+        assert!(xml.contains("<path>/tmp/a&amp;b&lt;c&gt;.txt</path>"));
+    }
+
+    #[test]
+    fn test_xml_encoder_sanitizes_field_names() {
+        let output = OutputConfig::default();
+        let context = CollectionContext::new(&output, PathBuf::from("./tmp")).artifact(
+            "runtime",
+            &output.start_time_filter,
+            &output.end_time_filter,
+        );
+        let value = json!({
+            "123field": "starts with number",
+            "field name": "contains space",
+            "field/name": "contains slash"
+        });
+        let mut writer = Cursor::new(Vec::new());
+        XmlEncoder
+            .encode(
+                &mut SingleRecordStream::new(Record::Json(JsonRecord::new(
+                    value.as_object().unwrap().clone(),
+                ))),
+                &mut writer,
+                &context,
+            )
+            .unwrap();
+        let xml = String::from_utf8(writer.into_inner()).unwrap();
+        assert!(xml.contains("<_123field>starts with number</_123field>"));
+        assert!(xml.contains("<field_name>contains space</field_name>"));
+        assert!(xml.contains("<field_name>contains slash</field_name>"));
+    }
+}

--- a/forensics/src/output/encoder/xml.rs
+++ b/forensics/src/output/encoder/xml.rs
@@ -11,7 +11,7 @@ use quick_xml::{
 use serde_json::{Map, Value};
 use std::io::Write;
 
-/// Encoder for XML files
+/// Encodes artifact records as a single XML document with a records root element
 #[derive(Debug, PartialEq)]
 pub(crate) struct XmlEncoder;
 
@@ -58,7 +58,7 @@ fn end_element<W: Write>(writer: &mut Writer<W>, name: &str) -> OutputResult<()>
     Ok(writer.write_event(Event::End(BytesEnd::new(name)))?)
 }
 
-/// Write the XML element value
+/// Write a JSON value to its XML representation
 fn write_value<W: Write>(writer: &mut Writer<W>, name: &str, value: &Value) -> OutputResult<()> {
     let name = sanitize_element_name(name);
     match value {
@@ -71,7 +71,7 @@ fn write_value<W: Write>(writer: &mut Writer<W>, name: &str, value: &Value) -> O
     }
 }
 
-/// Ensure element name meets XML requirements
+/// Convert an arbitrary JSON key into a proper XML element name
 fn sanitize_element_name(name: &str) -> String {
     let mut element_name = String::new();
     for (index, character) in name.chars().enumerate() {
@@ -90,7 +90,7 @@ fn sanitize_element_name(name: &str) -> String {
         element_name = String::from("field");
     }
 
-    // Element names cannot start with "XML"
+    // Names beginning with "xml", in any case combination, are reserved by XML specification
     if element_name.to_ascii_lowercase().starts_with("xml") {
         element_name.insert(0, '_');
     }
@@ -98,17 +98,17 @@ fn sanitize_element_name(name: &str) -> String {
     element_name
 }
 
-/// Ensure XML name starts with approved starting character
+/// Return whether a character is allowed as the first character in this encoder's XML names
 fn is_xml_name_start(ch: char) -> bool {
     ch == '_' || ch.is_ascii_alphabetic()
 }
 
-/// Ensure element character is valid for XML
+/// Return whether a character is allowed after the first character in this encoder's XML names
 fn is_xml_name_char(ch: char) -> bool {
     is_xml_name_start(ch) || ch.is_ascii_digit() || ch == '-' || ch == '.'
 }
 
-/// Write objects to XML
+/// Write a JSON object as an XML element with one child element per field
 fn write_object<W: Write>(
     writer: &mut Writer<W>,
     name: &str,
@@ -124,12 +124,12 @@ fn write_object<W: Write>(
     Ok(())
 }
 
-/// Write array to XML
+/// Write a JSON array as repeated child elements using the array field name
 fn write_array<W: Write>(writer: &mut Writer<W>, name: &str, values: &[Value]) -> OutputResult<()> {
     start_element(writer, name)?;
 
     for value in values {
-        write_value(writer, name, value)?;
+        write_value(writer, "item", value)?;
     }
 
     end_element(writer, name)?;
@@ -137,7 +137,7 @@ fn write_array<W: Write>(writer: &mut Writer<W>, name: &str, values: &[Value]) -
     Ok(())
 }
 
-/// Write text values to XML
+/// Write a scalar JSON value as escaped XML text content
 fn write_text_element<W: Write>(
     writer: &mut Writer<W>,
     name: &str,
@@ -151,17 +151,13 @@ fn write_text_element<W: Write>(
     Ok(())
 }
 
-/// Write empty XML value
+/// Write JSON null as an empty XML element
 fn write_empty_element<W: Write>(writer: &mut Writer<W>, name: &str) -> OutputResult<()> {
     Ok(writer.write_event(Event::Empty(BytesStart::new(name)))?)
 }
 
 #[cfg(test)]
 mod tests {
-    use std::{io::Cursor, path::PathBuf};
-
-    use serde_json::json;
-
     use crate::{
         output::{
             context::CollectionContext,
@@ -170,6 +166,8 @@ mod tests {
         },
         structs::toml::OutputConfig,
     };
+    use serde_json::json;
+    use std::{io::Cursor, path::PathBuf};
 
     #[test]
     fn test_xml_encoder() {
@@ -209,7 +207,7 @@ mod tests {
         assert!(xml.contains("<path>/tmp/one.txt</path>"));
         assert!(xml.contains("<size>1234</size>"));
         assert!(xml.contains("<is_file>true</is_file>"));
-        assert!(xml.contains("<tags><tags>one</tags><tags>maybe</tags></tags>"));
+        assert!(xml.contains("<tags><item>one</item><item>maybe</item></tags>"));
         assert!(xml.contains("<nested><key>rust</key></nested>"));
         assert!(xml.contains("<collection_metadata>"));
         assert!(xml.contains("<artifact_name>files</artifact_name>"));

--- a/forensics/src/output/manager.rs
+++ b/forensics/src/output/manager.rs
@@ -763,4 +763,65 @@ mod tests {
         assert_eq!(report["artifact_runs"][0]["record_count"], 5);
         assert_eq!(report["artifact_runs"][0]["status"], "completed");
     }
+
+    #[test]
+    fn test_output_manager_xml() {
+        let name = String::from("manager_collection");
+        let config = OutputConfig {
+            name,
+            endpoint_id: String::from("test"),
+            collection_id: 0,
+            directory: PathBuf::from("./tmp"),
+            destination: OutputDestination::Local,
+            format: OutputFormat::Xml,
+            ..Default::default()
+        };
+
+        let mut manage = OutputManager::new(config).unwrap();
+        let mut first = Map::new();
+        first.insert("path".to_string(), "/tmp/one.txt".into());
+        first.insert("size".to_string(), 1235.into());
+        let mut second = Map::new();
+        second.insert("path".to_string(), "/tmp/two.txt".into());
+        second.insert("size".to_string(), 5.into());
+        let mut records = VecRecordStream::new(vec![
+            Record::Json(JsonRecord::new(first)),
+            Record::Json(JsonRecord::new(second)),
+        ]);
+
+        manage
+            .write_artifact(
+                "files",
+                &json!({"start_path": "./tmp", "depth": 99}),
+                &mut records,
+            )
+            .unwrap();
+
+        manage.write_failed_artifact("made_up_artifact", &String::from("test"));
+
+        manage.finalize().unwrap();
+
+        let output_dir = PathBuf::from("./tmp").join(String::from("manager_collection"));
+        assert!(output_dir.exists());
+
+        let mut xml_files = Vec::new();
+        let mut report_files = Vec::new();
+        let mut log_files = Vec::new();
+        for entry in read_dir(&output_dir).unwrap() {
+            let path = entry.unwrap().path();
+            let name = path.file_name().unwrap().to_string_lossy();
+            if name.starts_with("files_") && name.ends_with(".xml") {
+                xml_files.push(path);
+            } else if name.starts_with("report_") && name.ends_with(".json") {
+                report_files.push(path);
+            } else if name.starts_with("artemis_") && name.ends_with(".log") {
+                log_files.push(path);
+            }
+        }
+        assert!(!xml_files.is_empty());
+        assert!(!report_files.is_empty());
+        assert!(!log_files.is_empty());
+        let xml_data = read_to_string(&xml_files[0]).unwrap();
+        assert!(xml_data.contains("<path>/tmp/one.txt</path>"));
+    }
 }

--- a/forensics/src/output/sink/local.rs
+++ b/forensics/src/output/sink/local.rs
@@ -83,6 +83,7 @@ impl LocalSink {
                 && !entry.ends_with(".csv")
                 && !entry.ends_with(".jsonl")
                 && !entry.ends_with(".zip")
+                && !entry.ends_with(".xml")
             {
                 continue;
             }

--- a/forensics/src/structs/toml.rs
+++ b/forensics/src/structs/toml.rs
@@ -74,6 +74,7 @@ pub enum OutputFormat {
     Timeline,
     /// Plaintext output for `BoaJS` runtime data
     Text,
+    Xml,
 }
 
 /// Determine where our data should be sent


### PR DESCRIPTION
Added support for encoding output into XML.

This was mostly practice to before attempting to support #420.

The new output workflow should make it easier to support different output formats like xml, sqlite, or parquet.