### PR TITLE
Parquet support

### DIFF
--- a/.changes/unreleased/Added-20260614-233720.yaml
+++ b/.changes/unreleased/Added-20260614-233720.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Parquet output support
+time: 2026-06-14T23:37:20.9837036-04:00

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "const-random",
  "getrandom 0.3.4",
  "once_cell",
  "version_check",
@@ -893,6 +894,26 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
 
 [[package]]
 name = "convert_case"
@@ -1933,6 +1954,7 @@ dependencies = [
  "nom 8.0.0",
  "ntapi",
  "ntfs",
+ "parquet",
  "pelite",
  "plist",
  "quick-xml 0.40.1",
@@ -2246,6 +2268,7 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "num-traits",
  "zerocopy",
 ]
 
@@ -3549,6 +3572,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "parquet"
+version = "59.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "970dff83e97d953c827ae8176f6bf4e9f77bf62daacc01ec5df348ec5eacd913"
+dependencies = [
+ "ahash",
+ "base64",
+ "bytes",
+ "chrono",
+ "half",
+ "hashbrown 0.17.1",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "paste",
+ "seq-macro",
+ "serde_json",
+ "simdutf8",
+ "snap",
+ "twox-hash",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4615,6 +4661,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5226,6 +5278,15 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]

--- a/cli/src/collector/system.rs
+++ b/cli/src/collector/system.rs
@@ -30,7 +30,7 @@ pub(crate) enum Commands {
     Acquire {
         #[command(subcommand)]
         artifact: Option<CommandArgs>,
-        /// Output format. JSON, JSONL, CSV, XML, or Timeline.
+        /// Output format. JSON, JSONL, CSV, XML, Parquet, or Timeline.
         #[arg(long, default_value_t = String::from("JSONL"))]
         format: String,
         /// Optional output directory for storing results

--- a/cli/src/collector/system.rs
+++ b/cli/src/collector/system.rs
@@ -98,6 +98,7 @@ fn format_choice(format: &str) -> OutputFormat {
         "csv" => OutputFormat::Csv,
         "timeline" => OutputFormat::Timeline,
         "xml" => OutputFormat::Xml,
+        "parquet" => OutputFormat::Parquet,
         _ => OutputFormat::Jsonl,
     }
 }

--- a/forensics/Cargo.toml
+++ b/forensics/Cargo.toml
@@ -96,6 +96,12 @@ boa_runtime = { version = "0.21.1", default-features = false, optional = true }
 futures-concurrency = { version = "7.7.1", default-features = false, optional = true }
 futures-lite = { version = "2.6.1", default-features = false, optional = true }
 
+parquet = { version = "59.0.0", default-features = false, features = [
+    "json",
+    "snap",
+    "simdutf8",
+] }
+
 # Windows API Dependencies
 [target.'cfg(target_os = "windows")'.dependencies]
 ntapi = "0.4.3"

--- a/forensics/build.rs
+++ b/forensics/build.rs
@@ -32,7 +32,7 @@ fn main() {
     // Cargo sets an env var for every enabled feature (e.g., CARGO_FEATURE_MY_FEATURE)
     for (key, _) in std::env::vars() {
         if let Some(feature) = key.strip_prefix("CARGO_FEATURE_") {
-            if feature.to_ascii_lowercase() == "default" {
+            if feature.eq_ignore_ascii_case("default") {
                 continue;
             }
             features.push(feature.to_ascii_lowercase());

--- a/forensics/src/output/encoder/artifact_encoder.rs
+++ b/forensics/src/output/encoder/artifact_encoder.rs
@@ -19,11 +19,11 @@ use std::{io::Write, path::PathBuf};
 pub(crate) enum EncoderMode {
     /// Artifact records are written in chunks. Each artifact records is written to a separate file
     ///
-    /// For example, EventLogs are written in chunks to multiple JSONL files
+    /// For example, `EventLogs` are written in chunks to multiple JSONL files
     Chunked,
     /// Artifact records are streamed into a single file
     ///
-    /// For example, EventLogs are streamed into a single Parquet file
+    /// For example, `EventLogs` are streamed into a single Parquet file
     Streamed,
 }
 

--- a/forensics/src/output/encoder/artifact_encoder.rs
+++ b/forensics/src/output/encoder/artifact_encoder.rs
@@ -1,13 +1,67 @@
 use crate::output::{
     context::ArtifactContext,
     encoder::{
-        csv::CsvEncoder, json::JsonEncoder, jsonl::JsonlEncoder, text::TextEncoder,
-        timeline::TimelineEncoder, xml::XmlEncoder,
+        csv::CsvEncoder,
+        json::JsonEncoder,
+        jsonl::JsonlEncoder,
+        parquet::{ParquetEncoder, ParquetWriter},
+        text::TextEncoder,
+        timeline::TimelineEncoder,
+        xml::XmlEncoder,
     },
-    error::OutputResult,
+    error::{OutputError, OutputResult},
     record::RecordStream,
 };
-use std::io::Write;
+use std::{io::Write, path::PathBuf};
+
+/// Describes how the encoder will write artifact records
+#[derive(Debug, PartialEq)]
+pub(crate) enum EncoderMode {
+    /// Artifact records are written in chunks. Each artifact records is written to a separate file
+    /// For example, EventLogs are written in chunks to multiple JSONL files
+    Chunked,
+    /// Artifact records are streamed into a single file
+    /// For example, EventLogs are streamed into a single Parquet file
+    Streamed,
+}
+
+#[derive(Debug)]
+pub(crate) struct StreamTarget {
+    pub(crate) path: PathBuf,
+}
+
+impl StreamTarget {
+    pub(crate) fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+}
+
+pub(crate) enum StreamWriter {
+    Parquet(ParquetWriter),
+}
+
+pub(crate) struct EncoderStreamWriter {
+    pub(crate) writer: StreamWriter,
+    pub(crate) record_count: usize,
+}
+
+impl StreamWriter {
+    pub(crate) fn write_records(
+        &mut self,
+        records: &mut dyn RecordStream,
+        context: &ArtifactContext,
+    ) -> OutputResult<usize> {
+        match self {
+            Self::Parquet(writer) => writer.write_records(records, context),
+        }
+    }
+
+    pub(crate) fn finish(self) -> OutputResult<()> {
+        match self {
+            Self::Parquet(writer) => writer.finish(),
+        }
+    }
+}
 
 /// A `Record` may be encoded into different formats
 ///
@@ -26,6 +80,8 @@ pub(crate) enum Encoder {
     Text(TextEncoder),
     /// XML encoder
     Xml(XmlEncoder),
+    /// Parquet encoder
+    Parquet(ParquetEncoder),
 }
 
 impl Encoder {
@@ -38,6 +94,7 @@ impl Encoder {
             Self::Timeline(encoder) => encoder.extension(),
             Self::Text(encoder) => encoder.extension(),
             Self::Xml(encoder) => encoder.extension(),
+            Self::Parquet(encoder) => encoder.extension(),
         }
     }
 
@@ -52,6 +109,7 @@ impl Encoder {
             Self::Timeline(encoder) => encoder.mime_type(),
             Self::Text(encoder) => encoder.mime_type(),
             Self::Xml(encoder) => encoder.mime_type(),
+            Self::Parquet(encoder) => encoder.mime_type(),
         }
     }
 
@@ -71,11 +129,41 @@ impl Encoder {
             Self::Timeline(encoder) => encoder.encode(records, writer, context),
             Self::Text(encoder) => encoder.encode(records, writer, context),
             Self::Xml(encoder) => encoder.encode(records, writer, context),
+            Self::Parquet(_) => Err(OutputError::Encode(String::from(
+                "parquet output is streamed; use 'encode_stream' instead",
+            ))),
+        }
+    }
+
+    pub(crate) fn encode_stream(
+        &self,
+        target: StreamTarget,
+        records: &mut dyn RecordStream,
+        context: &ArtifactContext,
+    ) -> OutputResult<EncoderStreamWriter> {
+        match self {
+            Self::Parquet(encoder) => encoder.encode_stream(target, records, context),
+            _ => Err(OutputError::Encode(format!(
+                "{} output is chunked and does not support streamed writers",
+                self.extension()
+            ))),
+        }
+    }
+
+    pub(crate) fn encoder_mode(&self) -> EncoderMode {
+        match self {
+            Encoder::Json(_)
+            | Encoder::Text(_)
+            | Encoder::Jsonl(_)
+            | Encoder::Timeline(_)
+            | Encoder::Csv(_)
+            | Encoder::Xml(_) => EncoderMode::Chunked,
+            Encoder::Parquet(_) => EncoderMode::Streamed,
         }
     }
 }
 
-/// Common interface for artifact encoders
+/// Common interface for chunked artifact encoders
 pub(crate) trait ArtifactEncoder {
     /// Returns the extension for the output format
     fn extension(&self) -> &str;
@@ -92,6 +180,24 @@ pub(crate) trait ArtifactEncoder {
         writer: &mut dyn Write,
         context: &ArtifactContext,
     ) -> OutputResult<usize>;
+}
+
+pub(crate) trait StreamArtifactEncoder {
+    /// Returns the extension for the output format
+    fn extension(&self) -> &str;
+    /// Returns ths MIME type for output format.
+    ///
+    /// Used for remote uploads
+    fn mime_type(&self) -> &str;
+    /// Encodes a `RecordStream` into select streaming output format
+    ///
+    /// Returns a writer to stream data to disk
+    fn encode_stream(
+        &self,
+        target: StreamTarget,
+        records: &mut dyn RecordStream,
+        context: &ArtifactContext,
+    ) -> OutputResult<EncoderStreamWriter>;
 }
 
 #[cfg(test)]

--- a/forensics/src/output/encoder/artifact_encoder.rs
+++ b/forensics/src/output/encoder/artifact_encoder.rs
@@ -39,16 +39,28 @@ impl StreamTarget {
     }
 }
 
+/// A `Record` may be encoded into different formats
+///
+/// Each format either writes the data in multiple chunks to the `Sink`
+/// or streams to a single file on disk using the `LocalSink`
 pub(crate) enum StreamWriter {
+    /// Stream the output to a single parquet file on disk
     Parquet(ParquetWriter),
 }
 
+/// A generic stream writer that outputs data to
+/// a file on disk
 pub(crate) struct EncoderStreamWriter {
+    /// Writer that writes results to a file on disk
     pub(crate) writer: StreamWriter,
+    /// Number of records written
     pub(crate) record_count: usize,
 }
 
 impl StreamWriter {
+    /// Write `Record` values to disk using the `StreamWriter`
+    ///
+    /// Returns number of records written
     pub(crate) fn write_records(
         &mut self,
         records: &mut dyn RecordStream,
@@ -59,6 +71,7 @@ impl StreamWriter {
         }
     }
 
+    /// Finish streaming the `Record` values to disk
     pub(crate) fn finish(self) -> OutputResult<()> {
         match self {
             Self::Parquet(writer) => writer.finish(),
@@ -138,6 +151,9 @@ impl Encoder {
         }
     }
 
+    /// Encodes a `RecordStream` into `EncoderStreamWriter` tp stream results to disk
+    ///
+    /// Returns a `EncoderStreamWriter`
     pub(crate) fn encode_stream(
         &self,
         target: StreamTarget,
@@ -153,6 +169,10 @@ impl Encoder {
         }
     }
 
+    /// Returns the current encoding method based on encoder type
+    ///
+    /// `Chunked` is most common and will encode to multiple files
+    /// `Streamed` is used to stream results to a single file on disk
     pub(crate) fn encoder_mode(&self) -> EncoderMode {
         match self {
             Encoder::Json(_)

--- a/forensics/src/output/encoder/artifact_encoder.rs
+++ b/forensics/src/output/encoder/artifact_encoder.rs
@@ -18,38 +18,40 @@ use std::{io::Write, path::PathBuf};
 #[derive(Debug, PartialEq)]
 pub(crate) enum EncoderMode {
     /// Artifact records are written in chunks. Each artifact records is written to a separate file
+    ///
     /// For example, EventLogs are written in chunks to multiple JSONL files
     Chunked,
     /// Artifact records are streamed into a single file
+    ///
     /// For example, EventLogs are streamed into a single Parquet file
     Streamed,
 }
 
-/// Target file to stream results too
+/// Target file for streamed output
 #[derive(Debug)]
 pub(crate) struct StreamTarget {
-    /// Full path to stream data to
+    /// Full path to the streamed output file
     pub(crate) path: PathBuf,
 }
 
 impl StreamTarget {
-    /// Return a new `StreamTarget` based on provided provided file path
+    /// Creates a new `StreamTarget` from a file path
     pub(crate) fn new(path: PathBuf) -> Self {
         Self { path }
     }
 }
 
-/// A `Record` may be encoded into different formats
-///
-/// Each format either writes the data in multiple chunks to the `Sink`
-/// or streams to a single file on disk using the `LocalSink`
+/// Active writer for a streamed output format
+#[derive(Debug)]
 pub(crate) enum StreamWriter {
     /// Stream the output to a single parquet file on disk
     Parquet(ParquetWriter),
 }
 
-/// A generic stream writer that outputs data to
-/// a file on disk
+/// Writer returned after opening a streamed encoder
+///
+/// `record_count` is the number of records written while opening the stream
+#[derive(Debug)]
 pub(crate) struct EncoderStreamWriter {
     /// Writer that writes results to a file on disk
     pub(crate) writer: StreamWriter,
@@ -151,9 +153,7 @@ impl Encoder {
         }
     }
 
-    /// Encodes a `RecordStream` into `EncoderStreamWriter` tp stream results to disk
-    ///
-    /// Returns a `EncoderStreamWriter`
+    /// Opens a streamed output writer and writes the first record chunk
     pub(crate) fn encode_stream(
         &self,
         target: StreamTarget,
@@ -169,10 +169,7 @@ impl Encoder {
         }
     }
 
-    /// Returns the current encoding method based on encoder type
-    ///
-    /// `Chunked` is most common and will encode to multiple files
-    /// `Streamed` is used to stream results to a single file on disk
+    /// Returns whether this encoder writes chunked files or a streamed file
     pub(crate) fn encoder_mode(&self) -> EncoderMode {
         match self {
             Encoder::Json(_)
@@ -205,6 +202,7 @@ pub(crate) trait ArtifactEncoder {
     ) -> OutputResult<usize>;
 }
 
+/// Common interface for streamed artifact encoders
 pub(crate) trait StreamArtifactEncoder {
     /// Returns the extension for the output format
     fn extension(&self) -> &str;
@@ -229,10 +227,15 @@ mod tests {
         output::{
             context::CollectionContext,
             encoder::{
-                artifact_encoder::Encoder, csv::CsvEncoder, json::JsonEncoder, jsonl::JsonlEncoder,
+                artifact_encoder::{Encoder, StreamTarget},
+                csv::CsvEncoder,
+                json::JsonEncoder,
+                jsonl::JsonlEncoder,
+                parquet::ParquetEncoder,
                 text::TextEncoder,
             },
-            record::{JsonRecord, Record, ScalarRecord, VecRecordStream},
+            error::OutputError,
+            record::{JsonRecord, Record, ScalarRecord, SingleRecordStream, VecRecordStream},
         },
         structs::toml::OutputConfig,
     };
@@ -349,5 +352,45 @@ mod tests {
 
         let output = String::from_utf8(writer.into_inner()).unwrap();
         assert_eq!(output, "[\"one\",2,true,3.14]\n");
+    }
+
+    #[test]
+    fn test_stream_encoder_parquet() {
+        let test = json!({"test":"value"});
+        let output = OutputConfig::default();
+        let context = &CollectionContext::new(&output, PathBuf::from("./tmp")).artifact(
+            "test",
+            &output.start_time_filter,
+            &output.end_time_filter,
+        );
+        let path = PathBuf::from("./tmp/parquet_encoder");
+        let target = StreamTarget::new(path);
+        let mut mem_writer = Cursor::new(Vec::new());
+
+        let par_encoder = Encoder::Parquet(ParquetEncoder);
+        let err = par_encoder
+            .encode(
+                &mut SingleRecordStream::new(Record::Json(JsonRecord::new(
+                    test.as_object().unwrap().clone(),
+                ))),
+                &mut mem_writer,
+                context,
+            )
+            .unwrap_err();
+        assert!(
+            matches!(err, OutputError::Encode(value) if value == "parquet output is streamed; use 'encode_stream' instead")
+        );
+        let writer = par_encoder
+            .encode_stream(
+                target,
+                &mut SingleRecordStream::new(Record::Json(JsonRecord::new(
+                    test.as_object().unwrap().clone(),
+                ))),
+                context,
+            )
+            .unwrap();
+
+        assert_eq!(writer.record_count, 1);
+        writer.writer.finish().unwrap();
     }
 }

--- a/forensics/src/output/encoder/artifact_encoder.rs
+++ b/forensics/src/output/encoder/artifact_encoder.rs
@@ -17,7 +17,7 @@ use std::{io::Write, path::PathBuf};
 /// Describes how the encoder will write artifact records
 #[derive(Debug, PartialEq)]
 pub(crate) enum EncoderMode {
-    /// Artifact records are written in chunks. Each artifact records is written to a separate file
+    /// Artifact records are written in chunks. Each chunk is written to a separate file
     ///
     /// For example, `EventLogs` are written in chunks to multiple JSONL files
     Chunked,

--- a/forensics/src/output/encoder/artifact_encoder.rs
+++ b/forensics/src/output/encoder/artifact_encoder.rs
@@ -25,12 +25,15 @@ pub(crate) enum EncoderMode {
     Streamed,
 }
 
+/// Target file to stream results too
 #[derive(Debug)]
 pub(crate) struct StreamTarget {
+    /// Full path to stream data to
     pub(crate) path: PathBuf,
 }
 
 impl StreamTarget {
+    /// Return a new `StreamTarget` based on provided provided file path
     pub(crate) fn new(path: PathBuf) -> Self {
         Self { path }
     }

--- a/forensics/src/output/encoder/factory.rs
+++ b/forensics/src/output/encoder/factory.rs
@@ -1,7 +1,7 @@
 use crate::{
     output::encoder::{
         artifact_encoder::Encoder, csv::CsvEncoder, json::JsonEncoder, jsonl::JsonlEncoder,
-        text::TextEncoder, timeline::TimelineEncoder, xml::XmlEncoder,
+        parquet::ParquetEncoder, text::TextEncoder, timeline::TimelineEncoder, xml::XmlEncoder,
     },
     structs::toml::{OutputConfig, OutputFormat},
 };
@@ -15,6 +15,7 @@ pub(crate) fn build_encoder(config: &OutputConfig) -> Encoder {
         OutputFormat::Timeline => Encoder::Timeline(TimelineEncoder),
         OutputFormat::Text => Encoder::Text(TextEncoder),
         OutputFormat::Xml => Encoder::Xml(XmlEncoder),
+        OutputFormat::Parquet => Encoder::Parquet(ParquetEncoder),
     }
 }
 

--- a/forensics/src/output/encoder/mod.rs
+++ b/forensics/src/output/encoder/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod factory;
 mod json;
 mod jsonl;
 mod metadata;
+mod parquet;
 mod text;
 mod timeline;
 mod xml;

--- a/forensics/src/output/encoder/parquet.rs
+++ b/forensics/src/output/encoder/parquet.rs
@@ -292,10 +292,14 @@ impl ColumnKind {
         match value {
             Value::Bool(_) => Self::Bool,
             Value::Number(number) => {
-                if number.is_i64() || number.as_u64().is_some_and(|n| n <= i64::MAX as u64) {
+                if number.is_i64() {
                     Self::Int64
-                } else {
+                } else if number.as_u64().is_some_and(|n| n <= i64::MAX as u64) {
+                    Self::Int64
+                } else if number.is_f64() {
                     Self::Double
+                } else {
+                    Self::Utf8
                 }
             }
             Value::Null => Self::Utf8,
@@ -505,7 +509,7 @@ fn write_column(writer: &mut SerializedColumnWriter<'_>, column: ColumnBatch) ->
         }
         _ => {
             return Err(OutputError::Encode(String::from(
-                "parquet column type did match schema",
+                "parquet column type did not match schema",
             )));
         }
     }

--- a/forensics/src/output/encoder/parquet.rs
+++ b/forensics/src/output/encoder/parquet.rs
@@ -15,7 +15,7 @@ use parquet::{
     data_type::ByteArray,
     errors::ParquetError,
     file::{
-        properties::WriterProperties,
+        properties::{EnabledStatistics, WriterProperties},
         writer::{SerializedColumnWriter, SerializedFileWriter},
     },
     schema::parser::parse_message_type,
@@ -63,6 +63,7 @@ impl StreamArtifactEncoder for ParquetEncoder {
         let props = Arc::new(
             WriterProperties::builder()
                 .set_compression(Compression::SNAPPY)
+                .set_statistics_enabled(EnabledStatistics::None)
                 .build(),
         );
 
@@ -378,7 +379,7 @@ enum ColumnBatch {
     },
 }
 
-/// Assemble columns for the parquet file
+/// Builds parquet column batches for the provided rows
 fn build_columns(schema: &ParquetSchema, rows: &[Map<String, Value>]) -> Vec<ColumnBatch> {
     schema
         .columns
@@ -535,7 +536,7 @@ fn value_as_string(value: &Value) -> Option<String> {
     }
 }
 
-/// If later values are identified on the JSON `Record` append them to our `extra_json` column
+/// Serializes fields not present in the inferred schema into the `_extra_json` column
 fn extra_json(schema: &ParquetSchema, row: &Map<String, Value>) -> Option<String> {
     let mut extra = Map::new();
     for (key, value) in row {

--- a/forensics/src/output/encoder/parquet.rs
+++ b/forensics/src/output/encoder/parquet.rs
@@ -49,6 +49,12 @@ impl StreamArtifactEncoder for ParquetEncoder {
         // Convert first record chunk into parquet rows and append collection metadata
         let rows = read_json_rows(records, context)?;
 
+        if rows.is_empty() {
+            return Err(OutputError::Encode(String::from(
+                "cannot create parquet schema from empty data",
+            )));
+        }
+
         // Infer the parquet schema from the first non-empty record chunk
         let schema = ParquetSchema::infer(&rows);
         let message_type = schema.message_type();
@@ -721,22 +727,12 @@ mod tests {
         let context = test_context();
         let encoder = ParquetEncoder;
         let mut records = VecRecordStream::new(Vec::new());
-        let opened = encoder
+
+        let err = encoder
             .encode_stream(target, &mut records, &context)
-            .unwrap();
+            .unwrap_err();
 
-        opened.writer.finish().unwrap();
-        let path = PathBuf::from("./tmp/parquet_empty_first_chunk.parquet");
-
-        let metadata = parquet_metadata(&path);
-        let schema = metadata.file_metadata().schema_descr();
-        let column = schema
-            .columns()
-            .iter()
-            .find(|column| column.name() == "_extra_json")
-            .unwrap();
-
-        assert_eq!(column.physical_type(), parquet::basic::Type::BYTE_ARRAY);
+        assert!(err.to_string().contains("cannot create parquet schema"));
     }
 
     #[test]

--- a/forensics/src/output/encoder/parquet.rs
+++ b/forensics/src/output/encoder/parquet.rs
@@ -146,7 +146,7 @@ impl ParquetWriter {
         Ok(rows.len())
     }
 
-    /// Finish streaming the `Record` values to disk
+    /// Finalizes the parquet file
     pub(crate) fn finish(self) -> OutputResult<()> {
         self.writer.close().map_err(|err| {
             OutputError::Encode(format!(
@@ -271,7 +271,7 @@ impl ParquetSchema {
         candidate
     }
 
-    /// Ensure field names use authorized characters
+    /// Replaces unsupported parquet column-name characters with underscores
     fn sanitize_field_name(source: &str) -> String {
         let mut name = source
             .chars()
@@ -296,10 +296,10 @@ impl ParquetSchema {
     }
 }
 
-/// Data associated with our parquet columns
+/// Metadata for one parquet column
 #[derive(Debug)]
 struct ColumnSpec {
-    /// Source key of our parquet column name
+    /// Source JSON field name for the column
     source_name: Option<String>,
     /// The unique parquet column name
     parquet_name: String,
@@ -307,7 +307,7 @@ struct ColumnSpec {
     kind: ColumnKind,
 }
 
-/// Common Column value types
+/// Supported parquet column value types
 #[derive(Copy, Clone, Debug)]
 enum ColumnKind {
     Bool,
@@ -322,9 +322,7 @@ impl ColumnKind {
         match value {
             Value::Bool(_) => Self::Bool,
             Value::Number(number) => {
-                if number.is_i64() {
-                    Self::Int64
-                } else if number.as_u64().is_some_and(|n| n <= i64::MAX as u64) {
+                if number.is_i64() || number.as_u64().is_some_and(|n| i64::try_from(n).is_ok()) {
                     Self::Int64
                 } else if number.is_f64() {
                     Self::Double
@@ -332,12 +330,11 @@ impl ColumnKind {
                     Self::Utf8
                 }
             }
-            Value::Null => Self::Utf8,
-            Value::Array(_) | Value::Object(_) | Value::String(_) => Self::Utf8,
+            Value::Null | Value::Array(_) | Value::Object(_) | Value::String(_) => Self::Utf8,
         }
     }
 
-    /// Attempt to merge column types if a key-value has more than one type
+    /// Merges inferred column types when a field has mixed value types in the schema chunk
     ///
     /// Example: `{"value": 1}` and later `{"value": 2.5}`
     ///
@@ -353,30 +350,30 @@ impl ColumnKind {
     }
 }
 
-/// Data for each column type
+/// Column values and definition levels prepared for parquet writing
 enum ColumnBatch {
     Bool {
         /// Array of booleans
         values: Vec<bool>,
-        /// Definition level for the parquet row
+        /// Per-row definition levels; 1 means present, 0 means null or missing.
         definition_levels: Vec<i16>,
     },
     Int64 {
         /// Array of integers
         values: Vec<i64>,
-        /// Definition level for the parquet row
+        /// Per-row definition levels; 1 means present, 0 means null or missing.
         definition_levels: Vec<i16>,
     },
     Double {
         /// Array of floats
         values: Vec<f64>,
-        /// Definition level for the parquet row
+        /// Per-row definition levels; 1 means present, 0 means null or missing.
         definition_levels: Vec<i16>,
     },
     Utf8 {
         /// Array of `ByteArray`
         values: Vec<ByteArray>,
-        /// Definition level for the parquet row
+        /// Per-row definition levels; 1 means present, 0 means null or missing.
         definition_levels: Vec<i16>,
     },
 }
@@ -421,6 +418,7 @@ fn bool_column(column: &ColumnSpec, rows: &[Map<String, Value>]) -> ColumnBatch 
             continue;
         }
 
+        // Missing values will become null
         definition_levels.push(0);
     }
 
@@ -447,6 +445,7 @@ fn i64_column(column: &ColumnSpec, rows: &[Map<String, Value>]) -> ColumnBatch {
             continue;
         }
 
+        // Missing values will become null
         definition_levels.push(0);
     }
 
@@ -484,6 +483,7 @@ fn f64_column(column: &ColumnSpec, rows: &[Map<String, Value>]) -> ColumnBatch {
             continue;
         }
 
+        // Missing values will become null
         definition_levels.push(0);
     }
 
@@ -513,6 +513,7 @@ fn utf8_column(
             continue;
         }
 
+        // Missing values will become null
         definition_levels.push(0);
     }
 

--- a/forensics/src/output/encoder/parquet.rs
+++ b/forensics/src/output/encoder/parquet.rs
@@ -1,0 +1,518 @@
+use crate::output::{
+    context::ArtifactContext,
+    encoder::{
+        artifact_encoder::{
+            EncoderStreamWriter, StreamArtifactEncoder, StreamTarget, StreamWriter,
+        },
+        metadata::append_metadata,
+    },
+    error::{OutputError, OutputResult},
+    record::{Record, RecordStream},
+};
+use parquet::{
+    basic::Compression,
+    column::writer::ColumnWriter,
+    data_type::ByteArray,
+    errors::ParquetError,
+    file::{
+        properties::WriterProperties,
+        writer::{SerializedColumnWriter, SerializedFileWriter},
+    },
+    schema::parser::parse_message_type,
+};
+use serde_json::{Map, Value};
+use std::{
+    collections::{HashMap, HashSet},
+    fs::File,
+    sync::Arc,
+};
+
+/// Encodes artifact records into a single Parquet file
+#[derive(Debug, PartialEq)]
+pub(crate) struct ParquetEncoder;
+
+impl StreamArtifactEncoder for ParquetEncoder {
+    fn extension(&self) -> &str {
+        "parquet"
+    }
+
+    fn mime_type(&self) -> &str {
+        "application/vnd.apache.parquet"
+    }
+
+    fn encode_stream(
+        &self,
+        target: StreamTarget,
+        records: &mut dyn RecordStream,
+        context: &ArtifactContext,
+    ) -> OutputResult<EncoderStreamWriter> {
+        let rows = read_json_rows(records, context)?;
+
+        if rows.is_empty() {
+            return Err(OutputError::Encode(String::from(
+                "cannot create parquet schema from empty data",
+            )));
+        }
+
+        let schema = ParquetSchema::infer(&rows);
+        let message_type = schema.message_type();
+
+        let parquet_schema = Arc::new(parse_message_type(&message_type).map_err(parquet_error)?);
+        let props = Arc::new(
+            WriterProperties::builder()
+                .set_compression(Compression::SNAPPY)
+                .build(),
+        );
+
+        let file =
+            File::create(&target.path).map_err(|err| OutputError::io_path(&target.path, err))?;
+        let writer =
+            SerializedFileWriter::new(file, parquet_schema, props).map_err(parquet_error)?;
+        let mut parquet_writer = ParquetWriter {
+            target,
+            schema,
+            writer,
+        };
+
+        parquet_writer.write_row_group(&rows)?;
+
+        Ok(EncoderStreamWriter {
+            writer: StreamWriter::Parquet(parquet_writer),
+            record_count: rows.len(),
+        })
+    }
+}
+
+fn read_json_rows(
+    records: &mut dyn RecordStream,
+    context: &ArtifactContext,
+) -> OutputResult<Vec<Map<String, Value>>> {
+    let mut rows = Vec::new();
+
+    while let Some(record) = records.next_record()? {
+        let Record::Json(record) = record else {
+            return Err(OutputError::UnsupportedRecord {
+                format: String::from("parquet"),
+                record_type: record.kind().to_string(),
+            });
+        };
+
+        let mut value = record.into_value();
+        append_metadata(&mut value, context);
+        let Value::Object(fields) = value else {
+            return Err(OutputError::Encode(String::from(
+                "parquet records must be JSON objects",
+            )));
+        };
+
+        rows.push(fields);
+    }
+
+    Ok(rows)
+}
+
+pub(crate) struct ParquetWriter {
+    target: StreamTarget,
+    schema: ParquetSchema,
+    writer: SerializedFileWriter<File>,
+}
+
+impl ParquetWriter {
+    pub(crate) fn write_records(
+        &mut self,
+        records: &mut dyn RecordStream,
+        context: &ArtifactContext,
+    ) -> OutputResult<usize> {
+        let rows = read_json_rows(records, context)?;
+        if rows.is_empty() {
+            return Ok(0);
+        }
+
+        self.write_row_group(&rows)?;
+
+        Ok(rows.len())
+    }
+
+    pub(crate) fn finish(self) -> OutputResult<()> {
+        self.writer.close().map_err(|err| {
+            OutputError::Encode(format!(
+                "failed to close parquet file {}: {err}",
+                self.target.path.display()
+            ))
+        })?;
+
+        Ok(())
+    }
+
+    fn write_row_group(&mut self, rows: &[Map<String, Value>]) -> OutputResult<()> {
+        let columns = build_columns(&self.schema, rows);
+
+        let mut row_group = self.writer.next_row_group().map_err(parquet_error)?;
+        for column in columns {
+            let Some(mut column_writer) = row_group.next_column().map_err(parquet_error)? else {
+                return Err(OutputError::Encode(String::from(
+                    "parquet schema expected more columns than writer returned",
+                )));
+            };
+
+            write_column(&mut column_writer, column)?;
+            column_writer.close().map_err(parquet_error)?;
+        }
+
+        row_group.close().map_err(parquet_error)?;
+
+        Ok(())
+    }
+}
+
+struct ParquetSchema {
+    columns: Vec<ColumnSpec>,
+    known_fields: HashSet<String>,
+}
+
+impl ParquetSchema {
+    fn infer(rows: &[Map<String, Value>]) -> Self {
+        let mut order = Vec::new();
+        let mut kinds: HashMap<String, ColumnKind> = HashMap::new();
+        for row in rows {
+            for (key, value) in row {
+                if !kinds.contains_key(key) {
+                    order.push(key.clone());
+                    kinds.insert(key.clone(), ColumnKind::from_value(value));
+                    continue;
+                }
+
+                let current = kinds.get(key).copied().unwrap_or(ColumnKind::Utf8);
+                kinds.insert(key.clone(), current.merge(ColumnKind::from_value(value)));
+            }
+        }
+
+        let mut used_names = HashSet::new();
+        let mut known_fields = HashSet::new();
+        let mut columns = Vec::new();
+
+        for source_name in order {
+            known_fields.insert(source_name.clone());
+
+            let parquet_name = Self::unique_field_name(&source_name, &mut used_names);
+            let kind = kinds.get(&source_name).copied().unwrap_or(ColumnKind::Utf8);
+
+            columns.push(ColumnSpec {
+                source_name: Some(source_name),
+                parquet_name,
+                kind,
+            });
+        }
+
+        columns.push(ColumnSpec {
+            source_name: None,
+            parquet_name: Self::unique_field_name("_extra_json", &mut used_names),
+            kind: ColumnKind::Utf8,
+        });
+
+        Self {
+            columns,
+            known_fields,
+        }
+    }
+
+    fn message_type(&self) -> String {
+        let mut message = String::from("message artemis {\n");
+        for column in &self.columns {
+            let field = match column.kind {
+                ColumnKind::Bool => format!("  optional BOOLEAN {};\n", column.parquet_name),
+                ColumnKind::Double => format!("  optional DOUBLE {};\n", column.parquet_name),
+                ColumnKind::Utf8 => {
+                    format!("  optional BYTE_ARRAY {} (UTF8);\n", column.parquet_name)
+                }
+                ColumnKind::Int64 => format!("  optional INT64 {};\n", column.parquet_name),
+            };
+
+            message.push_str(&field);
+        }
+
+        message.push_str("}\n");
+        message
+    }
+
+    fn unique_field_name(source: &str, used: &mut HashSet<String>) -> String {
+        let base = Self::sanitize_field_name(source);
+        let mut candidate = base.clone();
+
+        let mut suffix = 1;
+        while used.contains(&candidate) {
+            candidate = format!("{base}_{suffix}");
+            suffix += 1;
+        }
+
+        used.insert(candidate.clone());
+        candidate
+    }
+
+    fn sanitize_field_name(source: &str) -> String {
+        let mut name = source
+            .chars()
+            .map(|c| {
+                if c.is_ascii_alphanumeric() || c == '_' {
+                    c
+                } else {
+                    '_'
+                }
+            })
+            .collect::<String>();
+
+        if name.is_empty() {
+            name = String::from("field");
+        }
+
+        if name.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+            name.insert(0, '_');
+        }
+
+        name
+    }
+}
+
+struct ColumnSpec {
+    source_name: Option<String>,
+    parquet_name: String,
+    kind: ColumnKind,
+}
+
+#[derive(Copy, Clone)]
+enum ColumnKind {
+    Bool,
+    Int64,
+    Double,
+    Utf8,
+}
+
+impl ColumnKind {
+    fn from_value(value: &Value) -> Self {
+        match value {
+            Value::Bool(_) => Self::Bool,
+            Value::Number(number) => {
+                if number.is_i64() || number.as_u64().is_some_and(|n| n <= i64::MAX as u64) {
+                    Self::Int64
+                } else {
+                    Self::Double
+                }
+            }
+            Value::Null => Self::Utf8,
+            Value::Array(_) | Value::Object(_) | Value::String(_) => Self::Utf8,
+        }
+    }
+
+    fn merge(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::Utf8, _) | (_, Self::Utf8) => Self::Utf8,
+            (Self::Double, _) | (_, Self::Double) => Self::Double,
+            (Self::Int64, Self::Int64) => Self::Int64,
+            (Self::Bool, Self::Bool) => Self::Bool,
+            _ => Self::Utf8,
+        }
+    }
+}
+
+enum ColumnBatch {
+    Bool {
+        values: Vec<bool>,
+        def_levels: Vec<i16>,
+    },
+    Int64 {
+        values: Vec<i64>,
+        def_levels: Vec<i16>,
+    },
+    Double {
+        values: Vec<f64>,
+        def_levels: Vec<i16>,
+    },
+    Utf8 {
+        values: Vec<ByteArray>,
+        def_levels: Vec<i16>,
+    },
+}
+
+fn build_columns(schema: &ParquetSchema, rows: &[Map<String, Value>]) -> Vec<ColumnBatch> {
+    schema
+        .columns
+        .iter()
+        .map(|column| build_column(schema, column, rows))
+        .collect()
+}
+
+fn build_column(
+    schema: &ParquetSchema,
+    column: &ColumnSpec,
+    rows: &[Map<String, Value>],
+) -> ColumnBatch {
+    match column.kind {
+        ColumnKind::Bool => bool_column(column, rows),
+        ColumnKind::Int64 => i64_column(column, rows),
+        ColumnKind::Double => f64_column(column, rows),
+        ColumnKind::Utf8 => utf8_column(schema, column, rows),
+    }
+}
+
+fn bool_column(column: &ColumnSpec, rows: &[Map<String, Value>]) -> ColumnBatch {
+    let mut values = Vec::new();
+    let mut def_levels = Vec::with_capacity(rows.len());
+    for row in rows {
+        let value = column
+            .source_name
+            .as_ref()
+            .and_then(|name| row.get(name))
+            .and_then(Value::as_bool);
+
+        if let Some(val) = value {
+            values.push(val);
+            def_levels.push(1);
+            continue;
+        }
+
+        def_levels.push(0);
+    }
+
+    ColumnBatch::Bool { values, def_levels }
+}
+
+fn i64_column(column: &ColumnSpec, rows: &[Map<String, Value>]) -> ColumnBatch {
+    let mut values = Vec::new();
+    let mut def_levels = Vec::with_capacity(rows.len());
+    for row in rows {
+        let value = column
+            .source_name
+            .as_ref()
+            .and_then(|name| row.get(name))
+            .and_then(value_as_i64);
+
+        if let Some(val) = value {
+            values.push(val);
+            def_levels.push(1);
+            continue;
+        }
+
+        def_levels.push(0);
+    }
+
+    ColumnBatch::Int64 { values, def_levels }
+}
+
+fn value_as_i64(value: &Value) -> Option<i64> {
+    let number = value.as_number()?;
+    if let Some(val) = number.as_i64() {
+        return Some(val);
+    }
+
+    let value = number.as_u64()?;
+    i64::try_from(value).ok()
+}
+
+fn f64_column(column: &ColumnSpec, rows: &[Map<String, Value>]) -> ColumnBatch {
+    let mut values = Vec::new();
+    let mut def_levels = Vec::with_capacity(rows.len());
+    for row in rows {
+        let value = column
+            .source_name
+            .as_ref()
+            .and_then(|name| row.get(name))
+            .and_then(Value::as_f64);
+
+        if let Some(val) = value {
+            values.push(val);
+            def_levels.push(1);
+            continue;
+        }
+
+        def_levels.push(0);
+    }
+
+    ColumnBatch::Double { values, def_levels }
+}
+
+fn utf8_column(
+    schema: &ParquetSchema,
+    column: &ColumnSpec,
+    rows: &[Map<String, Value>],
+) -> ColumnBatch {
+    let mut values = Vec::new();
+    let mut def_levels = Vec::with_capacity(rows.len());
+    for row in rows {
+        let value = match &column.source_name {
+            Some(name) => row.get(name).and_then(value_as_string),
+            None => extra_json(schema, row),
+        };
+
+        if let Some(val) = value {
+            values.push(ByteArray::from(val.as_str()));
+            def_levels.push(1);
+            continue;
+        }
+
+        def_levels.push(0);
+    }
+
+    ColumnBatch::Utf8 { values, def_levels }
+}
+
+fn value_as_string(value: &Value) -> Option<String> {
+    match value {
+        Value::Null => None,
+        Value::String(val) => Some(val.clone()),
+        Value::Bool(val) => Some(val.to_string()),
+        Value::Number(val) => Some(val.to_string()),
+        Value::Array(val) => serde_json::to_string(val).ok(),
+        Value::Object(val) => serde_json::to_string(val).ok(),
+    }
+}
+
+fn extra_json(schema: &ParquetSchema, row: &Map<String, Value>) -> Option<String> {
+    let mut extra = Map::new();
+    for (key, value) in row {
+        if !schema.known_fields.contains(key) {
+            extra.insert(key.clone(), value.clone());
+        }
+    }
+
+    if extra.is_empty() {
+        return None;
+    }
+
+    serde_json::to_string(&Value::Object(extra)).ok()
+}
+
+fn write_column(writer: &mut SerializedColumnWriter<'_>, column: ColumnBatch) -> OutputResult<()> {
+    match (writer.untyped(), column) {
+        (ColumnWriter::BoolColumnWriter(write), ColumnBatch::Bool { values, def_levels }) => {
+            write
+                .write_batch(&values, Some(&def_levels), None)
+                .map_err(parquet_error)?;
+        }
+        (ColumnWriter::Int64ColumnWriter(write), ColumnBatch::Int64 { values, def_levels }) => {
+            write
+                .write_batch(&values, Some(&def_levels), None)
+                .map_err(parquet_error)?;
+        }
+        (ColumnWriter::DoubleColumnWriter(write), ColumnBatch::Double { values, def_levels }) => {
+            write
+                .write_batch(&values, Some(&def_levels), None)
+                .map_err(parquet_error)?;
+        }
+        (ColumnWriter::ByteArrayColumnWriter(write), ColumnBatch::Utf8 { values, def_levels }) => {
+            write
+                .write_batch(&values, Some(&def_levels), None)
+                .map_err(parquet_error)?;
+        }
+        _ => {
+            return Err(OutputError::Encode(String::from(
+                "parquet column type did match schema",
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+fn parquet_error(err: ParquetError) -> OutputError {
+    OutputError::Encode(format!("parquet error: {err}"))
+}

--- a/forensics/src/output/encoder/parquet.rs
+++ b/forensics/src/output/encoder/parquet.rs
@@ -46,6 +46,7 @@ impl StreamArtifactEncoder for ParquetEncoder {
         records: &mut dyn RecordStream,
         context: &ArtifactContext,
     ) -> OutputResult<EncoderStreamWriter> {
+        // Add metadata to our records
         let rows = read_json_rows(records, context)?;
 
         if rows.is_empty() {
@@ -54,6 +55,7 @@ impl StreamArtifactEncoder for ParquetEncoder {
             )));
         }
 
+        // Based on the parsed data try to create a parquet schema
         let schema = ParquetSchema::infer(&rows);
         let message_type = schema.message_type();
 
@@ -64,6 +66,7 @@ impl StreamArtifactEncoder for ParquetEncoder {
                 .build(),
         );
 
+        // Create the writer to the parquet file
         let file =
             File::create(&target.path).map_err(|err| OutputError::io_path(&target.path, err))?;
         let writer =
@@ -74,6 +77,7 @@ impl StreamArtifactEncoder for ParquetEncoder {
             writer,
         };
 
+        // Write the first batch of rows
         parquet_writer.write_row_group(&rows)?;
 
         Ok(EncoderStreamWriter {
@@ -83,6 +87,7 @@ impl StreamArtifactEncoder for ParquetEncoder {
     }
 }
 
+/// Read `Record` JSON values into rows
 fn read_json_rows(
     records: &mut dyn RecordStream,
     context: &ArtifactContext,
@@ -111,13 +116,21 @@ fn read_json_rows(
     Ok(rows)
 }
 
+/// Data we need to create a parquet writer
+#[derive(Debug)]
 pub(crate) struct ParquetWriter {
+    /// Full path to the streamed output file
     target: StreamTarget,
+    /// The parquet schema
     schema: ParquetSchema,
+    /// Writer to the parquet file
     writer: SerializedFileWriter<File>,
 }
 
 impl ParquetWriter {
+    /// Write `Record` values to disk using the `StreamWriter`
+    ///
+    /// Returns number of records written
     pub(crate) fn write_records(
         &mut self,
         records: &mut dyn RecordStream,
@@ -133,6 +146,7 @@ impl ParquetWriter {
         Ok(rows.len())
     }
 
+    /// Finish streaming the `Record` values to disk
     pub(crate) fn finish(self) -> OutputResult<()> {
         self.writer.close().map_err(|err| {
             OutputError::Encode(format!(
@@ -144,6 +158,7 @@ impl ParquetWriter {
         Ok(())
     }
 
+    /// Write the rows to the parquet file
     fn write_row_group(&mut self, rows: &[Map<String, Value>]) -> OutputResult<()> {
         let columns = build_columns(&self.schema, rows);
 
@@ -165,12 +180,17 @@ impl ParquetWriter {
     }
 }
 
+/// The parquet schema implementation
+#[derive(Debug)]
 struct ParquetSchema {
+    /// Column info for our parquet file
     columns: Vec<ColumnSpec>,
+    /// Field tracker
     known_fields: HashSet<String>,
 }
 
 impl ParquetSchema {
+    /// Try to implement a parquet schema based on artifact keys and values
     fn infer(rows: &[Map<String, Value>]) -> Self {
         let mut order = Vec::new();
         let mut kinds: HashMap<String, ColumnKind> = HashMap::new();
@@ -216,6 +236,7 @@ impl ParquetSchema {
         }
     }
 
+    /// Determine schema message type
     fn message_type(&self) -> String {
         let mut message = String::from("message artemis {\n");
         for column in &self.columns {
@@ -235,6 +256,7 @@ impl ParquetSchema {
         message
     }
 
+    /// Make sure each schema field is unique
     fn unique_field_name(source: &str, used: &mut HashSet<String>) -> String {
         let base = Self::sanitize_field_name(source);
         let mut candidate = base.clone();
@@ -249,6 +271,7 @@ impl ParquetSchema {
         candidate
     }
 
+    /// Ensure field names use authorized characters
     fn sanitize_field_name(source: &str) -> String {
         let mut name = source
             .chars()
@@ -273,13 +296,15 @@ impl ParquetSchema {
     }
 }
 
+/// Data associated with our parquet columns
+#[derive(Debug)]
 struct ColumnSpec {
     source_name: Option<String>,
     parquet_name: String,
     kind: ColumnKind,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 enum ColumnKind {
     Bool,
     Int64,
@@ -517,6 +542,230 @@ fn write_column(writer: &mut SerializedColumnWriter<'_>, column: ColumnBatch) ->
     Ok(())
 }
 
+/// Convert `ParquetError` to `OutputError`
 fn parquet_error(err: ParquetError) -> OutputError {
     OutputError::Encode(format!("parquet error: {err}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ParquetEncoder;
+    use crate::{
+        output::{
+            context::CollectionContext,
+            encoder::artifact_encoder::StreamArtifactEncoder,
+            encoder::artifact_encoder::StreamTarget,
+            record::{JsonRecord, Record, ScalarRecord, VecRecordStream},
+        },
+        structs::toml::OutputConfig,
+    };
+    use parquet::file::reader::{FileReader, SerializedFileReader};
+    use serde_json::{Value, json};
+    use std::{fs::File, path::PathBuf};
+
+    fn test_context() -> crate::output::context::ArtifactContext {
+        let output = OutputConfig::default();
+
+        CollectionContext::new(&output, PathBuf::from("./tmp/parquet_test.log")).artifact(
+            "test",
+            &output.start_time_filter,
+            &output.end_time_filter,
+        )
+    }
+
+    fn target(name: &str) -> StreamTarget {
+        let path = PathBuf::from("./tmp").join(format!("{name}.parquet"));
+        let _ = std::fs::create_dir_all("./tmp");
+        let _ = std::fs::remove_file(&path);
+
+        StreamTarget::new(path)
+    }
+
+    fn json_record(value: Value) -> Record {
+        Record::Json(JsonRecord::new(value.as_object().unwrap().clone()))
+    }
+
+    fn parquet_metadata(path: &PathBuf) -> parquet::file::metadata::ParquetMetaData {
+        let file = File::open(path).unwrap();
+        let reader = SerializedFileReader::new(file).unwrap();
+        reader.metadata().clone()
+    }
+
+    fn column_names(metadata: &parquet::file::metadata::ParquetMetaData) -> Vec<String> {
+        metadata
+            .file_metadata()
+            .schema_descr()
+            .columns()
+            .iter()
+            .map(|column| column.name().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn test_parquet_encode_stream() {
+        let path = PathBuf::from("./tmp/parquet_encode_stream.parquet");
+        let target = target("parquet_encode_stream");
+        let context = test_context();
+        let encoder = ParquetEncoder;
+
+        let mut records = VecRecordStream::new(vec![
+            json_record(json!({"path": "/tmp/one", "size": 1})),
+            json_record(json!({"path": "/tmp/two", "size": 2})),
+        ]);
+
+        let opened = encoder
+            .encode_stream(target, &mut records, &context)
+            .unwrap();
+
+        assert_eq!(opened.record_count, 2);
+        opened.writer.finish().unwrap();
+
+        let metadata = parquet_metadata(&path);
+        assert_eq!(metadata.file_metadata().num_rows(), 2);
+        assert_eq!(metadata.num_row_groups(), 1);
+    }
+
+    #[test]
+    fn test_parquet_write_records_second_chunk() {
+        let path = PathBuf::from("./tmp/parquet_second_chunk.parquet");
+        let target = target("parquet_second_chunk");
+        let context = test_context();
+        let encoder = ParquetEncoder;
+
+        let mut first = VecRecordStream::new(vec![json_record(json!({
+            "path": "/tmp/one",
+            "size": 1
+        }))]);
+
+        let mut opened = encoder.encode_stream(target, &mut first, &context).unwrap();
+
+        let mut second = VecRecordStream::new(vec![json_record(json!({
+            "path": "/tmp/two",
+            "size": 2
+        }))]);
+
+        let count = opened.writer.write_records(&mut second, &context).unwrap();
+        assert_eq!(count, 1);
+
+        opened.writer.finish().unwrap();
+
+        let metadata = parquet_metadata(&path);
+        assert_eq!(metadata.file_metadata().num_rows(), 2);
+        assert_eq!(metadata.num_row_groups(), 2);
+    }
+
+    #[test]
+    fn test_parquet_empty_first_chunk_error() {
+        let target = target("parquet_empty_first_chunk");
+        let context = test_context();
+        let encoder = ParquetEncoder;
+        let mut records = VecRecordStream::new(Vec::new());
+
+        let err = encoder
+            .encode_stream(target, &mut records, &context)
+            .unwrap_err();
+
+        assert!(err.to_string().contains("cannot create parquet schema"));
+    }
+
+    #[test]
+    fn test_parquet_empty_later_chunk_ok() {
+        let path = PathBuf::from("./tmp/parquet_empty_later_chunk.parquet");
+        let target = target("parquet_empty_later_chunk");
+        let context = test_context();
+        let encoder = ParquetEncoder;
+
+        let mut first = VecRecordStream::new(vec![json_record(json!({
+            "path": "/tmp/one",
+            "size": 1
+        }))]);
+
+        let mut opened = encoder.encode_stream(target, &mut first, &context).unwrap();
+
+        let mut empty = VecRecordStream::new(Vec::new());
+        let count = opened.writer.write_records(&mut empty, &context).unwrap();
+        assert_eq!(count, 0);
+
+        opened.writer.finish().unwrap();
+
+        let metadata = parquet_metadata(&path);
+        assert_eq!(metadata.file_metadata().num_rows(), 1);
+        assert_eq!(metadata.num_row_groups(), 1);
+    }
+
+    #[test]
+    fn test_parquet_unsupported_record() {
+        let target = target("parquet_unsupported_record");
+        let context = test_context();
+        let encoder = ParquetEncoder;
+
+        let mut records = VecRecordStream::new(vec![Record::Scalar(ScalarRecord::Text(
+            String::from("not json"),
+        ))]);
+
+        let err = encoder
+            .encode_stream(target, &mut records, &context)
+            .unwrap_err();
+
+        assert!(err.to_string().contains("parquet"));
+        assert!(err.to_string().contains("text"));
+    }
+
+    #[test]
+    fn test_parquet_large_u64_is_utf8() {
+        let path = PathBuf::from("./tmp/parquet_large_u64.parquet");
+        let target = target("parquet_large_u64");
+        let context = test_context();
+        let encoder = ParquetEncoder;
+
+        let mut records = VecRecordStream::new(vec![json_record(json!({
+            "value": u64::MAX
+        }))]);
+
+        let opened = encoder
+            .encode_stream(target, &mut records, &context)
+            .unwrap();
+
+        opened.writer.finish().unwrap();
+
+        let metadata = parquet_metadata(&path);
+        let schema = metadata.file_metadata().schema_descr();
+        let column = schema
+            .columns()
+            .iter()
+            .find(|column| column.name() == "value")
+            .unwrap();
+
+        assert_eq!(column.physical_type(), parquet::basic::Type::BYTE_ARRAY);
+    }
+
+    #[test]
+    fn test_parquet_late_fields_extra_json_schema() {
+        let path = PathBuf::from("./tmp/parquet_late_fields.parquet");
+        let target = target("parquet_late_fields");
+        let context = test_context();
+        let encoder = ParquetEncoder;
+
+        let mut first = VecRecordStream::new(vec![json_record(json!({
+            "path": "/tmp/one"
+        }))]);
+
+        let mut opened = encoder.encode_stream(target, &mut first, &context).unwrap();
+
+        let mut second = VecRecordStream::new(vec![json_record(json!({
+            "path": "/tmp/two",
+            "late_field": "value"
+        }))]);
+
+        opened.writer.write_records(&mut second, &context).unwrap();
+        opened.writer.finish().unwrap();
+
+        let metadata = parquet_metadata(&path);
+        let names = column_names(&metadata);
+
+        assert!(names.iter().any(|name| name == "path"));
+        assert!(names.iter().any(|name| name == "_extra_json"));
+        assert!(!names.iter().any(|name| name == "late_field"));
+        assert_eq!(metadata.file_metadata().num_rows(), 2);
+    }
 }

--- a/forensics/src/output/encoder/parquet.rs
+++ b/forensics/src/output/encoder/parquet.rs
@@ -46,7 +46,7 @@ impl StreamArtifactEncoder for ParquetEncoder {
         records: &mut dyn RecordStream,
         context: &ArtifactContext,
     ) -> OutputResult<EncoderStreamWriter> {
-        // Add metadata to our records
+        // Convert first record chunk into parquet rows and append collection metadata
         let rows = read_json_rows(records, context)?;
 
         if rows.is_empty() {
@@ -55,7 +55,7 @@ impl StreamArtifactEncoder for ParquetEncoder {
             )));
         }
 
-        // Based on the parsed data try to create a parquet schema
+        // Infer the parquet schema from the first non-empty record chunk
         let schema = ParquetSchema::infer(&rows);
         let message_type = schema.message_type();
 
@@ -66,7 +66,7 @@ impl StreamArtifactEncoder for ParquetEncoder {
                 .build(),
         );
 
-        // Create the writer to the parquet file
+        // Open the parquet file writer using the inferred schema
         let file =
             File::create(&target.path).map_err(|err| OutputError::io_path(&target.path, err))?;
         let writer =
@@ -77,7 +77,7 @@ impl StreamArtifactEncoder for ParquetEncoder {
             writer,
         };
 
-        // Write the first batch of rows
+        // Write the first chunk as the first parquet row group
         parquet_writer.write_row_group(&rows)?;
 
         Ok(EncoderStreamWriter {
@@ -87,7 +87,9 @@ impl StreamArtifactEncoder for ParquetEncoder {
     }
 }
 
-/// Read `Record` JSON values into rows
+/// Converts JSON record values into parquet rows.
+///
+/// Parquet output currently supports only JSON object records.
 fn read_json_rows(
     records: &mut dyn RecordStream,
     context: &ArtifactContext,
@@ -116,7 +118,7 @@ fn read_json_rows(
     Ok(rows)
 }
 
-/// Data we need to create a parquet writer
+/// Active parquet writer for one streamed artifact output
 #[derive(Debug)]
 pub(crate) struct ParquetWriter {
     /// Full path to the streamed output file
@@ -128,9 +130,7 @@ pub(crate) struct ParquetWriter {
 }
 
 impl ParquetWriter {
-    /// Write `Record` values to disk using the `StreamWriter`
-    ///
-    /// Returns number of records written
+    /// Writes the next record chunk as a parquet row group
     pub(crate) fn write_records(
         &mut self,
         records: &mut dyn RecordStream,
@@ -158,7 +158,7 @@ impl ParquetWriter {
         Ok(())
     }
 
-    /// Write the rows to the parquet file
+    /// Writes rows to the parquet file as one row group
     fn write_row_group(&mut self, rows: &[Map<String, Value>]) -> OutputResult<()> {
         let columns = build_columns(&self.schema, rows);
 
@@ -180,17 +180,17 @@ impl ParquetWriter {
     }
 }
 
-/// The parquet schema implementation
+/// Schema inferred for a streamed parquet artifact
 #[derive(Debug)]
 struct ParquetSchema {
-    /// Column info for our parquet file
+    /// Ordered parquet columns
     columns: Vec<ColumnSpec>,
-    /// Field tracker
+    /// Source field names included in the inferred schema
     known_fields: HashSet<String>,
 }
 
 impl ParquetSchema {
-    /// Try to implement a parquet schema based on artifact keys and values
+    /// Infers a parquet schema from the first chunk of artifact rows
     fn infer(rows: &[Map<String, Value>]) -> Self {
         let mut order = Vec::new();
         let mut kinds: HashMap<String, ColumnKind> = HashMap::new();
@@ -236,7 +236,7 @@ impl ParquetSchema {
         }
     }
 
-    /// Determine schema message type
+    /// Builds the parquet message type string
     fn message_type(&self) -> String {
         let mut message = String::from("message artemis {\n");
         for column in &self.columns {
@@ -256,7 +256,7 @@ impl ParquetSchema {
         message
     }
 
-    /// Make sure each schema field is unique
+    /// Converts a source field name into a unique parquet column name
     fn unique_field_name(source: &str, used: &mut HashSet<String>) -> String {
         let base = Self::sanitize_field_name(source);
         let mut candidate = base.clone();
@@ -299,11 +299,15 @@ impl ParquetSchema {
 /// Data associated with our parquet columns
 #[derive(Debug)]
 struct ColumnSpec {
+    /// Source key of our parquet column name
     source_name: Option<String>,
+    /// The unique parquet column name
     parquet_name: String,
+    /// Column type
     kind: ColumnKind,
 }
 
+/// Common Column value types
 #[derive(Copy, Clone, Debug)]
 enum ColumnKind {
     Bool,
@@ -313,6 +317,7 @@ enum ColumnKind {
 }
 
 impl ColumnKind {
+    /// Convert JSON value to `ColumnKind`
     fn from_value(value: &Value) -> Self {
         match value {
             Value::Bool(_) => Self::Bool,
@@ -332,6 +337,11 @@ impl ColumnKind {
         }
     }
 
+    /// Attempt to merge column types if a key-value has more than one type
+    ///
+    /// Example: `{"value": 1}` and later `{"value": 2.5}`
+    ///
+    /// The column type becomes `ColumnKind::Double`
     fn merge(self, other: Self) -> Self {
         match (self, other) {
             (Self::Utf8, _) | (_, Self::Utf8) => Self::Utf8,
@@ -343,25 +353,35 @@ impl ColumnKind {
     }
 }
 
+/// Data for each column type
 enum ColumnBatch {
     Bool {
+        /// Array of booleans
         values: Vec<bool>,
-        def_levels: Vec<i16>,
+        /// Definition level for the parquet row
+        definition_levels: Vec<i16>,
     },
     Int64 {
+        /// Array of integers
         values: Vec<i64>,
-        def_levels: Vec<i16>,
+        /// Definition level for the parquet row
+        definition_levels: Vec<i16>,
     },
     Double {
+        /// Array of floats
         values: Vec<f64>,
-        def_levels: Vec<i16>,
+        /// Definition level for the parquet row
+        definition_levels: Vec<i16>,
     },
     Utf8 {
+        /// Array of `ByteArray`
         values: Vec<ByteArray>,
-        def_levels: Vec<i16>,
+        /// Definition level for the parquet row
+        definition_levels: Vec<i16>,
     },
 }
 
+/// Assemble columns for the parquet file
 fn build_columns(schema: &ParquetSchema, rows: &[Map<String, Value>]) -> Vec<ColumnBatch> {
     schema
         .columns
@@ -370,6 +390,7 @@ fn build_columns(schema: &ParquetSchema, rows: &[Map<String, Value>]) -> Vec<Col
         .collect()
 }
 
+/// Assemble each column value
 fn build_column(
     schema: &ParquetSchema,
     column: &ColumnSpec,
@@ -383,9 +404,10 @@ fn build_column(
     }
 }
 
+/// Construct boolean column
 fn bool_column(column: &ColumnSpec, rows: &[Map<String, Value>]) -> ColumnBatch {
     let mut values = Vec::new();
-    let mut def_levels = Vec::with_capacity(rows.len());
+    let mut definition_levels = Vec::with_capacity(rows.len());
     for row in rows {
         let value = column
             .source_name
@@ -395,19 +417,23 @@ fn bool_column(column: &ColumnSpec, rows: &[Map<String, Value>]) -> ColumnBatch 
 
         if let Some(val) = value {
             values.push(val);
-            def_levels.push(1);
+            definition_levels.push(1);
             continue;
         }
 
-        def_levels.push(0);
+        definition_levels.push(0);
     }
 
-    ColumnBatch::Bool { values, def_levels }
+    ColumnBatch::Bool {
+        values,
+        definition_levels,
+    }
 }
 
+/// Construct integer column
 fn i64_column(column: &ColumnSpec, rows: &[Map<String, Value>]) -> ColumnBatch {
     let mut values = Vec::new();
-    let mut def_levels = Vec::with_capacity(rows.len());
+    let mut definition_levels = Vec::with_capacity(rows.len());
     for row in rows {
         let value = column
             .source_name
@@ -417,16 +443,20 @@ fn i64_column(column: &ColumnSpec, rows: &[Map<String, Value>]) -> ColumnBatch {
 
         if let Some(val) = value {
             values.push(val);
-            def_levels.push(1);
+            definition_levels.push(1);
             continue;
         }
 
-        def_levels.push(0);
+        definition_levels.push(0);
     }
 
-    ColumnBatch::Int64 { values, def_levels }
+    ColumnBatch::Int64 {
+        values,
+        definition_levels,
+    }
 }
 
+/// Attempt to convert JSON value to integer
 fn value_as_i64(value: &Value) -> Option<i64> {
     let number = value.as_number()?;
     if let Some(val) = number.as_i64() {
@@ -437,9 +467,10 @@ fn value_as_i64(value: &Value) -> Option<i64> {
     i64::try_from(value).ok()
 }
 
+/// Construct float column
 fn f64_column(column: &ColumnSpec, rows: &[Map<String, Value>]) -> ColumnBatch {
     let mut values = Vec::new();
-    let mut def_levels = Vec::with_capacity(rows.len());
+    let mut definition_levels = Vec::with_capacity(rows.len());
     for row in rows {
         let value = column
             .source_name
@@ -449,23 +480,27 @@ fn f64_column(column: &ColumnSpec, rows: &[Map<String, Value>]) -> ColumnBatch {
 
         if let Some(val) = value {
             values.push(val);
-            def_levels.push(1);
+            definition_levels.push(1);
             continue;
         }
 
-        def_levels.push(0);
+        definition_levels.push(0);
     }
 
-    ColumnBatch::Double { values, def_levels }
+    ColumnBatch::Double {
+        values,
+        definition_levels,
+    }
 }
 
+/// Construct string column
 fn utf8_column(
     schema: &ParquetSchema,
     column: &ColumnSpec,
     rows: &[Map<String, Value>],
 ) -> ColumnBatch {
     let mut values = Vec::new();
-    let mut def_levels = Vec::with_capacity(rows.len());
+    let mut definition_levels = Vec::with_capacity(rows.len());
     for row in rows {
         let value = match &column.source_name {
             Some(name) => row.get(name).and_then(value_as_string),
@@ -474,16 +509,20 @@ fn utf8_column(
 
         if let Some(val) = value {
             values.push(ByteArray::from(val.as_str()));
-            def_levels.push(1);
+            definition_levels.push(1);
             continue;
         }
 
-        def_levels.push(0);
+        definition_levels.push(0);
     }
 
-    ColumnBatch::Utf8 { values, def_levels }
+    ColumnBatch::Utf8 {
+        values,
+        definition_levels,
+    }
 }
 
+/// Attempt to convert JSON value to string
 fn value_as_string(value: &Value) -> Option<String> {
     match value {
         Value::Null => None,
@@ -495,6 +534,7 @@ fn value_as_string(value: &Value) -> Option<String> {
     }
 }
 
+/// If later values are identified on the JSON `Record` append them to our `extra_json` column
 fn extra_json(schema: &ParquetSchema, row: &Map<String, Value>) -> Option<String> {
     let mut extra = Map::new();
     for (key, value) in row {
@@ -510,26 +550,51 @@ fn extra_json(schema: &ParquetSchema, row: &Map<String, Value>) -> Option<String
     serde_json::to_string(&Value::Object(extra)).ok()
 }
 
+/// Write the column to the parquet file
 fn write_column(writer: &mut SerializedColumnWriter<'_>, column: ColumnBatch) -> OutputResult<()> {
     match (writer.untyped(), column) {
-        (ColumnWriter::BoolColumnWriter(write), ColumnBatch::Bool { values, def_levels }) => {
+        (
+            ColumnWriter::BoolColumnWriter(write),
+            ColumnBatch::Bool {
+                values,
+                definition_levels,
+            },
+        ) => {
             write
-                .write_batch(&values, Some(&def_levels), None)
+                .write_batch(&values, Some(&definition_levels), None)
                 .map_err(parquet_error)?;
         }
-        (ColumnWriter::Int64ColumnWriter(write), ColumnBatch::Int64 { values, def_levels }) => {
+        (
+            ColumnWriter::Int64ColumnWriter(write),
+            ColumnBatch::Int64 {
+                values,
+                definition_levels,
+            },
+        ) => {
             write
-                .write_batch(&values, Some(&def_levels), None)
+                .write_batch(&values, Some(&definition_levels), None)
                 .map_err(parquet_error)?;
         }
-        (ColumnWriter::DoubleColumnWriter(write), ColumnBatch::Double { values, def_levels }) => {
+        (
+            ColumnWriter::DoubleColumnWriter(write),
+            ColumnBatch::Double {
+                values,
+                definition_levels,
+            },
+        ) => {
             write
-                .write_batch(&values, Some(&def_levels), None)
+                .write_batch(&values, Some(&definition_levels), None)
                 .map_err(parquet_error)?;
         }
-        (ColumnWriter::ByteArrayColumnWriter(write), ColumnBatch::Utf8 { values, def_levels }) => {
+        (
+            ColumnWriter::ByteArrayColumnWriter(write),
+            ColumnBatch::Utf8 {
+                values,
+                definition_levels,
+            },
+        ) => {
             write
-                .write_batch(&values, Some(&def_levels), None)
+                .write_batch(&values, Some(&definition_levels), None)
                 .map_err(parquet_error)?;
         }
         _ => {

--- a/forensics/src/output/encoder/parquet.rs
+++ b/forensics/src/output/encoder/parquet.rs
@@ -49,12 +49,6 @@ impl StreamArtifactEncoder for ParquetEncoder {
         // Convert first record chunk into parquet rows and append collection metadata
         let rows = read_json_rows(records, context)?;
 
-        if rows.is_empty() {
-            return Err(OutputError::Encode(String::from(
-                "cannot create parquet schema from empty data",
-            )));
-        }
-
         // Infer the parquet schema from the first non-empty record chunk
         let schema = ParquetSchema::infer(&rows);
         let message_type = schema.message_type();
@@ -727,12 +721,22 @@ mod tests {
         let context = test_context();
         let encoder = ParquetEncoder;
         let mut records = VecRecordStream::new(Vec::new());
-
-        let err = encoder
+        let opened = encoder
             .encode_stream(target, &mut records, &context)
-            .unwrap_err();
+            .unwrap();
 
-        assert!(err.to_string().contains("cannot create parquet schema"));
+        opened.writer.finish().unwrap();
+        let path = PathBuf::from("./tmp/parquet_empty_first_chunk.parquet");
+
+        let metadata = parquet_metadata(&path);
+        let schema = metadata.file_metadata().schema_descr();
+        let column = schema
+            .columns()
+            .iter()
+            .find(|column| column.name() == "_extra_json")
+            .unwrap();
+
+        assert_eq!(column.physical_type(), parquet::basic::Type::BYTE_ARRAY);
     }
 
     #[test]

--- a/forensics/src/output/manager.rs
+++ b/forensics/src/output/manager.rs
@@ -5,7 +5,7 @@ use crate::{
             artifact_encoder::{Encoder, EncoderMode, StreamWriter},
             factory::build_encoder,
         },
-        error::{OutputError, OutputResult},
+        error::OutputResult,
         record::RecordStream,
         report::{ArtifactRunReport, CollectionReport, hash_artifact_options},
         sink::{

--- a/forensics/src/output/manager.rs
+++ b/forensics/src/output/manager.rs
@@ -270,10 +270,6 @@ impl OutputManager {
         records: &mut dyn RecordStream,
         artifact_context: &ArtifactContext,
     ) -> OutputResult<()> {
-        if !self.artifacts.iter().any(|name| name == artifact_name) {
-            self.artifacts.push(artifact_name.to_string());
-        }
-
         let options_hash = hash_artifact_options(artifact_options)?;
         let should_finish = self.active_stream.as_ref().is_some_and(|act| {
             act.artifact_name != artifact_name || act.artifact_options_hash != options_hash
@@ -300,12 +296,15 @@ impl OutputManager {
 
         self.active_stream = Some(ActiveStream {
             artifact_name: artifact_name.to_string(),
-            artifact_options_hash: hash_artifact_options(artifact_options).unwrap_or_default(),
+            artifact_options_hash: options_hash,
             artifact_options: serde_json::to_value(artifact_options).unwrap_or_default(),
             output_file,
             record_count: open.record_count,
             writer: open.writer,
         });
+        if !self.artifacts.iter().any(|name| name == artifact_name) {
+            self.artifacts.push(artifact_name.to_string());
+        }
         Ok(())
     }
 

--- a/forensics/src/output/manager.rs
+++ b/forensics/src/output/manager.rs
@@ -274,14 +274,16 @@ impl OutputManager {
             self.artifacts.push(artifact_name.to_string());
         }
 
-        if let Some(active) = self.active_stream.as_mut() {
-            if active.artifact_name != artifact_name {
-                return Err(OutputError::Encode(format!(
-                    "stream output for '{}' is still open; finish it before writing '{}'",
-                    active.artifact_name, artifact_name
-                )));
-            }
+        let options_hash = hash_artifact_options(artifact_options)?;
+        let should_finish = self.active_stream.as_ref().is_some_and(|act| {
+            act.artifact_name != artifact_name || act.artifact_options_hash != options_hash
+        });
 
+        if should_finish {
+            self.finish_stream()?;
+        }
+
+        if let Some(active) = self.active_stream.as_mut() {
             let count = active.writer.write_records(records, artifact_context)?;
             active.record_count += count;
             return Ok(());

--- a/forensics/src/output/manager.rs
+++ b/forensics/src/output/manager.rs
@@ -1,8 +1,11 @@
 use crate::{
     output::{
-        context::CollectionContext,
-        encoder::{artifact_encoder::Encoder, factory::build_encoder},
-        error::OutputResult,
+        context::{ArtifactContext, CollectionContext},
+        encoder::{
+            artifact_encoder::{Encoder, EncoderMode, StreamWriter},
+            factory::build_encoder,
+        },
+        error::{OutputError, OutputResult},
         record::RecordStream,
         report::{ArtifactRunReport, CollectionReport, hash_artifact_options},
         sink::{
@@ -14,6 +17,7 @@ use crate::{
 };
 use log::LevelFilter;
 use serde::Serialize;
+use serde_json::Value;
 use simplelog::{Config, WriteLogger};
 
 #[cfg(feature = "boa")]
@@ -34,6 +38,16 @@ pub(crate) struct OutputManager {
     /// Array of artifacts collected from the Artemis execution
     pub(crate) artifact_runs: Vec<ArtifactRunReport>,
     pub(crate) filter: bool,
+    active_stream: Option<ActiveStream>,
+}
+
+struct ActiveStream {
+    artifact_name: String,
+    artifact_options_hash: String,
+    artifact_options: Value,
+    output_file: String,
+    record_count: usize,
+    writer: StreamWriter,
 }
 
 impl OutputManager {
@@ -60,6 +74,7 @@ impl OutputManager {
             artifacts: Vec::new(),
             artifact_runs: Vec::new(),
             filter: false,
+            active_stream: None,
         })
     }
 
@@ -70,19 +85,24 @@ impl OutputManager {
         artifact_options: &T,
         records: &mut dyn RecordStream,
     ) -> OutputResult<()> {
-        let handle = self.write(artifact_name, records)?;
+        match self.encoder.encoder_mode() {
+            EncoderMode::Chunked => {
+                let handle = self.write(artifact_name, records)?;
 
-        if !self.artifacts.iter().any(|name| name == artifact_name) {
-            self.artifacts.push(artifact_name.to_string());
+                if !self.artifacts.iter().any(|name| name == artifact_name) {
+                    self.artifacts.push(artifact_name.to_string());
+                }
+                self.record_completed_artifact_output(
+                    artifact_name,
+                    artifact_options,
+                    handle.location_string(),
+                    handle.record_count,
+                );
+
+                Ok(())
+            }
+            EncoderMode::Streamed => self.write_stream(artifact_name, artifact_options, records),
         }
-        self.record_completed_artifact_output(
-            artifact_name,
-            artifact_options,
-            handle.location_string(),
-            handle.record_count,
-        );
-
-        Ok(())
     }
 
     /// Write a failed artifact run
@@ -105,6 +125,7 @@ impl OutputManager {
 
     /// Complete a Artemis collection execution
     pub(crate) fn finalize(mut self) -> OutputResult<()> {
+        self.finish_stream()?;
         let report = CollectionReport::new(
             &self.config,
             &self.context,
@@ -196,6 +217,144 @@ impl OutputManager {
             self.encoder.mime_type(),
             &mut |writer| self.encoder.encode(records, writer, &artifact_context),
         )
+    }
+
+    fn write_stream<T: Serialize>(
+        &mut self,
+        artifact_name: &str,
+        artifact_options: &T,
+        records: &mut dyn RecordStream,
+    ) -> OutputResult<()> {
+        let artifact_context = self.context.artifact(
+            artifact_name,
+            &self.config.start_time_filter,
+            &self.config.end_time_filter,
+        );
+
+        // If boa is enabled and we have a filter script
+        // Filter records before writing them to Sink
+        #[cfg(feature = "boa")]
+        if self.filter
+            && let Some(script) = &self.config.filter_script
+        {
+            // User should give us a name. But if we do not have one
+            // Use `UnknownFilterScript` as default
+            let filter_name = self
+                .config
+                .filter_name
+                .as_deref()
+                .unwrap_or("UnknownFilterScript");
+            let mut filtered_records = JsFilterRecordStream::new(
+                records,
+                script,
+                artifact_name,
+                filter_name,
+                &self.context,
+            )?;
+
+            return self.write_stream_records(
+                artifact_name,
+                artifact_options,
+                &mut filtered_records,
+                &artifact_context,
+            );
+        }
+
+        self.write_stream_records(artifact_name, artifact_options, records, &artifact_context)
+    }
+
+    fn write_stream_records<T: Serialize>(
+        &mut self,
+        artifact_name: &str,
+        artifact_options: &T,
+        records: &mut dyn RecordStream,
+        artifact_context: &ArtifactContext,
+    ) -> OutputResult<()> {
+        if !self.artifacts.iter().any(|name| name == artifact_name) {
+            self.artifacts.push(artifact_name.to_string());
+        }
+
+        if let Some(active) = self.active_stream.as_mut() {
+            if active.artifact_name != artifact_name {
+                return Err(OutputError::Encode(format!(
+                    "stream output for '{}' is still open; finish it before writing '{}'",
+                    active.artifact_name, artifact_name
+                )));
+            }
+
+            let count = active.writer.write_records(records, artifact_context)?;
+            active.record_count += count;
+            return Ok(());
+        }
+
+        let target = self
+            .sink
+            .stream_artifact(artifact_name, self.encoder.extension())?;
+
+        let output_file = target.path.display().to_string();
+        let open = self
+            .encoder
+            .encode_stream(target, records, artifact_context)?;
+
+        self.active_stream = Some(ActiveStream {
+            artifact_name: artifact_name.to_string(),
+            artifact_options_hash: hash_artifact_options(artifact_options).unwrap_or_default(),
+            artifact_options: serde_json::to_value(artifact_options).unwrap_or_default(),
+            output_file,
+            record_count: open.record_count,
+            writer: open.writer,
+        });
+        Ok(())
+    }
+
+    fn finish_stream(&mut self) -> OutputResult<()> {
+        let Some(output) = self.active_stream.take() else {
+            return Ok(());
+        };
+        let ActiveStream {
+            artifact_name,
+            artifact_options_hash,
+            artifact_options,
+            output_file,
+            record_count,
+            writer,
+        } = output;
+
+        writer.finish()?;
+        self.record_complete_stream(
+            artifact_name,
+            artifact_options_hash,
+            artifact_options,
+            output_file,
+            record_count,
+        );
+        Ok(())
+    }
+
+    fn record_complete_stream(
+        &mut self,
+        artifact_name: String,
+        artifact_option_hash: String,
+        artifact_options: Value,
+        output_file: String,
+        record_count: usize,
+    ) {
+        if let Some(run) = self.artifact_runs.iter_mut().find(|run| {
+            run.name == artifact_name && run.artifact_options_hash == artifact_option_hash
+        }) {
+            run.add_output_file(output_file, record_count);
+            return;
+        }
+
+        let mut run = ArtifactRunReport::new(
+            &artifact_name,
+            &artifact_options,
+            vec![output_file],
+            record_count,
+            "completed",
+        );
+        run.artifact_options_hash = artifact_option_hash;
+        self.artifact_runs.push(run);
     }
 }
 

--- a/forensics/src/output/manager.rs
+++ b/forensics/src/output/manager.rs
@@ -125,6 +125,7 @@ impl OutputManager {
 
     /// Complete a Artemis collection execution
     pub(crate) fn finalize(mut self) -> OutputResult<()> {
+        // Complete any active writer stream
         self.finish_stream()?;
         let report = CollectionReport::new(
             &self.config,
@@ -219,6 +220,9 @@ impl OutputManager {
         )
     }
 
+    /// Write artifact records to our configured destination `Sink`
+    ///
+    /// This writer streams the data to a single on disk
     fn write_stream<T: Serialize>(
         &mut self,
         artifact_name: &str,
@@ -263,6 +267,7 @@ impl OutputManager {
         self.write_stream_records(artifact_name, artifact_options, records, &artifact_context)
     }
 
+    /// Write records to single file on disk
     fn write_stream_records<T: Serialize>(
         &mut self,
         artifact_name: &str,
@@ -308,6 +313,7 @@ impl OutputManager {
         Ok(())
     }
 
+    /// Complete streaming to file on disk
     fn finish_stream(&mut self) -> OutputResult<()> {
         let Some(output) = self.active_stream.take() else {
             return Ok(());
@@ -332,6 +338,7 @@ impl OutputManager {
         Ok(())
     }
 
+    /// Update our artifact run report every time we complete writing records to disk
     fn record_complete_stream(
         &mut self,
         artifact_name: String,

--- a/forensics/src/output/manager.rs
+++ b/forensics/src/output/manager.rs
@@ -984,4 +984,61 @@ mod tests {
         let xml_data = read_to_string(&xml_files[0]).unwrap();
         assert!(xml_data.contains("<path>/tmp/one.txt</path>"));
     }
+
+    #[test]
+    fn test_output_manager_parquet() {
+        let name = String::from("manager_collection_par");
+        let config = OutputConfig {
+            name,
+            endpoint_id: String::from("test"),
+            collection_id: 0,
+            directory: PathBuf::from("./tmp"),
+            destination: OutputDestination::Local,
+            format: OutputFormat::Parquet,
+            ..Default::default()
+        };
+
+        let mut manage = OutputManager::new(config).unwrap();
+        let mut first = Map::new();
+        first.insert("path".to_string(), "/tmp/one.txt".into());
+        first.insert("size".to_string(), 1235.into());
+        let mut second = Map::new();
+        second.insert("path".to_string(), "/tmp/two.txt".into());
+        second.insert("size".to_string(), 5.into());
+        let mut records = VecRecordStream::new(vec![
+            Record::Json(JsonRecord::new(first)),
+            Record::Json(JsonRecord::new(second)),
+        ]);
+
+        manage
+            .write_artifact(
+                "files",
+                &json!({"start_path": "./tmp", "depth": 99}),
+                &mut records,
+            )
+            .unwrap();
+
+        manage.finalize().unwrap();
+
+        let output_dir = PathBuf::from("./tmp").join(String::from("manager_collection_par"));
+        assert!(output_dir.exists());
+
+        let mut par_files = Vec::new();
+        let mut report_files = Vec::new();
+        let mut log_files = Vec::new();
+        for entry in read_dir(&output_dir).unwrap() {
+            let path = entry.unwrap().path();
+            let name = path.file_name().unwrap().to_string_lossy();
+            if name.starts_with("files_") && name.ends_with(".parquet") {
+                par_files.push(path);
+            } else if name.starts_with("report_") && name.ends_with(".json") {
+                report_files.push(path);
+            } else if name.starts_with("artemis_") && name.ends_with(".log") {
+                log_files.push(path);
+            }
+        }
+        assert!(!par_files.is_empty());
+        assert!(!report_files.is_empty());
+        assert!(!log_files.is_empty());
+    }
 }

--- a/forensics/src/output/sink/factory.rs
+++ b/forensics/src/output/sink/factory.rs
@@ -71,6 +71,7 @@ impl Sink {
         }
     }
 
+    /// Stream artifact results to destination
     pub(crate) fn stream_artifact(
         &self,
         artifact_name: &str,

--- a/forensics/src/output/sink/factory.rs
+++ b/forensics/src/output/sink/factory.rs
@@ -75,6 +75,8 @@ impl Sink {
     ) -> OutputResult<StreamTarget> {
         match self {
             Self::Local(sink) => Ok(sink.stream_artifact(artifact_name, extension)),
+
+            #[cfg(any(feature = "gcp", feature = "aws", feature = "azure", feature = "api"))]
             _ => Err(OutputError::Config(String::from(
                 "streamed output only supports local destination",
             ))),

--- a/forensics/src/output/sink/factory.rs
+++ b/forensics/src/output/sink/factory.rs
@@ -1,6 +1,7 @@
 use crate::{
     output::{
-        error::OutputResult,
+        encoder::artifact_encoder::StreamTarget,
+        error::{OutputError, OutputResult},
         report::CollectionReport,
         sink::{
             local::LocalSink,
@@ -64,6 +65,19 @@ impl Sink {
             Self::Azure(sink) => sink.write_artifact(artifact_name, extension, mime_type, encode),
             #[cfg(feature = "api")]
             Self::Api(sink) => sink.write_artifact(artifact_name, extension, mime_type, encode),
+        }
+    }
+
+    pub(crate) fn stream_artifact(
+        &self,
+        artifact_name: &str,
+        extension: &str,
+    ) -> OutputResult<StreamTarget> {
+        match self {
+            Self::Local(sink) => Ok(sink.stream_artifact(artifact_name, extension)),
+            _ => Err(OutputError::Config(String::from(
+                "streamed output only supports local destination",
+            ))),
         }
     }
 

--- a/forensics/src/output/sink/factory.rs
+++ b/forensics/src/output/sink/factory.rs
@@ -1,7 +1,7 @@
 use crate::{
     output::{
         encoder::artifact_encoder::StreamTarget,
-        error::{OutputError, OutputResult},
+        error::OutputResult,
         report::CollectionReport,
         sink::{
             local::LocalSink,
@@ -20,6 +20,9 @@ use crate::output::sink::aws::AwsSink;
 use crate::output::sink::azure::AzureSink;
 #[cfg(feature = "gcp")]
 use crate::output::sink::gcp::GcpSink;
+
+#[cfg(any(feature = "gcp", feature = "aws", feature = "azure", feature = "api"))]
+use crate::output::error::OutputError;
 
 /// Selected destination for encoded output.
 ///

--- a/forensics/src/output/sink/local.rs
+++ b/forensics/src/output/sink/local.rs
@@ -82,7 +82,7 @@ impl LocalSink {
             .collect::<String>();
 
         if santize.is_empty() {
-            santize = String::from("artifact")
+            santize = String::from("artifact");
         }
 
         santize

--- a/forensics/src/output/sink/local.rs
+++ b/forensics/src/output/sink/local.rs
@@ -44,17 +44,20 @@ impl LocalSink {
 
     pub(crate) fn stream_artifact(&self, artifact_name: &str, extension: &str) -> StreamTarget {
         let uuid = generate_uuid();
-        let filename = format!("{artifact_name}_{uuid}.{extension}");
+        let name = Self::safe_artifact_filename(artifact_name);
+        let filename = format!("{name}_{uuid}.{extension}");
         StreamTarget::new(self.output_directory.join(filename))
     }
 
     /// Builds a unique output path for an artifact file
     fn output_path(&self, artifact_name: &str, extension: &str) -> PathBuf {
         let uuid = generate_uuid();
+        let name = Self::safe_artifact_filename(artifact_name);
+
         let filename = if self.compress {
-            format!("{artifact_name}_{uuid}.{extension}.gz")
+            format!("{name}_{uuid}.{extension}.gz")
         } else {
-            format!("{artifact_name}_{uuid}.{extension}")
+            format!("{name}_{uuid}.{extension}")
         };
 
         self.output_directory.join(filename)
@@ -64,6 +67,25 @@ impl LocalSink {
     fn log_path(&self) -> PathBuf {
         let log = format!("artemis_{}_{}.log", self.collection_id, generate_uuid());
         self.output_directory.join(log)
+    }
+
+    fn safe_artifact_filename(artifact_name: &str) -> String {
+        let mut santize = artifact_name
+            .chars()
+            .map(|c| {
+                if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
+                    c
+                } else {
+                    '_'
+                }
+            })
+            .collect::<String>();
+
+        if santize.is_empty() {
+            santize = String::from("artifact")
+        }
+
+        santize
     }
 
     /// Zips the completed local output directory and removes loose output files
@@ -195,5 +217,17 @@ mod tests {
         assert_eq!(handle.extension, "jsonl");
 
         sink.finalize().unwrap();
+    }
+
+    #[test]
+    fn test_safe_artifact_filename() {
+        assert_eq!(LocalSink::safe_artifact_filename("eventlogs"), "eventlogs");
+        assert_eq!(
+            LocalSink::safe_artifact_filename("../eventlogs"),
+            "___eventlogs"
+        );
+        assert_eq!(LocalSink::safe_artifact_filename("foo/bar"), "foo_bar");
+        assert_eq!(LocalSink::safe_artifact_filename(""), "artifact");
+        assert_eq!(LocalSink::safe_artifact_filename("C:\\test"), "C__test");
     }
 }

--- a/forensics/src/output/sink/local.rs
+++ b/forensics/src/output/sink/local.rs
@@ -91,7 +91,7 @@ impl LocalSink {
                 && !entry.ends_with(".jsonl")
                 && !entry.ends_with(".zip")
                 && !entry.ends_with(".xml")
-                && !entry.ends_with("parquet")
+                && !entry.ends_with(".parquet")
             {
                 continue;
             }

--- a/forensics/src/output/sink/local.rs
+++ b/forensics/src/output/sink/local.rs
@@ -1,6 +1,7 @@
 use crate::{
     filesystem::files::list_files,
     output::{
+        encoder::artifact_encoder::StreamTarget,
         error::{OutputError, OutputResult},
         report::CollectionReport,
         sink::{
@@ -39,6 +40,12 @@ impl LocalSink {
             collection_id: config.collection_id,
             compress: config.compress,
         })
+    }
+
+    pub(crate) fn stream_artifact(&self, artifact_name: &str, extension: &str) -> StreamTarget {
+        let uuid = generate_uuid();
+        let filename = format!("{artifact_name}_{uuid}.{extension}");
+        StreamTarget::new(self.output_directory.join(filename))
     }
 
     /// Builds a unique output path for an artifact file
@@ -102,7 +109,7 @@ impl OutputSink for LocalSink {
         artifact_name: &str,
         extension: &str,
         _mime_type: &str,
-        encode: &mut dyn FnMut(&mut dyn std::io::Write) -> OutputResult<usize>,
+        encode: &mut dyn FnMut(&mut dyn Write) -> OutputResult<usize>,
     ) -> OutputResult<OutputHandle> {
         let output_path = self.output_path(artifact_name, extension);
         let file =

--- a/forensics/src/output/sink/local.rs
+++ b/forensics/src/output/sink/local.rs
@@ -91,6 +91,7 @@ impl LocalSink {
                 && !entry.ends_with(".jsonl")
                 && !entry.ends_with(".zip")
                 && !entry.ends_with(".xml")
+                && !entry.ends_with("parquet")
             {
                 continue;
             }

--- a/forensics/src/runtime/run.rs
+++ b/forensics/src/runtime/run.rs
@@ -118,7 +118,7 @@ pub(crate) fn output_data(
                 options,
                 &mut VecRecordStream::new(record_array),
             ) {
-                println!("[runtime] Could not write record from data: {err:?}");
+                error!("[runtime] Could not write record from data: {err:?}");
                 return Err(RuntimeError::Output);
             }
         }

--- a/forensics/src/runtime/system/output.rs
+++ b/forensics/src/runtime/system/output.rs
@@ -47,6 +47,11 @@ pub(crate) fn js_output(
         let issue = String::from("Failed could not output script data");
         return Err(JsError::from_opaque(js_string!(issue).into()));
     }
+    if let Err(err) = manager.finalize() {
+        error!("[runtime] Could not complete record from data: {err:?}");
+        let issue = format!("Could not complete record from data: {err:?}");
+        return Err(JsError::from_opaque(js_string!(issue).into()));
+    }
     let sucess = true;
     Ok(JsValue::new(sucess))
 }

--- a/forensics/src/structs/toml.rs
+++ b/forensics/src/structs/toml.rs
@@ -75,6 +75,7 @@ pub enum OutputFormat {
     /// Plaintext output for `BoaJS` runtime data
     Text,
     Xml,
+    Parquet,
 }
 
 /// Determine where our data should be sent

--- a/forensics/tests/parquet_tester.rs
+++ b/forensics/tests/parquet_tester.rs
@@ -1,0 +1,33 @@
+use forensics::core::parse_toml_file;
+use glob::glob;
+use std::fs::read;
+use std::path::PathBuf;
+
+#[test]
+fn test_parquest_tester() {
+    let mut test_location = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    test_location.push("tests/test_data/linux/parquet.toml");
+
+    parse_toml_file(&test_location.display().to_string()).unwrap();
+    let mut output_location = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    output_location.push("tmp/parquet_tester/*");
+
+    let results = glob(output_location.to_str().unwrap()).unwrap();
+    let mut par_count = 0;
+    for result in results {
+        let value = &result.unwrap();
+        if value.to_str().unwrap().contains("report_") {
+            let bytes = read(value).unwrap();
+            let text = String::from_utf8(bytes).unwrap();
+            if text.contains("\"total_output_files\":0,") {
+                panic!("missing parquest results??");
+            }
+            continue;
+        }
+
+        if value.display().to_string().contains(".parquet") {
+            par_count += 1;
+        }
+    }
+    assert_ne!(par_count, 0);
+}

--- a/forensics/tests/test_data/linux/parquet.toml
+++ b/forensics/tests/test_data/linux/parquet.toml
@@ -1,0 +1,37 @@
+
+[output]
+name = "parquet_tester"
+directory = "./tmp"
+format = "parquet"
+compress = false
+timeline = false
+endpoint_id = "abdc"
+collection_id = 1
+destination = "local"
+
+[[artifacts]]
+artifact_name = "processes"
+[artifacts.processes]
+md5 = false
+sha1 = false
+sha256 = false
+metadata = false
+
+[[artifacts]]
+artifact_name = "systeminfo"
+
+[[artifacts]]
+artifact_name = "journal"
+[artifacts.journal]
+
+[[artifacts]]
+artifact_name = "files" # Name of artifact
+[artifacts.files]
+start_path = "/usr/bin" # Start of file listing
+depth = 5               # How many sub directories to descend
+metadata = true         # Get executable metadata
+md5 = true              # MD5 all files
+sha1 = false            # SHA1 all files
+sha256 = false          # SHA256 all files
+path_regex = ""         # Regex for paths
+file_regex = ""         # Regex for files


### PR DESCRIPTION
This PR adds initial support for outputting results to a single Parquet file. Parquet is a column-oriented data storage format, popular when working with large amounts of data.  Should close #420  


Currently artemis outputs results in streamed chunks.  For example, the eventlog parser streams 1,000 events to a single file.  So every 1k events a new file is created. This keeps output small and makes it easier to do follow up analysis

However, parquet is typically used as a single file. So instead of writing multiple parquet files, this PR implements support for streaming data to a single file on disk.

This implementation writes one parquet file per artifact. So if multiple artifacts are parsed each gets their own parquet file.

The BoaJS runtime is also supported so parquet files can be created for JS runtime artifacts


Examples using [nushell](https://www.nushell.sh/):
```
for VSCode/VSCodium FileHistory (artemis -j main.js)
~/Projects/artemis/target/release> polars open tmp/js_parquet/vscode_history_78166ada-032e-4657-b4a8-f7e67f0b3a4d.parquet | polars schema
╭─────────────────────┬─────╮
│ version             │ i64 │
│ resource            │ str │
│ evidence            │ str │
│ message             │ str │
│ datetime            │ str │
│ timestamp_desc      │ str │
│ artifact            │ str │
│ data_type           │ str │
│ id                  │ str │
│ file_saved          │ str │
│ content             │ str │
│ path                │ str │
│ source              │ str │
│ sourceDescription   │ str │
│ collection_metadata │ str │
│ _extra_json         │ str │
╰─────────────────────┴─────╯
~/Projects/artemis/target/release> polars open tmp/js_parquet/vscode_history_78166ada-032e-4657-b4a8-f7e67f0b3a4d.parquet | polars get message evidence datetime timestamp_desc path
╭─────────────┬─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┬───────────────────────────────────────────────────────────────────────────┬─────────────────────────────────┬───────────────────────┬─────────────────────────────────────────────────────────────────────╮
│           # │                                                               message                                                               │                                 evidence                                  │            datetime             │    timestamp_desc     │                                path                                 │
├─────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────┼─────────────────────────────────┼───────────────────────┼─────────────────────────────────────────────────────────────────────┤
│           0 │ file:///home/ubunty/Downloads/main.ts - History Entry: NmmZ.ts                                                                      │ /home/ubunty/.config/VSCodium/User/History/-1283351e/entries.json         │ 2026-06-15T23:25:45.339Z        │ File Saved            │ /home/ubunty/.config/VSCodium/User/History/-1283351e/NmmZ.ts        │
│           1 │ file:///home/ubunty/Downloads/main.ts - History Entry: jmcJ.ts                                                                      │ /home/ubunty/.config/VSCodium/User/History/-1283351e/entries.json         │ 2026-06-15T23:26:08.446Z        │ File Saved            │ /home/ubunty/.config/VSCodium/User/History/-1283351e/jmcJ.ts        │
│           2 │ file:///home/ubunty/Downloads/main.ts - History Entry: me4M.ts                                                                      │ /home/ubunty/.config/VSCodium/User/History/-1283351e/entries.json         │ 2026-06-15T23:26:14.814Z        │ File Saved            │ /home/ubunty/.config/VSCodium/User/History/-1283351e/me4M.ts        │
│           3 │ file:///home/ubunty/Downloads/main.ts - History Entry: tgO7.ts                                                                      │ /home/ubunty/.config/VSCodium/User/History/-1283351e/entries.json         │ 2026-06-15T23:26:20.773Z        │ File Saved            │ /home/ubunty/.config/VSCodium/User/History/-1283351e/tgO7.ts        │
│           4 │ file:///home/ubunty/Downloads/main.ts - History Entry: 2SIY.ts                                                                      │ /home/ubunty/.config/VSCodium/User/History/-1283351e/entries.json         │ 2026-06-15T23:26:39.896Z        │ File Saved            │ /home/ubunty/.config/VSCodium/User/History/-1283351e/2SIY.ts        │
│           5 │ file:///home/ubunty/Downloads/main.ts - History Entry: HATN.ts                                                                      │ /home/ubunty/.config/VSCodium/User/History/-1283351e/entries.json         │ 2026-06-15T23:27:06.848Z        │ File Saved            │ /home/ubunty/.config/VSCodium/User/History/-1283351e/HATN.ts        │
│           6 │ file:///home/ubunty/Downloads/main.ts - History Entry: yedZ.ts                                                                      │ /home/ubunty/.config/VSCodium/User/History/-1283351e/entries.json         │ 2026-06-15T23:27:23.551Z        │ File Saved            │ /home/ubunty/.config/VSCodium/User/History/-1283351e/yedZ.ts        │
│           7 │ file:///home/ubunty/Downloads/main.ts - History Entry: Lg9x.ts                                                                      │ /home/ubunty/.config/VSCodium/User/History/-1283351e/entries.json         │ 2026-06-15T23:28:18.192Z        │ File Saved            │ /home/ubunty/.config/VSCodium/User/History/-1283351e/Lg9x.ts        │
│           8 │ file:///home/ubunty/Downloads/main.ts - History Entry: sNr3.ts                                                                      │ /home/ubunty/.config/VSCodium/User/History/-1283351e/entries.json         │ 2026-06-15T23:30:21.928Z        │ File Saved            │ /home/ubunty/.config/VSCodium/User/History/-1283351e/sNr3.ts        │
│           9 │ file:///home/ubunty/Downloads/main.ts - History Entry: iQ4v.ts                                                                      │ /home/ubunty/.config/VSCodium/User/History/-1283351e/entries.json         │ 2026-06-15T23:31:51.783Z        │ File Saved            │ /home/ubunty/.config/VSCodium/User/History/-1283351e/iQ4v.ts        │
│         ... │ ...                                                                                                                                 │ ...                                                                       │ ...                             │ ...                   │ ...                                                                 │
│         515 │ file:///home/ubunty/Projects/artemis-api/mod.ts - History Entry: mvbp.ts                                                            │ /home/ubunty/.config/VSCodium/User/History/7e30e8ff/entries.json          │ 2026-06-07T20:22:01.387Z        │ File Saved            │ /home/ubunty/.config/VSCodium/User/History/7e30e8ff/mvbp.ts         │
│         516 │ file:///home/ubunty/Projects/artemis-api/mod.ts - History Entry: FcRT.ts                                                            │ /home/ubunty/.config/VSCodium/User/History/7e30e8ff/entries.json          │ 2026-06-07T20:22:21.385Z        │ File Saved            │ /home/ubunty/.config/VSCodium/User/History/7e30e8ff/FcRT.ts         │
│         517 │ file:///home/ubunty/Projects/artemis/forensics/src/runtime/windows/prefetch.rs - History Entry: 3bw2.rs                             │ /home/ubunty/.config/VSCodium/User/History/7f613af2/entries.json          │ 2026-06-06T20:58:31.144Z        │ File Saved            │ /home/ubunty/.config/VSCodium/User/History/7f613af2/3bw2.rs         │
│         518 │ file:///home/ubunty/Projects/artemis-api/src/macos/alias.ts - History Entry: buTx.ts                                                │ /home/ubunty/.config/VSCodium/User/History/9a4798/entries.json            │ 2026-06-07T21:13:25.969Z        │ File Saved            │ /home/ubunty/.config/VSCodium/User/History/9a4798/buTx.ts           │

```


```
Linux Journal logs (artemis acquire --format parquet journal)
~/Projects/artemis/target/release> polars open tmp/local_collector/journal_2eb7cfd3-95ea-431b-bab0-6458d7d8c6ca.parquet | polars schema 
╭───────────────────────┬─────╮
│ uid                   │ i64 │
│ gid                   │ i64 │
│ pid                   │ i64 │
│ comm                  │ str │
│ priority              │ str │
│ syslog_facility       │ str │
│ thread_id             │ i64 │
│ syslog_identifier     │ str │
│ executable            │ str │
│ cmdline               │ str │
│ cap_effective         │ str │
│ audit_session         │ i64 │
│ audit_loginuid        │ i64 │
│ systemd_cgroup        │ str │
│ systemd_owner_uid     │ i64 │
│ systemd_unit          │ str │
│ systemd_user_unit     │ str │
│ systemd_slice         │ str │
│ systemd_user_slice    │ str │
│ systemd_invocation_id │ str │
│ boot_id               │ str │
│ machine_id            │ str │
│ hostname              │ str │
│ runtime_scope         │ str │
│ source_realtime       │ str │
│ realtime              │ str │
│ transport             │ str │
│ message               │ str │
│ message_id            │ str │
│ unit_result           │ str │
│ code_line             │ i64 │
│ code_function         │ str │
│ code_file             │ str │
│ user_invocation_id    │ str │
│ user_unit             │ str │
│ custom                │ str │
│ seqnum                │ i64 │
│ evidence              │ str │
│ collection_metadata   │ str │
│ _extra_json           │ str │
╰───────────────────────┴─────╯
~/Projects/artemis/target/release> polars open tmp/local_collector/journal_2eb7cfd3-95ea-431b-bab0-6458d7d8c6ca.parquet | polars get message evidence source_realtime | polars first 20
╭────┬──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┬────────────────────────────────────────────────────────────────────────────────────────────────────────┬──────────────────────────╮
│  # │                                                                 message                                                                  │                                                evidence                                                │     source_realtime      │
├────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────┼──────────────────────────┤
│  0 │ /usr/lib/systemd/user/spice-vdagent.service:23: Unknown key 'StandardError' in section [Install], ignoring.                              │ /var/log/journal/b73abcb99b2c4038aa5d55976c260316/user-1000@000652496e160a63-146475ffdd930b6b.journal~ │ 2026-05-18T22:28:24.105Z │
│  1 │ Queued start job for default target default.target.                                                                                      │ /var/log/journal/b73abcb99b2c4038aa5d55976c260316/user-1000@000652496e160a63-146475ffdd930b6b.journal~ │ 2026-05-18T22:28:24.109Z │
│  2 │ Created slice app.slice - User Application Slice.                                                                                        │ /var/log/journal/b73abcb99b2c4038aa5d55976c260316/user-1000@000652496e160a63-146475ffdd930b6b.journal~ │ 2026-05-18T22:28:24.128Z │
│  3 │ Created slice session.slice - User Core Session Slice.                                                                                   │ /var/log/journal/b73abcb99b2c4038aa5d55976c260316/user-1000@000652496e160a63-146475ffdd930b6b.journal~ │ 2026-05-18T22:28:24.128Z │
│  4 │ Started ubuntu-report.path - Pending report trigger for Ubuntu Report.                                                                   │ /var/log/journal/b73abcb99b2c4038aa5d55976c260316/user-1000@000652496e160a63-146475ffdd930b6b.journal~ │ 2026-05-18T22:28:24.128Z │
│  5 │ Started launchpadlib-cache-clean.timer - Clean up old files in the Launchpadlib cache.                                                   │ /var/log/journal/b73abcb99b2c4038aa5d55976c260316/user-1000@000652496e160a63-146475ffdd930b6b.journal~ │ 2026-05-18T22:28:24.128Z │
│  6 │ Started snap.firmware-updater.firmware-notifier.timer - Timer firmware-notifier for snap application firmware-updater.firmware-notifier. │ /var/log/journal/b73abcb99b2c4038aa5d55976c260316/user-1000@000652496e160a63-146475ffdd930b6b.journal~ │ 2026-05-18T22:28:24.129Z │
│  7 │ Started ubuntu-insights-collect.timer - "Run Ubuntu-Insights collect 5 mins after boot and every month relative to the activation time". │ /var/log/journal/b73abcb99b2c4038aa5d55976c260316/user-1000@000652496e160a63-146475ffdd930b6b.journal~ │ 2026-05-18T22:28:24.129Z │
│  8 │ Started ubuntu-insights-upload.timer - "Run Ubuntu-Insights upload 8 mins after boot and every week relative to the activation time".    │ /var/log/journal/b73abcb99b2c4038aa5d55976c260316/user-1000@000652496e160a63-146475ffdd930b6b.journal~ │ 2026-05-18T22:28:24.129Z │
│  9 │ Reached target paths.target - Paths.                                                                                                     │ /var/log/journal/b73abcb99b2c4038aa5d55976c260316/user-1000@000652496e160a63-146475ffdd930b6b.journal~ │ 2026-05-18T22:28:24.129Z │
│ 10 │ Reached target timers.target - Timers.                                                                                                   │ /var/log/journal/b73abcb99b2c4038aa5d55976c260316/user-1000@000652496e160a63-146475ffdd930b6b.journal~ │ 2026-05-18T22:28:24.129Z │
│ 11 │ Starting dbus.socket - D-Bus User Message Bus Socket...                                                                                  │ /var/log/journal/b73abcb99b2c4038aa5d55976c260316/user-1000@000652496e160a63-146475ffdd930b6b.journal~ │ 2026-05-18T22:28:24.129Z │
│ 12 │ Listening on dirmngr.socket - GnuPG network certificate management daemon.                                                               │ /var/log/journal/b73abcb99b2c4038aa5d55976c260316/user-1000@000652496e160a63-146475ffdd930b6b.journal~ │ 2026-05-18T22:28:24.129Z │
│ 13 │ Listening on gnome-keyring-daemon.socket - GNOME Keyring daemon.                                                                         │ /var/log/journal/b73abcb99b2c4038aa5d55976c260316/user-1000@000652496e160a63-146475ffdd930b6b.journal~ │ 2026-05-18T22:28:24.129Z │
│ 14 │ Listening on gpg-agent-browser.socket - GnuPG cryptographic agent and passphrase cache (access for web browsers).                        │ /var/log/journal/b73abcb99b2c4038aa5d55976c260316/user-1000@000652496e160a63-146475ffdd930b6b.journal~ │ 2026-05-18T22:28:24.129Z │
│ 15 │ Listening on gpg-agent-extra.socket - GnuPG cryptographic agent and passphrase cache (restricted).                                       │ /var/log/journal/b73abcb99b2c4038aa5d55976c260316/user-1000@000652496e160a63-146475ffdd930b6b.journal~ │ 2026-05-18T22:28:24.129Z │
│ 16 │ Starting gpg-agent.socket - GnuPG cryptographic agent and passphrase cache...                                                            │ /var/log/journal/b73abcb99b2c4038aa5d55976c260316/user-1000@000652496e160a63-146475ffdd930b6b.journal~ │ 2026-05-18T22:28:24.130Z │
│ 17 │ Listening on keyboxd.socket - GnuPG public key management service.                                                                       │ /var/log/journal/b73abcb99b2c4038aa5d55976c260316/user-1000@000652496e160a63-146475ffdd930b6b.journal~ │ 2026-05-18T22:28:24.130Z │
│ 18 │ Listening on pipewire-pulse.socket - PipeWire PulseAudio.                                                                                │ /var/log/journal/b73abcb99b2c4038aa5d55976c260316/user-1000@000652496e160a63-146475ffdd930b6b.journal~ │ 2026-05-18T22:28:24.130Z │
│ 19 │ Listening on pipewire.socket - PipeWire Multimedia System Sockets.                                                                       │ /var/log/journal/b73abcb99b2c4038aa5d55976c260316/user-1000@000652496e160a63-146475ffdd930b6b.journal~ │ 2026-05-18T22:28:24.130Z │
╰────┴──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────────────────────────────────────────────────────┴──────────────────────────╯
```

Users can output to parquet file using the format flag `--format parquet`

Streaming to a parquet file will use a bit more memory than streaming to a CSV or JSONL file since artemis needs to convert the data to a columnar structure. In addition, it will be a little bit slower since it needs to convert the data  to a columnar structure.


Also currently parquet format only supports outputting to local system. Remote uploads not supported yet
