### PR TITLE
Migrate linux artifacts to accessor

### DIFF
--- a/forensics/src/accessor/filesystem/ntfs/attributes.rs
+++ b/forensics/src/accessor/filesystem/ntfs/attributes.rs
@@ -65,8 +65,8 @@ pub(crate) fn read_attribute_data<T: Read + Seek>(
 ) -> AccessorResult<Vec<u8>> {
     // We need to walk the raw Attribute List
     // In case the attribute we want to really large
-    let mut attrs_raw = file.attributes_raw();
-    while let Some(item) = attrs_raw.next() {
+    let attrs_raw = file.attributes_raw();
+    for item in attrs_raw {
         let item = item.map_err(ntfs_err)?;
 
         // Large attribute, need to iterate through the AttributeList to find it
@@ -175,10 +175,10 @@ pub(crate) fn read_data_runs<T: Read + Seek>(
         return Ok(out);
     }
 
-    return Err(AccessorError::Ntfs {
+    Err(AccessorError::Ntfs {
         path: None,
         reason: format!("file has no non-resident `{stream_name}` stream"),
-    });
+    })
 }
 
 /// Get the attribute bytes

--- a/forensics/src/accessor/location/loc.rs
+++ b/forensics/src/accessor/location/loc.rs
@@ -395,7 +395,7 @@ mod tests {
             SourcePath::new(PathBuf::from("test.zip"))
         );
         assert_eq!(loc.scheme, Scheme::Zip);
-        assert_eq!(loc.inner_path.display(), "var/log");
+        assert!(loc.inner_path.display().contains("var"));
         assert_eq!(pattern, "wtmp");
     }
 

--- a/forensics/src/accessor/location/loc.rs
+++ b/forensics/src/accessor/location/loc.rs
@@ -152,7 +152,7 @@ impl Location {
         if pattern.is_empty() {
             return Err(AccessorError::location(
                 value,
-                "glob pattern must contain a wildcard",
+                "empty glob pattern must contain a wildcard",
             ));
         }
 

--- a/forensics/src/accessor/location/loc.rs
+++ b/forensics/src/accessor/location/loc.rs
@@ -447,7 +447,7 @@ mod tests {
     }
 
     #[test]
-    fn test_glob_zip_root() {
+    fn test_glob_zip_root_path() {
         let (loc, pattern) = Location::split_glob_pattern("zip:test.zip!/").unwrap();
         assert_eq!(pattern, "*");
         assert_eq!(loc.scheme, Scheme::Zip);

--- a/forensics/src/accessor/location/loc.rs
+++ b/forensics/src/accessor/location/loc.rs
@@ -458,7 +458,7 @@ mod tests {
     fn test_glob_zip_folder() {
         let (loc, pattern) = Location::split_glob_pattern("zip:test.zip!var/log/").unwrap();
         assert_eq!(pattern, "*");
-        assert_eq!(loc.inner_path.display(), "var/log");
+        assert!(loc.inner_path.display().contains("var"));
     }
 
     #[test]

--- a/forensics/src/accessor/location/loc.rs
+++ b/forensics/src/accessor/location/loc.rs
@@ -155,6 +155,10 @@ impl Location {
             None => (String::new(), value.to_string()),
         };
 
+        if value.ends_with(['/', '\\']) && pattern.is_empty() {
+            return Ok((location_part, String::from("*")));
+        }
+
         if pattern.is_empty() {
             return Err(AccessorError::location(
                 value,
@@ -308,8 +312,9 @@ fn parse_inner_path(scheme: Scheme, remainder: &str) -> AccessorResult<InnerPath
 mod tests {
     use crate::accessor::{
         error::AccessorError,
-        location::{loc::Location, scheme::Scheme},
+        location::{loc::Location, path::SourcePath, scheme::Scheme},
     };
+    use std::path::PathBuf;
 
     #[test]
     fn test_location() {
@@ -376,10 +381,13 @@ mod tests {
 
     #[test]
     fn test_location_glob_exact_path() {
-        let (loc, pattern) = Location::split_glob_pattern("/var/log/wtmp").unwrap();
-        assert!(loc.source.is_none());
-        assert_eq!(loc.scheme, Scheme::Host);
-        assert_eq!(loc.inner_path.display(), "/var/log");
+        let (loc, pattern) = Location::split_glob_pattern("zip:test.zip!var/log/wtmp").unwrap();
+        assert_eq!(
+            loc.source.unwrap(),
+            SourcePath::new(PathBuf::from("test.zip"))
+        );
+        assert_eq!(loc.scheme, Scheme::Zip);
+        assert_eq!(loc.inner_path.display(), "var/log");
         assert_eq!(pattern, "wtmp");
     }
 
@@ -413,5 +421,35 @@ mod tests {
         assert_eq!(loc.scheme, Scheme::Host);
         assert_eq!(loc.inner_path.display(), r"C:\Windows\System32\config");
         assert_eq!(pattern, "SAM");
+    }
+
+    #[test]
+    fn test_glob_root() {
+        let (loc, pattern) = Location::split_glob_pattern("/").unwrap();
+        assert_eq!(pattern, "*");
+        assert_eq!(loc.inner_path.display(), "/");
+    }
+
+    #[test]
+    fn test_glob_zip_root() {
+        let err = Location::split_glob_pattern("zip:test.zip!").unwrap_err();
+        assert!(
+            matches!(err, AccessorError::Location { input, reason } if input == "" && reason == "glob input cannot be empty")
+        );
+    }
+
+    #[test]
+    fn test_glob_zip_bad_root() {
+        let err = Location::split_glob_pattern("zip:test.zip!/").unwrap_err();
+        assert!(
+            matches!(err, AccessorError::Location { input, reason } if input == "/" && reason == "container paths must be relative to the archive root")
+        );
+    }
+
+    #[test]
+    fn test_glob_zip_folder() {
+        let (loc, pattern) = Location::split_glob_pattern("zip:test.zip!var/log/").unwrap();
+        assert_eq!(pattern, "*");
+        assert_eq!(loc.inner_path.display(), "var/log");
     }
 }

--- a/forensics/src/accessor/location/loc.rs
+++ b/forensics/src/accessor/location/loc.rs
@@ -122,6 +122,12 @@ impl Location {
                 source: None,
                 inner_path: InnerPath::empty(),
             }
+        } else if matches!(directory.as_str(), "\\" | "/") {
+            Self {
+                scheme: Scheme::Host,
+                source: None,
+                inner_path: InnerPath::new(PathBuf::from(&directory)),
+            }
         } else {
             Self::parse(directory.trim_end_matches('/').trim_end_matches('\\'))?
         };
@@ -139,14 +145,14 @@ impl Location {
         let glob_at = value
             .char_indices()
             .find(|(_, ch)| matches!(ch, '*' | '?' | '['))
-            .map(|(index, _)| index)
-            .ok_or_else(|| {
-                AccessorError::location(input, "glob pattern must contain a wildcard")
-            })?;
+            .map_or(value.len(), |(index, _)| index);
 
         let (location_part, pattern) = match value[..glob_at].rfind(['/', '\\']) {
+            Some(0) if matches!(value.as_bytes().first(), Some(b'/' | b'\\')) => {
+                (value[..1].to_string(), value[1..].to_string())
+            }
             Some(sep) => (value[..sep].to_string(), value[sep + 1..].to_string()),
-            None => (String::new(), value[glob_at..].to_string()),
+            None => (String::new(), value.to_string()),
         };
 
         if pattern.is_empty() {
@@ -366,5 +372,46 @@ mod tests {
         assert_eq!(loc.scheme, Scheme::Host);
         assert_eq!(loc.inner_path.display(), r"C:\Users");
         assert_eq!(pattern, r"*\NTUSER*");
+    }
+
+    #[test]
+    fn test_location_glob_exact_path() {
+        let (loc, pattern) = Location::split_glob_pattern("/var/log/wtmp").unwrap();
+        assert!(loc.source.is_none());
+        assert_eq!(loc.scheme, Scheme::Host);
+        assert_eq!(loc.inner_path.display(), "/var/log");
+        assert_eq!(pattern, "wtmp");
+    }
+
+    #[test]
+    fn test_location_glob_exact_root_child() {
+        let (loc, pattern) = Location::split_glob_pattern("/wtmp").unwrap();
+        assert_eq!(loc.scheme, Scheme::Host);
+        assert_eq!(loc.inner_path.display(), "/");
+        assert_eq!(pattern, "wtmp");
+    }
+
+    #[test]
+    fn test_location_glob_exact_backslash_root_child() {
+        let (loc, pattern) = Location::split_glob_pattern(r"\wtmp").unwrap();
+        assert_eq!(loc.scheme, Scheme::Host);
+        assert_eq!(loc.inner_path.display(), r"\");
+        assert_eq!(pattern, "wtmp");
+    }
+
+    #[test]
+    fn test_parse_glob_pattern_exact_relative() {
+        let (directory, pattern) = Location::parse_glob_pattern("wtmp").unwrap();
+        assert!(directory.is_empty());
+        assert_eq!(pattern, "wtmp");
+    }
+
+    #[test]
+    fn test_location_glob_exact_windows_path() {
+        let (loc, pattern) =
+            Location::split_glob_pattern(r"C:\Windows\System32\config\SAM").unwrap();
+        assert_eq!(loc.scheme, Scheme::Host);
+        assert_eq!(loc.inner_path.display(), r"C:\Windows\System32\config");
+        assert_eq!(pattern, "SAM");
     }
 }

--- a/forensics/src/accessor/location/loc.rs
+++ b/forensics/src/accessor/location/loc.rs
@@ -447,7 +447,7 @@ mod tests {
     }
 
     #[test]
-    fn test_glob_zip_bad_root() {
+    fn test_glob_zip_root() {
         let (loc, pattern) = Location::split_glob_pattern("zip:test.zip!/").unwrap();
         assert_eq!(pattern, "*");
         assert_eq!(loc.scheme, Scheme::Zip);

--- a/forensics/src/accessor/location/loc.rs
+++ b/forensics/src/accessor/location/loc.rs
@@ -105,6 +105,9 @@ impl Location {
         // 'zip:test.zip!*' or 'ntfs:image.raw!/users/*/*.txt'
         if let Some((source_path, inner_glob)) = input.split_once('!') {
             let (directory, pattern) = Self::parse_glob_pattern(inner_glob)?;
+            // If the user provides a glob path of "zip:test.zip!/"
+            // Trim forward or backslash and just glob the root directory
+            let directory = directory.trim_start_matches(['/', '\\']);
             let location_str = if directory.is_empty() {
                 source_path.to_string()
             } else {
@@ -155,6 +158,7 @@ impl Location {
             None => (String::new(), value.to_string()),
         };
 
+        // If the user provide a directory path but no pattern. Treat as a single glob
         if value.ends_with(['/', '\\']) && pattern.is_empty() {
             return Ok((location_part, String::from("*")));
         }
@@ -312,7 +316,11 @@ fn parse_inner_path(scheme: Scheme, remainder: &str) -> AccessorResult<InnerPath
 mod tests {
     use crate::accessor::{
         error::AccessorError,
-        location::{loc::Location, path::SourcePath, scheme::Scheme},
+        location::{
+            loc::Location,
+            path::{InnerPath, SourcePath},
+            scheme::Scheme,
+        },
     };
     use std::path::PathBuf;
 
@@ -440,10 +448,10 @@ mod tests {
 
     #[test]
     fn test_glob_zip_bad_root() {
-        let err = Location::split_glob_pattern("zip:test.zip!/").unwrap_err();
-        assert!(
-            matches!(err, AccessorError::Location { input, reason } if input == "/" && reason == "container paths must be relative to the archive root")
-        );
+        let (loc, pattern) = Location::split_glob_pattern("zip:test.zip!/").unwrap();
+        assert_eq!(pattern, "*");
+        assert_eq!(loc.scheme, Scheme::Zip);
+        assert_eq!(loc.inner_path, InnerPath::new(PathBuf::from("")));
     }
 
     #[test]
@@ -451,5 +459,12 @@ mod tests {
         let (loc, pattern) = Location::split_glob_pattern("zip:test.zip!var/log/").unwrap();
         assert_eq!(pattern, "*");
         assert_eq!(loc.inner_path.display(), "var/log");
+    }
+
+    #[test]
+    fn test_glob_folder() {
+        let (loc, pattern) = Location::split_glob_pattern("C:\\Windows\\System32\\").unwrap();
+        assert_eq!(pattern, "*");
+        assert_eq!(loc.inner_path.display(), "C:\\Windows\\System32");
     }
 }

--- a/forensics/src/accessor/mod.rs
+++ b/forensics/src/accessor/mod.rs
@@ -1,9 +1,9 @@
 pub(crate) mod access;
 mod cache;
 pub(crate) mod config;
-mod entry;
+pub(crate) mod entry;
 pub(crate) mod error;
 mod filesystem;
-mod io;
+pub(crate) mod io;
 mod location;
 pub(crate) mod source;

--- a/forensics/src/artifacts/os/linux/executable/parser.rs
+++ b/forensics/src/artifacts/os/linux/executable/parser.rs
@@ -1,3 +1,4 @@
+use crate::accessor::access::Accessor;
 /**
  * Linux Executable and Linkable Format `ELF` is the native executable format of Linux programs  
  * We currently parse out basic amount of metadata
@@ -9,17 +10,16 @@
  *   `https://github.com/radareorg/radare2`  
  *   `https://lief-project.github.io/`
  */
-use crate::filesystem::files::{file_reader, file_too_large};
 use common::linux::ElfInfo;
-use elf::ElfBytes;
 use elf::endian::AnyEndian;
-use std::io::{Error, ErrorKind, Read, Seek, SeekFrom};
+use elf::{ElfBytes, ParseError};
+use std::io::{Error, ErrorKind, Read};
 use tracing::error;
 
 /// Parse an `ELF` file at provided path
-pub(crate) fn parse_elf_file(path: &str) -> Result<ElfInfo, elf::parse::ParseError> {
-    let reader_result = file_reader(path);
-    let mut reader = match reader_result {
+pub(crate) fn parse_elf_file(path: &str) -> Result<ElfInfo, ParseError> {
+    let mut accessor = Accessor::with_defaults();
+    let mut reader = match accessor.open_reader(path) {
         Ok(result) => result,
         Err(err) => {
             error!("Could not get reader for {path}: {err:?}");
@@ -29,6 +29,8 @@ pub(crate) fn parse_elf_file(path: &str) -> Result<ElfInfo, elf::parse::ParseErr
             )));
         }
     };
+
+    // Read a few bytes to check for magic signature
     let mut buff = [0; 4];
     if reader.read(&mut buff).is_err() {
         return Err(elf::ParseError::IOError(Error::new(
@@ -41,31 +43,14 @@ pub(crate) fn parse_elf_file(path: &str) -> Result<ElfInfo, elf::parse::ParseErr
         return Err(elf::ParseError::BadMagic(buff));
     }
 
-    if reader.seek(SeekFrom::Start(0)).is_err() {
-        return Err(elf::ParseError::IOError(Error::new(
-            ErrorKind::InvalidData,
-            "Could not seek to start",
-        )));
-    }
-
-    if file_too_large(path) {
-        return Err(elf::ParseError::IOError(Error::new(
-            ErrorKind::InvalidInput,
-            "File larger than 2GB",
-        )));
-    }
-
-    let mut data = Vec::new();
-
-    // Allow File read_to_end because we partially read the file above to check for Magic Header
-    #[allow(clippy::verbose_file_reads)]
-    let data_result = reader.read_to_end(&mut data);
-    match data_result {
-        Ok(_) => {}
-        Err(_) => {
+    // Read the ELF binary
+    // The `Accessor` will auto reject files larger than 2GB
+    let data = match accessor.read_file(path) {
+        Ok(result) => result,
+        Err(err) => {
             return Err(elf::ParseError::IOError(Error::new(
-                ErrorKind::InvalidInput,
-                "Could not read file to end",
+                ErrorKind::InvalidData,
+                err,
             )));
         }
     };

--- a/forensics/src/artifacts/os/linux/journals/header.rs
+++ b/forensics/src/artifacts/os/linux/journals/header.rs
@@ -6,7 +6,7 @@ use nom::bytes::complete::take;
 
 #[derive(Debug)]
 pub(crate) struct JournalHeader {
-    _sig: u64,
+    pub(crate) sig: u64,
     _compatible_flags: Vec<CompatFlags>,
     pub(crate) incompatible_flags: Vec<IncompatFlags>,
     _state: State,
@@ -107,7 +107,7 @@ impl JournalHeader {
         let version_252 = 264;
 
         let mut journal_header = JournalHeader {
-            _sig: sig,
+            sig,
             _compatible_flags: JournalHeader::compat_flags(compatible_flags),
             incompatible_flags: JournalHeader::incompat_flags(incompatible_flags),
             _state: JournalHeader::journal_state(state),
@@ -271,7 +271,7 @@ mod tests {
             120, 59, 0, 174, 1, 0, 0,
         ];
         let (_, result) = JournalHeader::parse_header(&test_data).unwrap();
-        assert_eq!(result._sig, 5211307194293375052);
+        assert_eq!(result.sig, 5211307194293375052);
         assert!(result._compatible_flags.is_empty());
         assert_eq!(
             result.incompatible_flags,

--- a/forensics/src/artifacts/os/linux/journals/journal.rs
+++ b/forensics/src/artifacts/os/linux/journals/journal.rs
@@ -7,24 +7,28 @@ use super::{
     },
 };
 use crate::{
-    filesystem::files::file_reader, output::manager::OutputManager,
+    accessor::{access::Accessor, entry::handle::FileHandle, io::reader::AccessorReader},
+    output::manager::OutputManager,
     structs::artifacts::os::linux::JournalOptions,
 };
 use common::linux::Journal;
-use std::{collections::HashSet, fs::File, io::Read};
+use std::{collections::HashSet, io::Read};
 use tracing::error;
 
 /// Parse provided `Journal` file path. Will output results when finished. Use `parse_journal_file` if you want the results
 pub(crate) fn parse_journal(
-    path: &str,
+    accessor: &mut Accessor,
+    file: &FileHandle,
     manager: &mut OutputManager,
     options: &JournalOptions,
 ) -> Result<(), JournalError> {
-    let reader_result = file_reader(path);
-    let mut reader = match reader_result {
+    let mut reader = match accessor.open_reader_handle(file) {
         Ok(result) => result,
         Err(err) => {
-            error!("Could not create reader for file {path}: {err:?}");
+            error!(
+                "Could not create reader for file {}: {err:?}",
+                file.display_path()
+            );
             return Err(JournalError::ReaderError);
         }
     };
@@ -32,7 +36,7 @@ pub(crate) fn parse_journal(
     // We technically only need first 232 bytes but version 252 is 264 bytes in size
     let mut header_buff = [0; 264];
     if reader.read(&mut header_buff).is_err() {
-        error!("Could not read file header {path}");
+        error!("Could not read file header {}", file.display_path());
         return Err(JournalError::ReadError);
     }
 
@@ -40,7 +44,7 @@ pub(crate) fn parse_journal(
     let journal_header = match header_result {
         Ok((_, result)) => result,
         Err(_err) => {
-            error!("Could not parser file header {path}");
+            error!("Could not parser file header {}", file.display_path());
             return Err(JournalError::JournalHeader);
         }
     };
@@ -55,27 +59,21 @@ pub(crate) fn parse_journal(
         is_compact,
         manager,
         options,
-        path,
+        file,
     )?;
 
     Ok(())
 }
 
 /// Parse provided `Journal` file path. Returns parsed entries.
-pub(crate) fn parse_journal_file(path: &str) -> Result<Vec<Journal>, JournalError> {
-    let reader_result = file_reader(path);
-    let mut reader = match reader_result {
-        Ok(result) => result,
-        Err(err) => {
-            error!("Could not create reader for file {path}: {err:?}");
-            return Err(JournalError::ReaderError);
-        }
-    };
-
+pub(crate) fn parse_journal_file(
+    reader: &mut AccessorReader,
+    file: &FileHandle,
+) -> Result<Vec<Journal>, JournalError> {
     // We technically only need first 232 bytes but version 252 is 264 bytes in size
     let mut header_buff = [0; 264];
     if reader.read(&mut header_buff).is_err() {
-        error!("Could not read file header {path}");
+        error!("Could not read file header {}", file.display_path());
         return Err(JournalError::ReadError);
     }
 
@@ -83,10 +81,16 @@ pub(crate) fn parse_journal_file(path: &str) -> Result<Vec<Journal>, JournalErro
     let journal_header = match header_result {
         Ok((_, result)) => result,
         Err(_err) => {
-            error!("Could not parser file header {path}");
+            error!("Could not parse file header {}", file.display_path());
             return Err(JournalError::JournalHeader);
         }
     };
+
+    let signature = 5211307194293375052;
+    if journal_header.sig != signature {
+        error!("Bad journal header signature {}", file.display_path());
+        return Err(JournalError::JournalHeader);
+    }
 
     let is_compact = journal_header
         .incompatible_flags
@@ -105,17 +109,17 @@ pub(crate) fn parse_journal_file(path: &str) -> Result<Vec<Journal>, JournalErro
     };
 
     while offset != last_entry {
-        let object_header = ObjectHeader::parse_header(&mut reader, offset)?;
+        let object_header = ObjectHeader::parse_header(reader, offset)?;
         if object_header.obj_type != ObjectType::EntryArray {
             error!(
-                "Did not get Entry Array type at entry_array_offset. Got: {:?}. Exiting for {path}",
-                object_header.obj_type
+                "Did not get Entry Array type at entry_array_offset. Got: {:?}. Exiting for {}",
+                object_header.obj_type,
+                file.display_path()
             );
             break;
         }
 
-        let entry_result =
-            EntryArray::walk_all_entries(&mut reader, &object_header.payload, is_compact);
+        let entry_result = EntryArray::walk_all_entries(reader, &object_header.payload, is_compact);
         let mut entry_array = match entry_result {
             Ok((_, result)) => result,
             Err(_err) => {
@@ -133,19 +137,19 @@ pub(crate) fn parse_journal_file(path: &str) -> Result<Vec<Journal>, JournalErro
         }
     }
 
-    let messages = EntryArray::parse_messages(&entries.entries, path);
+    let messages = EntryArray::parse_messages(&entries.entries, file);
 
     Ok(messages)
 }
 
 /// Loop through the `Journal` entries and get the data
 fn get_entries(
-    reader: &mut File,
+    reader: &mut AccessorReader,
     array_offset: u64,
     is_compact: bool,
     manager: &mut OutputManager,
     options: &JournalOptions,
-    evidence: &str,
+    evidence: &FileHandle,
 ) -> Result<(), JournalError> {
     let mut offset = array_offset;
     let last_entry = 0;
@@ -158,8 +162,9 @@ fn get_entries(
         let object_header = ObjectHeader::parse_header(reader, offset)?;
         if object_header.obj_type != ObjectType::EntryArray {
             error!(
-                "Did not get Entry Array type at entry_array_offset. Got: {:?}. Exiting for {evidence}",
-                object_header.obj_type
+                "Did not get Entry Array type at entry_array_offset. Got: {:?}. Exiting for {}",
+                object_header.obj_type,
+                evidence.display_path()
             );
             break;
         }
@@ -195,8 +200,8 @@ fn get_entries(
 mod tests {
     use super::{get_entries, parse_journal};
     use crate::{
+        accessor::{access::Accessor, entry::handle::FileHandle},
         artifacts::os::linux::journals::journal::parse_journal_file,
-        filesystem::files::file_reader,
         output::manager::OutputManager,
         structs::{
             artifacts::os::linux::JournalOptions,
@@ -224,8 +229,11 @@ mod tests {
         test_location.push("tests/test_data/linux/journal/user-1000@e755452aab34485787b6d73f3035fb8c-000000000000068d-0005ff8ae923c73b.journal");
         let mut output = output_options("journal_test", "./tmp", false);
 
+        let mut accessor = Accessor::with_defaults();
+        let file = FileHandle::host(test_location);
         parse_journal(
-            &test_location.display().to_string(),
+            &mut accessor,
+            &file,
             &mut output,
             &JournalOptions { alt_dir: None },
         )
@@ -237,7 +245,9 @@ mod tests {
         let mut test_location = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_location.push("tests/test_data/linux/journal/user-1000@e755452aab34485787b6d73f3035fb8c-000000000000068d-0005ff8ae923c73b.journal");
 
-        let mut reader = file_reader(&test_location.display().to_string()).unwrap();
+        let mut reader = Accessor::with_defaults()
+            .open_reader(test_location.to_str().unwrap())
+            .unwrap();
         let mut output = output_options("journal_test", "./tmp", false);
         get_entries(
             &mut reader,
@@ -245,7 +255,7 @@ mod tests {
             true,
             &mut output,
             &JournalOptions { alt_dir: None },
-            test_location.to_str().unwrap(),
+            &FileHandle::host(test_location),
         )
         .unwrap();
     }
@@ -254,8 +264,10 @@ mod tests {
     fn test_parse_journal_file() {
         let mut test_location = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_location.push("tests/test_data/linux/journal/user-1000@e755452aab34485787b6d73f3035fb8c-000000000000068d-0005ff8ae923c73b.journal");
-
-        let result = parse_journal_file(&test_location.display().to_string()).unwrap();
+        let mut reader = Accessor::with_defaults()
+            .open_reader(test_location.to_str().unwrap())
+            .unwrap();
+        let result = parse_journal_file(&mut reader, &FileHandle::host(test_location)).unwrap();
         assert_eq!(result.len(), 410);
     }
 
@@ -263,8 +275,10 @@ mod tests {
     fn test_parse_journal_bad_file() {
         let mut test_location = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_location.push("tests/test_data/linux/journal/bad_recursive.journal");
-
-        let result = parse_journal_file(&test_location.display().to_string()).unwrap();
+        let mut reader = Accessor::with_defaults()
+            .open_reader(test_location.to_str().unwrap())
+            .unwrap();
+        let result = parse_journal_file(&mut reader, &FileHandle::host(test_location)).unwrap();
         assert_eq!(result.len(), 4);
     }
 
@@ -273,9 +287,11 @@ mod tests {
         let mut test_location = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_location.push("tests/test_data/linux/journal/bad_recursive.journal");
         let mut output = output_options("journal_test", "./tmp", false);
+        let mut accessor = Accessor::with_defaults();
 
         parse_journal(
-            &test_location.display().to_string(),
+            &mut accessor,
+            &FileHandle::host(test_location),
             &mut output,
             &JournalOptions { alt_dir: None },
         )

--- a/forensics/src/artifacts/os/linux/journals/journal.rs
+++ b/forensics/src/artifacts/os/linux/journals/journal.rs
@@ -49,6 +49,12 @@ pub(crate) fn parse_journal(
         }
     };
 
+    let signature = 5211307194293375052;
+    if journal_header.sig != signature {
+        error!("Bad journal header signature {}", file.display_path());
+        return Err(JournalError::JournalHeader);
+    }
+
     let is_compact = journal_header
         .incompatible_flags
         .contains(&IncompatFlags::Compact);

--- a/forensics/src/artifacts/os/linux/journals/objects/array.rs
+++ b/forensics/src/artifacts/os/linux/journals/objects/array.rs
@@ -3,6 +3,7 @@ use super::{
     header::{ObjectHeader, ObjectType},
 };
 use crate::{
+    accessor::{entry::handle::FileHandle, io::reader::AccessorReader},
     output::{manager::OutputManager, record::serialize_records_to_stream},
     structs::artifacts::os::linux::JournalOptions,
     utils::{
@@ -11,7 +12,6 @@ use crate::{
     },
 };
 use common::linux::{Facility, Journal, Priority};
-use std::fs::File;
 use tracing::{error, warn};
 
 #[derive(Debug)]
@@ -25,12 +25,12 @@ impl EntryArray {
     /// Walk through Array of entries and output the results
     /// Returns offset to next array of data
     pub(crate) fn walk_entries<'a>(
-        reader: &mut File,
+        reader: &mut AccessorReader,
         data: &'a [u8],
         is_compact: bool,
         manager: &mut OutputManager,
         options: &JournalOptions,
-        evidence: &str,
+        evidence: &FileHandle,
     ) -> nom::IResult<&'a [u8], u64> {
         let (mut input, next_entry_array_offset) = nom_unsigned_eight_bytes(data, Endian::Le)?;
 
@@ -76,7 +76,10 @@ impl EntryArray {
             let entry = match entry_result {
                 Ok((_, result)) => result,
                 Err(_err) => {
-                    error!("Could not parse log entry data for {evidence}");
+                    error!(
+                        "Could not parse log entry data for {}",
+                        evidence.display_path()
+                    );
                     continue;
                 }
             };
@@ -128,7 +131,7 @@ impl EntryArray {
     /// Walk through Array of entries and return to caller.
     /// Used for JS runtime
     pub(crate) fn walk_all_entries<'a>(
-        reader: &mut File,
+        reader: &mut AccessorReader,
         data: &'a [u8],
         is_compact: bool,
     ) -> nom::IResult<&'a [u8], EntryArray> {
@@ -184,13 +187,13 @@ impl EntryArray {
     }
 
     /// Parse the `Journal` message
-    pub(crate) fn parse_messages(entries: &[Entry], evidence: &str) -> Vec<Journal> {
+    pub(crate) fn parse_messages(entries: &[Entry], evidence: &FileHandle) -> Vec<Journal> {
         let mut journal_entries: Vec<Journal> = Vec::new();
 
         for entry in entries {
             let mut journal = Journal {
                 realtime: unixepoch_microseconds_to_iso(entry.realtime as i64),
-                evidence: evidence.to_string(),
+                evidence: evidence.display_path(),
                 seqnum: entry.seqnum,
                 ..Default::default()
             };
@@ -342,8 +345,9 @@ impl EntryArray {
                         .insert(field.to_string(), field_data.to_string());
                 } else {
                     warn!(
-                        "Message missing '=' delimiter for entry at {evidence}:seqnum - {}",
-                        entry.seqnum
+                        "Message missing '=' delimiter for entry at {}:seqnum - {}",
+                        entry.seqnum,
+                        evidence.display_path()
                     );
                     // Possible binary blob?
                     journal.custom.insert(data.message.clone(), String::new());
@@ -406,11 +410,11 @@ impl EntryArray {
 mod tests {
     use super::EntryArray;
     use crate::{
+        accessor::{access::Accessor, entry::handle::FileHandle},
         artifacts::os::linux::journals::{
             header::{IncompatFlags, JournalHeader},
             objects::header::{ObjectHeader, ObjectType},
         },
-        filesystem::files::file_reader,
         output::manager::OutputManager,
         structs::{
             artifacts::os::linux::JournalOptions,
@@ -438,7 +442,10 @@ mod tests {
         let mut test_location = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_location.push("tests/test_data/linux/journal/user-1000@e755452aab34485787b6d73f3035fb8c-000000000000068d-0005ff8ae923c73b.journal");
 
-        let mut reader = file_reader(&test_location.display().to_string()).unwrap();
+        let mut reader = Accessor::with_defaults()
+            .open_reader(test_location.to_str().unwrap())
+            .unwrap();
+        let file = FileHandle::host(test_location);
         let mut buff = [0; 264];
         let _ = reader.read(&mut buff).unwrap();
 
@@ -458,7 +465,7 @@ mod tests {
             is_compact,
             &mut output,
             &JournalOptions { alt_dir: None },
-            test_location.to_str().unwrap(),
+            &file,
         )
         .unwrap();
         assert_eq!(result, 3744448);
@@ -469,7 +476,9 @@ mod tests {
         let mut test_location = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_location.push("tests/test_data/linux/journal/user-1000@e755452aab34485787b6d73f3035fb8c-000000000000068d-0005ff8ae923c73b.journal");
 
-        let mut reader = file_reader(&test_location.display().to_string()).unwrap();
+        let mut reader = Accessor::with_defaults()
+            .open_reader(test_location.to_str().unwrap())
+            .unwrap();
         let mut buff = [0; 264];
         let _ = reader.read(&mut buff).unwrap();
 
@@ -493,7 +502,9 @@ mod tests {
         let mut test_location = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_location.push("tests/test_data/linux/journal/user-1000@e755452aab34485787b6d73f3035fb8c-000000000000068d-0005ff8ae923c73b.journal");
 
-        let mut reader = file_reader(&test_location.display().to_string()).unwrap();
+        let mut reader = Accessor::with_defaults()
+            .open_reader(test_location.to_str().unwrap())
+            .unwrap();
         let mut buff = [0; 264];
         let _ = reader.read(&mut buff).unwrap();
 
@@ -511,8 +522,8 @@ mod tests {
         assert_eq!(result.entries.len(), 4);
         assert_eq!(result.entries[2].realtime, 1688346965580106);
 
-        let messages =
-            EntryArray::parse_messages(&result.entries, &test_location.to_str().unwrap());
+        let file = FileHandle::host(test_location);
+        let messages = EntryArray::parse_messages(&result.entries, &file);
         assert_eq!(
             messages[2].message,
             "Started grub-boot-success.timer - Mark boot as successful after the user session has run 2 minutes."

--- a/forensics/src/artifacts/os/linux/journals/objects/array.rs
+++ b/forensics/src/artifacts/os/linux/journals/objects/array.rs
@@ -346,8 +346,8 @@ impl EntryArray {
                 } else {
                     warn!(
                         "Message missing '=' delimiter for entry at {}:seqnum - {}",
+                        evidence.display_path(),
                         entry.seqnum,
-                        evidence.display_path()
                     );
                     // Possible binary blob?
                     journal.custom.insert(data.message.clone(), String::new());

--- a/forensics/src/artifacts/os/linux/journals/objects/entry.rs
+++ b/forensics/src/artifacts/os/linux/journals/objects/entry.rs
@@ -1,9 +1,9 @@
 use super::header::{ObjectHeader, ObjectType};
+use crate::accessor::io::reader::AccessorReader;
 use crate::artifacts::os::linux::journals::objects::data::DataObject;
 use crate::utils::nom_helper::{
     Endian, nom_unsigned_eight_bytes, nom_unsigned_four_bytes, nom_unsigned_sixteen_bytes,
 };
-use std::fs::File;
 use tracing::{error, warn};
 
 #[derive(Debug)]
@@ -19,7 +19,7 @@ pub(crate) struct Entry {
 impl Entry {
     /// Parse Entry data in `Journal`
     pub(crate) fn parse_entry<'a>(
-        reader: &mut File,
+        reader: &mut AccessorReader,
         data: &'a [u8],
         is_compact: bool,
     ) -> nom::IResult<&'a [u8], Entry> {
@@ -88,15 +88,17 @@ impl Entry {
 #[cfg(test)]
 mod tests {
     use super::Entry;
-    use crate::filesystem::files::file_reader;
+    use crate::accessor::access::Accessor;
     use std::path::PathBuf;
 
     #[test]
     fn test_parse_entry() {
         let mut test_location = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_location.push("tests/test_data/linux/journal/user-1000@e755452aab34485787b6d73f3035fb8c-000000000000068d-0005ff8ae923c73b.journal");
+        let mut reader = Accessor::with_defaults()
+            .open_reader(test_location.to_str().unwrap())
+            .unwrap();
 
-        let mut reader = file_reader(&test_location.display().to_string()).unwrap();
         let test_data = [
             141, 6, 0, 0, 0, 0, 0, 0, 59, 199, 35, 233, 138, 255, 5, 0, 174, 136, 41, 4, 0, 0, 0,
             0, 5, 169, 105, 239, 87, 254, 73, 52, 144, 11, 89, 140, 131, 246, 45, 118, 31, 75, 110,

--- a/forensics/src/artifacts/os/linux/journals/objects/header.rs
+++ b/forensics/src/artifacts/os/linux/journals/objects/header.rs
@@ -1,12 +1,10 @@
 use crate::{
+    accessor::io::reader::AccessorReader,
     artifacts::os::linux::journals::error::JournalError,
     utils::nom_helper::{Endian, nom_unsigned_eight_bytes, nom_unsigned_one_byte},
 };
 use nom::bytes::complete::take;
-use std::{
-    fs::File,
-    io::{Read, Seek, SeekFrom},
-};
+use std::io::{Read, Seek, SeekFrom};
 use tracing::error;
 
 #[derive(Debug)]
@@ -41,7 +39,7 @@ pub(crate) enum ObjectFlag {
 impl ObjectHeader {
     /// Get the `Journal` object header
     pub(crate) fn parse_header(
-        reader: &mut File,
+        reader: &mut AccessorReader,
         offset: u64,
     ) -> Result<ObjectHeader, JournalError> {
         if reader.seek(SeekFrom::Start(offset)).is_err() {
@@ -157,8 +155,8 @@ impl ObjectHeader {
 mod tests {
     use super::ObjectHeader;
     use crate::{
+        accessor::access::Accessor,
         artifacts::os::linux::journals::objects::header::{ObjectFlag, ObjectType},
-        filesystem::files::file_reader,
     };
     use std::path::PathBuf;
 
@@ -167,7 +165,9 @@ mod tests {
         let mut test_location = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_location.push("tests/test_data/linux/journal/objects/objectheader.raw");
 
-        let mut reader = file_reader(&test_location.display().to_string()).unwrap();
+        let mut reader = Accessor::with_defaults()
+            .open_reader(test_location.to_str().unwrap())
+            .unwrap();
 
         let result = ObjectHeader::parse_header(&mut reader, 0).unwrap();
         assert_eq!(result.flag, ObjectFlag::None);

--- a/forensics/src/artifacts/os/linux/journals/parser.rs
+++ b/forensics/src/artifacts/os/linux/journals/parser.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 /**
  * Linux `Journal` files are the logs associated with the Systemd service
  * Systemd is a popular system service that is common on most Linux distros
@@ -17,14 +19,18 @@ use super::{
     journal::{parse_journal, parse_journal_file},
 };
 use crate::{
-    filesystem::{
-        directory::is_directory,
-        files::{is_file, list_files, list_files_directories},
+    accessor::{
+        access::Accessor,
+        entry::{
+            handle::{EntryKind, FileHandle},
+            locator::FileLocator,
+        },
     },
     output::manager::OutputManager,
     structs::artifacts::os::linux::JournalOptions,
 };
 use common::linux::Journal;
+use tracing::{error, warn};
 
 /// Parse and grab `Journal` entries at default paths. This can be changed though via /etc/systemd/journald.conf
 pub(crate) fn grab_journal(
@@ -34,35 +40,33 @@ pub(crate) fn grab_journal(
     let paths = if let Some(alt_dir) = &options.alt_dir {
         vec![alt_dir.clone()]
     } else {
-        let persist = "/var/log/journal/";
-        let tmp = "/run/log/journal/";
-        let mut logs = list_files_directories(persist).unwrap_or_default();
-        let mut tmp_files = list_files_directories(tmp).unwrap_or_default();
-
-        logs.append(&mut tmp_files);
-        logs
+        vec![
+            String::from("/var/log/journal/*/*"),
+            String::from("/run/log/journal/*/*"),
+        ]
     };
 
+    let mut accessor = Accessor::with_defaults();
     for path in paths {
-        if is_file(&path) && !path.contains(".journal") {
-            continue;
-        }
-        if is_file(&path) {
-            let _ = parse_journal(&path, manager, options);
-            continue;
-        }
-
-        // Journal files may be stored in a namespace folder. Check one more directory
-        if is_directory(&path) {
-            let log_files = list_files(&path).unwrap_or_default();
-            for log in log_files {
-                if is_file(&log) && !log.contains(".journal") {
-                    continue;
-                }
-                if is_file(&log) {
-                    let _ = parse_journal(&log, manager, options);
-                }
+        let journals = match accessor.globfs(&path) {
+            Ok(results) => results,
+            Err(err) => {
+                warn!("Could not glob journals '{path}': {err:?}");
+                continue;
             }
+        };
+
+        for journal in journals {
+            if journal.meta.kind != EntryKind::File {
+                continue;
+            }
+
+            // Should always be a file since we check above
+            let Some(file_handle) = journal.handle.as_file() else {
+                continue;
+            };
+
+            let _ = parse_journal(&mut accessor, file_handle, manager, options);
         }
     }
 
@@ -71,18 +75,27 @@ pub(crate) fn grab_journal(
 
 /// Parse a `Journal` file and return its entries
 pub(crate) fn grab_journal_file(path: &str) -> Result<Vec<Journal>, JournalError> {
-    if !is_file(path) || !path.contains(".journal") {
-        return Err(JournalError::NotJournal);
-    }
+    let mut accessor = Accessor::with_defaults();
+    let mut reader = match accessor.open_reader(path) {
+        Ok(result) => result,
+        Err(err) => {
+            error!("Could not read journal file '{path}': {err:?}");
+            return Err(JournalError::NotJournal);
+        }
+    };
 
-    parse_journal_file(path)
+    let file = FileHandle::new(FileLocator::Host {
+        path: PathBuf::from(path),
+    });
+
+    parse_journal_file(&mut reader, &file)
 }
 
 #[cfg(test)]
 mod tests {
     use super::grab_journal;
     use crate::{
-        artifacts::os::linux::journals::parser::grab_journal_file,
+        artifacts::os::linux::journals::{error::JournalError, parser::grab_journal_file},
         output::manager::OutputManager,
         structs::{
             artifacts::os::linux::JournalOptions,
@@ -120,12 +133,11 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "NotJournal")]
     fn test_grab_journal_file_bad() {
         let mut test_location = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_location.push("tests/test_data/windows.toml");
 
-        let result = grab_journal_file(&test_location.display().to_string()).unwrap();
-        assert_eq!(result.len(), 410);
+        let err = grab_journal_file(&test_location.display().to_string()).unwrap_err();
+        assert!(matches!(err, JournalError::JournalHeader))
     }
 }

--- a/forensics/src/artifacts/os/linux/logons/logon.rs
+++ b/forensics/src/artifacts/os/linux/logons/logon.rs
@@ -1,7 +1,12 @@
-use crate::utils::{
-    nom_helper::{Endian, nom_signed_four_bytes, nom_signed_two_bytes, nom_unsigned_four_bytes},
-    strings::extract_utf8_string,
-    time::unixepoch_to_iso_with_nano,
+use crate::{
+    accessor::{entry::handle::FileHandle, io::reader::AccessorReader},
+    utils::{
+        nom_helper::{
+            Endian, nom_signed_four_bytes, nom_signed_two_bytes, nom_unsigned_four_bytes,
+        },
+        strings::extract_utf8_string,
+        time::unixepoch_to_iso_with_nano,
+    },
 };
 use common::linux::{Logon, LogonType, Status};
 use nom::{
@@ -10,7 +15,6 @@ use nom::{
     bytes::complete::{take, take_until},
 };
 use std::{
-    fs::File,
     io::Read,
     mem::size_of,
     net::{Ipv4Addr, Ipv6Addr},
@@ -18,7 +22,11 @@ use std::{
 use tracing::error;
 
 /// Stream the logon info
-pub(crate) fn logon_reader(reader: &mut File, status: Status, evidence: &str) -> Vec<Logon> {
+pub(crate) fn logon_reader(
+    reader: &mut AccessorReader,
+    status: Status,
+    evidence: &FileHandle,
+) -> Vec<Logon> {
     let mut logon_buff = [0; 384];
     let mut logon_size = logon_buff.len();
     let mut logons = Vec::new();
@@ -53,7 +61,7 @@ fn parse_logon<'a>(
     data: &'a [u8],
     status: Status,
     logons: &mut Vec<Logon>,
-    evidence: &str,
+    evidence: &FileHandle,
 ) -> nom::IResult<&'a [u8], ()> {
     let (remaining, logon_type) = nom_unsigned_four_bytes(data, Endian::Le)?;
     let (remaining, pid) = nom_unsigned_four_bytes(remaining, Endian::Le)?;
@@ -121,7 +129,7 @@ fn parse_logon<'a>(
         microseconds,
         ip,
         status,
-        evidence: evidence.to_string(),
+        evidence: evidence.display_path(),
     };
 
     let nano = 1000;
@@ -151,10 +159,10 @@ fn get_logon_type(logon: u32) -> LogonType {
 #[cfg(test)]
 mod tests {
     use crate::{
+        accessor::{access::Accessor, entry::handle::FileHandle},
         artifacts::os::linux::logons::logon::{
             LogonType, Status, get_logon_type, logon_reader, parse_logon,
         },
-        filesystem::files::{file_reader, read_file},
     };
     use std::path::PathBuf;
 
@@ -163,11 +171,13 @@ mod tests {
         let mut test_location = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_location.push("tests/test_data/linux/logons/ubuntu18.04/wtmp");
 
-        let mut reader = file_reader(&test_location.display().to_string()).unwrap();
+        let mut reader = Accessor::with_defaults()
+            .open_reader(test_location.to_str().unwrap())
+            .unwrap();
         let results = logon_reader(
             &mut reader,
             Status::Success,
-            test_location.to_str().unwrap(),
+            &FileHandle::host(test_location),
         );
         assert_eq!(results.len(), 13);
 
@@ -181,14 +191,16 @@ mod tests {
     fn test_parse_logon() {
         let mut test_location = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_location.push("tests/test_data/linux/logons/ubuntu18.04/wtmp");
+        let data = Accessor::with_defaults()
+            .read_file(test_location.to_str().unwrap())
+            .unwrap();
 
-        let data = read_file(&test_location.display().to_string()).unwrap();
         let mut results = Vec::new();
         let (_, _) = parse_logon(
             &data,
             Status::Success,
             &mut results,
-            test_location.to_str().unwrap(),
+            &FileHandle::host(test_location),
         )
         .unwrap();
         assert_eq!(results.len(), 1);

--- a/forensics/src/artifacts/os/linux/logons/logon.rs
+++ b/forensics/src/artifacts/os/linux/logons/logon.rs
@@ -208,8 +208,10 @@ mod tests {
 
     #[test]
     fn test_get_logon_type() {
-        let test = 9;
-        let logon_type = get_logon_type(test);
-        assert_eq!(logon_type, LogonType::Accounting);
+        let test = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+        for entry in test {
+            assert_ne!(get_logon_type(entry), LogonType::Unknown);
+        }
+        assert_eq!(get_logon_type(100), LogonType::Unknown);
     }
 }

--- a/forensics/src/artifacts/os/linux/logons/parser.rs
+++ b/forensics/src/artifacts/os/linux/logons/parser.rs
@@ -38,26 +38,31 @@ pub(crate) fn grab_logons(options: &LogonOptions) -> Vec<Logon> {
 
     let mut accessor = Accessor::with_defaults();
     for path in paths {
-        let files = match accessor.globfs(&path) {
-            Ok(result) => result,
-            Err(err) => {
-                warn!("Could not glob '{path}': {err:?}");
-                continue;
-            }
-        };
-
-        for file in files {
-            if file.meta.kind != EntryKind::File {
-                continue;
-            }
-            let Some(file_handle) = file.handle.as_file() else {
-                continue;
-            };
-            grab_logon_file(&mut accessor, file_handle, &mut logons);
-        }
+        logon_file_path(&mut accessor, &path, &mut logons);
     }
 
     logons
+}
+
+/// Parse the provided logon file
+pub(crate) fn logon_file_path(accessor: &mut Accessor, path: &str, logons: &mut Vec<Logon>) {
+    let files = match accessor.globfs(path) {
+        Ok(result) => result,
+        Err(err) => {
+            warn!("Could not glob '{path}': {err:?}");
+            return;
+        }
+    };
+
+    for file in files {
+        if file.meta.kind != EntryKind::File {
+            continue;
+        }
+        let Some(file_handle) = file.handle.as_file() else {
+            continue;
+        };
+        grab_logon_file(accessor, file_handle, logons);
+    }
 }
 
 /// Parse logon files at provided path
@@ -102,9 +107,9 @@ pub(crate) fn grab_logon_file(
 #[cfg(test)]
 #[cfg(target_os = "linux")]
 mod tests {
-    use super::{grab_logon_file, grab_logons};
     use crate::{
         accessor::{access::Accessor, entry::handle::FileHandle},
+        artifacts::os::linux::logons::parser::{grab_logon_file, grab_logons, logon_file_path},
         structs::artifacts::os::linux::LogonOptions,
     };
     use std::path::PathBuf;
@@ -122,6 +127,14 @@ mod tests {
         let file_handle = FileHandle::host(PathBuf::from("/var/log/wtmp"));
 
         grab_logon_file(&mut accessor, &file_handle, &mut logons);
+        assert!(!logons.is_empty());
+    }
+
+    #[test]
+    fn test_logon_file_path() {
+        let mut logons = Vec::new();
+        let mut accessor = Accessor::with_defaults();
+        logon_file_path(&mut accessor, "/var/log/wtmp", &mut logons);
         assert!(!logons.is_empty());
     }
 

--- a/forensics/src/artifacts/os/linux/logons/parser.rs
+++ b/forensics/src/artifacts/os/linux/logons/parser.rs
@@ -12,7 +12,11 @@
  *  `https://github.com/Velocidex/velociraptor`
  */
 use crate::{
-    artifacts::os::linux::logons::logon::logon_reader, filesystem::files::file_reader,
+    accessor::{
+        access::Accessor,
+        entry::handle::{EntryKind, FileHandle},
+    },
+    artifacts::os::linux::logons::logon::logon_reader,
     structs::artifacts::os::linux::LogonOptions,
 };
 use common::linux::{Logon, Status};
@@ -22,46 +26,75 @@ use tracing::{error, warn};
 pub(crate) fn grab_logons(options: &LogonOptions) -> Vec<Logon> {
     let mut logons = Vec::new();
 
-    if let Some(alt_file) = &options.alt_file {
-        grab_logon_file(alt_file, &mut logons);
-        return logons;
-    }
-    let paths = vec![
-        String::from("/var/run/utmp"),
-        String::from("/var/log/wtmp"),
-        String::from("/var/log/btmp"),
-    ];
+    let paths = if let Some(alt_file) = &options.alt_file {
+        vec![alt_file.clone()]
+    } else {
+        vec![
+            String::from("/var/run/utmp"),
+            String::from("/var/log/wtmp"),
+            String::from("/var/log/btmp"),
+        ]
+    };
 
+    let mut accessor = Accessor::with_defaults();
     for path in paths {
-        grab_logon_file(&path, &mut logons);
+        let files = match accessor.globfs(&path) {
+            Ok(result) => result,
+            Err(err) => {
+                warn!("Could not glob '{path}': {err:?}");
+                continue;
+            }
+        };
+
+        for file in files {
+            if file.meta.kind != EntryKind::File {
+                continue;
+            }
+            let Some(file_handle) = file.handle.as_file() else {
+                continue;
+            };
+            grab_logon_file(&mut accessor, file_handle, &mut logons);
+        }
     }
 
     logons
 }
 
 /// Parse logon files at provided path
-pub(crate) fn grab_logon_file(path: &str, logons: &mut Vec<Logon>) {
-    if !path.ends_with("wtmp") && !path.ends_with("utmp") && !path.ends_with("btmp") {
-        warn!("Provided unsupported logon file {path}");
+pub(crate) fn grab_logon_file(
+    accessor: &mut Accessor,
+    file_handle: &FileHandle,
+    logons: &mut Vec<Logon>,
+) {
+    if !file_handle.display_path().ends_with("wtmp")
+        && !file_handle.display_path().ends_with("utmp")
+        && !file_handle.display_path().ends_with("btmp")
+    {
+        warn!(
+            "Provided unsupported logon file {}",
+            file_handle.display_path()
+        );
         return;
     }
 
-    let read_result = file_reader(path);
-    let mut reader = match read_result {
+    let mut reader = match accessor.open_reader_handle(file_handle) {
         Ok(result) => result,
         Err(err) => {
-            error!("Could not read file {path}: {err:?}");
+            error!(
+                "Could not read file {}: {err:?}",
+                file_handle.display_path()
+            );
             return;
         }
     };
 
-    let status = if path.ends_with("btmp") {
+    let status = if file_handle.display_path().ends_with("btmp") {
         Status::Failed
     } else {
         Status::Success
     };
 
-    let mut logon = logon_reader(&mut reader, status, path);
+    let mut logon = logon_reader(&mut reader, status, file_handle);
 
     logons.append(&mut logon);
 }
@@ -69,9 +102,12 @@ pub(crate) fn grab_logon_file(path: &str, logons: &mut Vec<Logon>) {
 #[cfg(test)]
 #[cfg(target_os = "linux")]
 mod tests {
-    use crate::structs::artifacts::os::linux::LogonOptions;
-
     use super::{grab_logon_file, grab_logons};
+    use crate::{
+        accessor::{access::Accessor, entry::handle::FileHandle},
+        structs::artifacts::os::linux::LogonOptions,
+    };
+    use std::path::PathBuf;
 
     #[test]
     fn test_grab_logons() {
@@ -82,16 +118,20 @@ mod tests {
     #[test]
     fn test_grab_logon_file() {
         let mut logons = Vec::new();
+        let mut accessor = Accessor::with_defaults();
+        let file_handle = FileHandle::host(PathBuf::from("/var/log/wtmp"));
 
-        grab_logon_file("/var/log/wtmp", &mut logons);
+        grab_logon_file(&mut accessor, &file_handle, &mut logons);
         assert!(!logons.is_empty());
     }
 
     #[test]
     fn test_grab_logon_file_bad_file() {
         let mut logons = Vec::new();
+        let mut accessor = Accessor::with_defaults();
+        let file_handle = FileHandle::host(PathBuf::from("/var/log/asdfasdfasdf"));
 
-        grab_logon_file("/var/log/asdfasdfasdf", &mut logons);
+        grab_logon_file(&mut accessor, &file_handle, &mut logons);
         assert!(logons.is_empty());
     }
 }

--- a/forensics/src/artifacts/os/linux/sudo/logs.rs
+++ b/forensics/src/artifacts/os/linux/sudo/logs.rs
@@ -1,49 +1,51 @@
 use crate::{
+    accessor::{access::Accessor, entry::handle::EntryKind},
     artifacts::os::linux::journals::{error::JournalError, journal::parse_journal_file},
-    filesystem::{
-        directory::is_directory,
-        files::{is_file, list_files, list_files_directories},
-    },
     structs::artifacts::os::linux::LinuxSudoOptions,
 };
 use common::linux::Journal;
+use tracing::warn;
 
 /// Grab sudo log entries in the Journal files
 pub(crate) fn grab_sudo_logs(options: &LinuxSudoOptions) -> Result<Vec<Journal>, JournalError> {
     let paths = if let Some(alt_dir) = &options.alt_dir {
         vec![alt_dir.clone()]
     } else {
-        let persist = "/var/log/journal/";
-        let tmp = "/run/log/journal";
-        let mut logs = list_files_directories(persist).unwrap_or_default();
-        let mut tmp_files = list_files_directories(tmp).unwrap_or_default();
-
-        logs.append(&mut tmp_files);
-        logs
+        vec![
+            String::from("/var/log/journal/*/*"),
+            String::from("/run/log/journal/*/*"),
+        ]
     };
 
     let mut sudo_logs: Vec<Journal> = Vec::new();
-    for path in paths {
-        if is_file(&path) && !path.ends_with("journal") {
-            continue;
-        }
-        if is_file(&path) {
-            let journal_entries = parse_journal_file(&path)?;
-            filter_logs(journal_entries, &mut sudo_logs);
-            continue;
-        }
+    let mut accessor = Accessor::with_defaults();
 
-        if is_directory(&path) {
-            let log_files = list_files(&path).unwrap_or_default();
-            for log in log_files {
-                if is_file(&log) && !log.ends_with("journal") {
+    for path in paths {
+        let journals = match accessor.globfs(&path) {
+            Ok(results) => results,
+            Err(err) => {
+                warn!("[sudo] Could not glob '{path}': {err:?}");
+                continue;
+            }
+        };
+        for journal in journals {
+            if journal.meta.kind != EntryKind::File {
+                continue;
+            }
+
+            // Should always be a file since we check above
+            let Some(file_handle) = journal.handle.as_file() else {
+                continue;
+            };
+            let mut reader = match accessor.open_reader_handle(file_handle) {
+                Ok(result) => result,
+                Err(err) => {
+                    warn!("[sudo] Could not open reader for '{path}': {err:?}");
                     continue;
                 }
-                if is_file(&log) {
-                    let journal_entries = parse_journal_file(&log)?;
-                    filter_logs(journal_entries, &mut sudo_logs);
-                }
-            }
+            };
+            let journal_entries = parse_journal_file(&mut reader, file_handle)?;
+            filter_logs(journal_entries, &mut sudo_logs);
         }
     }
 

--- a/forensics/src/artifacts/os/linux/sudo/logs.rs
+++ b/forensics/src/artifacts/os/linux/sudo/logs.rs
@@ -24,7 +24,7 @@ pub(crate) fn grab_sudo_logs(options: &LinuxSudoOptions) -> Result<Vec<Journal>,
         let journals = match accessor.globfs(&path) {
             Ok(results) => results,
             Err(err) => {
-                warn!("[sudo] Could not glob '{path}': {err:?}");
+                warn!("Could not glob '{path}': {err:?}");
                 continue;
             }
         };
@@ -40,11 +40,17 @@ pub(crate) fn grab_sudo_logs(options: &LinuxSudoOptions) -> Result<Vec<Journal>,
             let mut reader = match accessor.open_reader_handle(file_handle) {
                 Ok(result) => result,
                 Err(err) => {
-                    warn!("[sudo] Could not open reader for '{path}': {err:?}");
+                    warn!("Could not open reader for '{path}': {err:?}");
                     continue;
                 }
             };
-            let journal_entries = parse_journal_file(&mut reader, file_handle)?;
+            let journal_entries = match parse_journal_file(&mut reader, file_handle) {
+                Ok(results) => results,
+                Err(err) => {
+                    warn!("Could not parse journal file for sudo '{path}': {err:?}");
+                    continue;
+                }
+            };
             filter_logs(journal_entries, &mut sudo_logs);
         }
     }

--- a/forensics/src/runtime/linux/logons.rs
+++ b/forensics/src/runtime/linux/logons.rs
@@ -1,4 +1,10 @@
-use crate::{artifacts::os::linux::logons::parser::grab_logon_file, runtime::helper::string_arg};
+use std::path::PathBuf;
+
+use crate::{
+    accessor::{access::Accessor, entry::handle::FileHandle},
+    artifacts::os::linux::logons::parser::grab_logon_file,
+    runtime::helper::string_arg,
+};
 use boa_engine::{Context, JsResult, JsValue};
 
 /// Expose parsing logon file  to `BoaJS`
@@ -10,7 +16,9 @@ pub(crate) fn js_get_logon(
     let path = string_arg(args, 0)?;
 
     let mut logons = Vec::new();
-    grab_logon_file(&path, &mut logons);
+    let mut accessor = Accessor::with_defaults();
+    let file_handle = FileHandle::host(PathBuf::from(path));
+    grab_logon_file(&mut accessor, &file_handle, &mut logons);
 
     let results = serde_json::to_value(&logons).unwrap_or_default();
     let value = JsValue::from_json(&results, context)?;

--- a/forensics/src/runtime/linux/logons.rs
+++ b/forensics/src/runtime/linux/logons.rs
@@ -1,8 +1,5 @@
-use std::path::PathBuf;
-
 use crate::{
-    accessor::{access::Accessor, entry::handle::FileHandle},
-    artifacts::os::linux::logons::parser::grab_logon_file,
+    accessor::access::Accessor, artifacts::os::linux::logons::parser::logon_file_path,
     runtime::helper::string_arg,
 };
 use boa_engine::{Context, JsResult, JsValue};
@@ -17,8 +14,7 @@ pub(crate) fn js_get_logon(
 
     let mut logons = Vec::new();
     let mut accessor = Accessor::with_defaults();
-    let file_handle = FileHandle::host(PathBuf::from(path));
-    grab_logon_file(&mut accessor, &file_handle, &mut logons);
+    logon_file_path(&mut accessor, &path, &mut logons);
 
     let results = serde_json::to_value(&logons).unwrap_or_default();
     let value = JsValue::from_json(&results, context)?;


### PR DESCRIPTION
This PR migrates the linux artifacts to the new accessor workflow.

This allows artemis to parse artifacts from different sources such as zip files.

For example artemis now supports the following workflow

```
// Triage and acquire systemd journal files
artemis -t collect.toml

// Our file acquisition preserved full paths to the journal files
Archive:  tmp/triage_collection/files.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
 16777216  1980-01-01 00:00   var/log/journal/b73abcb99b2c4038aa5d55976c260316/system.journal
  8388608  1980-01-01 00:00   var/log/journal/b73abcb99b2c4038aa5d55976c260316/system@8198bfdc738d4240afdb15aa69fdbd33-00000000000030c6-000652496a107d07.journal
  8388608  1980-01-01 00:00   var/log/journal/b73abcb99b2c4038aa5d55976c260316/system@8198bfdc738d4240afdb15aa69fdbd33-000000000000bd06-00065295b82d135e.journal
  8388608  1980-01-01 00:00   var/log/journal/b73abcb99b2c4038aa5d55976c260316/system@8198bfdc738d4240afdb15aa69fdbd33-0000000000021b00-000652eafc694ae0.journal
  8388608  1980-01-01 00:00   var/log/journal/b73abcb99b2c4038aa5d55976c260316/system@8198bfdc738d4240afdb15aa69fdbd33-00000000000290ba-00065323f92004cc.journal
  8388608  1980-01-01 00:00   var/log/journal/b73abcb99b2c4038aa5d55976c260316/system@8198bfdc738d4240afdb15aa69fdbd33-000000000003a90b-00065389decda78e.journal



// We can parse directly without unzipping or providing full paths
artemis acquire journal --alt-dir 'zip:tmp/triage_collection/files.zip!**/*.journal'
```

Artemis run report:
```
....
  "artemis_version": "0.20.0",
  "artemis_commit": "b927799ae2b83ea75c23e19ab199af6f39661179",
  "artemis_args": "artemis acquire journal --alt-dir zip:tmp/triage_collection/files.zip!**/*.journal",
  "artemis_features": [
    "boa"
  ],
  "artemis_target": "x86_64-unknown-linux-gnu",
  "artemis_profile": "release",
  "rust_version": "1.95.0",
  "build_date": "2026-07-28",
  "product_name": "MS-7D30",
  "product_family": "Default string",
  "product_serial": "",
  "product_uuid": "",
  "product_version": "1.0",
  "vendor": "Micro-Star International Co., Ltd.",
  "artifact_runs": [
    {
      "name": "journal",
      "artifact_options_hash": "00106191858efa5aa1d21fd2456cf4dd",
      "artifact_options": {
        "alt_dir": "zip:tmp/triage_collection/files.zip!**/*.journal"
      },
      "last_run": "2026-07-28T02:15:50.000Z",
      "last_run_epoch": 1785204950,
      "output_count": 184,
      "record_count": 87257,
      "output_files": [
        "./tmp/local_collector/journal_51f6f4f9-a064-4c91-88ea-41fe1c4758bc.jsonl",
        "./tmp/local_collector/journal_6b45b012-643d-4da5-bd25-bf0b90d03fb5.jsonl",
....
```

In the future other accessor types can be added and linux artifacts will be supported
Ex: `artemis acquire journal --alt-dir 'qcow2:linux.qcow2!**/*.journal'`