### PR TITLE
Amcache fix

### DIFF
--- a/forensics/src/accessor/filesystem/ntfs/glob.rs
+++ b/forensics/src/accessor/filesystem/ntfs/glob.rs
@@ -108,6 +108,7 @@ fn glob_path_pattern<T: Read + Seek + Send>(
                             entry.meta.full_path
                         )));
                     };
+
                     let children =
                         match list_children_handle(&fs.volume, dir_ref, display_path, fs.drive) {
                             Ok(result) => result,
@@ -116,6 +117,7 @@ fn glob_path_pattern<T: Read + Seek + Send>(
                                 continue;
                             }
                         };
+
                     glob_path_pattern(fs, children, pattern, &relative, max_depth, guard, matches)?;
                 }
             }

--- a/forensics/src/artifacts/os/windows/amcache/parser.rs
+++ b/forensics/src/artifacts/os/windows/amcache/parser.rs
@@ -36,7 +36,7 @@ pub(crate) fn grab_amcache(options: &AmcacheOptions) -> Result<Vec<Amcache>, Amc
                 return Err(AmcacheError::DefaultDrive);
             }
         };
-        format!("ntfs:{drive}:\\Windows\\*\\Programs\\Amcache.hve")
+        format!("ntfs:{drive}:\\Windows\\AppCompat\\Programs\\Amcache.hve")
     };
 
     amcache_file(&pattern)


### PR DESCRIPTION
Remove unneeded glob for default amcache path

Path checks done by ntfs accessor should be case insensitive