### PR TITLE
Accessor stat support

### DIFF
--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -18,7 +18,6 @@
     clippy::flat_map_option,
     clippy::float_cmp_const,
     clippy::fn_params_excessive_bools,
-    clippy::from_iter_instead_of_collect,
     clippy::if_let_mutex,
     clippy::implicit_clone,
     clippy::imprecise_flops,

--- a/forensics/src/accessor/access.rs
+++ b/forensics/src/accessor/access.rs
@@ -662,10 +662,10 @@ mod tests {
                 assert!(!meta.times.is_empty());
 
                 continue;
+            } else if entry.is_file() {
+                let meta = access.stat_handle(entry.handle.as_file().unwrap()).unwrap();
+                assert!(!meta.times.is_empty());
             }
-
-            let meta = access.stat_handle(entry.handle.as_file().unwrap()).unwrap();
-            assert!(!meta.times.is_empty());
         }
     }
 
@@ -804,5 +804,110 @@ mod tests {
 
         let handle_stat = access.source_stat_handle(&source, file).unwrap();
         assert_eq!(handle_stat.meta.filename, "$MFT");
+    }
+
+    #[test]
+    fn test_host_accessor_source_stat_dir_handle() {
+        let dir = setup("test_host_accessor_source_stat_dir_handle");
+        write_file(&dir, "nested/stat.txt", b"hello");
+
+        let mut access = Accessor::with_defaults();
+        let source = access.open_source("host:").unwrap();
+        let matches = access
+            .source_globfs(&source, &format!("{}/*", dir.display()))
+            .unwrap();
+
+        let dir_handle = matches
+            .iter()
+            .find(|entry| entry.meta.kind == EntryKind::Directory)
+            .unwrap()
+            .handle
+            .as_directory()
+            .unwrap();
+
+        let stat = access.source_stat_dir_handle(&source, dir_handle).unwrap();
+        assert_eq!(stat.meta.kind, EntryKind::Directory);
+        assert_eq!(stat.meta.filename, "nested");
+
+        assert!(
+            stat.times
+                .iter()
+                .any(|time| matches!(time, Timestamp::Modified(_)))
+        );
+    }
+
+    #[test]
+    fn test_zip_accessor_stat() {
+        let mut archive = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        archive.push("tests/test_data/archives/document.odt");
+        let mut access = Accessor::with_defaults();
+
+        let file = access
+            .stat(&format!("zip:{}!content.xml", archive.display()))
+            .unwrap();
+
+        assert_eq!(file.meta.filename, "content.xml");
+        assert_eq!(file.meta.kind, EntryKind::File);
+
+        assert!(
+            file.times
+                .iter()
+                .any(|time| matches!(time, Timestamp::Modified(_)))
+        );
+
+        let virt = access
+            .stat(&format!("zip:{}!META-INF", archive.display()))
+            .unwrap();
+        assert_eq!(virt.meta.kind, EntryKind::Directory);
+        assert!(virt.times.is_empty());
+    }
+
+    #[test]
+    fn test_zip_accessor_source_stat_dir_handle() {
+        let mut archive = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        archive.push("tests/test_data/archives/document.odt");
+
+        let mut access = Accessor::with_defaults();
+        let source = access
+            .open_source(&format!("zip:{}", archive.display()))
+            .unwrap();
+
+        let matches = access.source_globfs(&source, "*").unwrap();
+        let dir_handle = matches
+            .iter()
+            .find(|entry| entry.meta.filename == "META-INF")
+            .unwrap()
+            .handle
+            .as_directory()
+            .unwrap();
+
+        let stat = access.source_stat_dir_handle(&source, dir_handle).unwrap();
+
+        assert_eq!(stat.meta.kind, EntryKind::Directory);
+        assert!(stat.times.is_empty());
+    }
+
+    #[test]
+    fn test_source_stat_handle_rejects_other_source() {
+        let mut archive = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        archive.push("tests/test_data/archives/document.odt");
+        let mut access = Accessor::with_defaults();
+
+        let host = access.open_source("host:").unwrap();
+        let zip = access
+            .open_source(&format!("zip:{}", archive.display()))
+            .unwrap();
+
+        let matches = access.source_globfs(&zip, "*").unwrap();
+        let zip_file = matches
+            .iter()
+            .find(|entry| entry.handle.as_file().is_some())
+            .unwrap()
+            .handle
+            .as_file()
+            .unwrap();
+
+        let err = access.source_stat_handle(&host, zip_file).unwrap_err();
+        assert!(matches!(err, AccessorError::InvalidHandle { .. }));
     }
 }

--- a/forensics/src/accessor/access.rs
+++ b/forensics/src/accessor/access.rs
@@ -22,7 +22,7 @@ use tracing::info;
 ///
 /// This accessor supports reading from a variety of sources
 ///
-/// Input is parsed into [`Location`] structure which is composed of (scheme, optional source path, and inner path)
+/// Input is parsed into `Location` structure which is composed of (scheme, optional source path, and inner path)
 ///
 /// Example: `zip:test.zip!./home/test.txt`
 ///
@@ -360,7 +360,11 @@ impl Accessor {
 
 #[cfg(test)]
 mod tests {
-    use crate::accessor::{access::Accessor, entry::handle::EntryKind};
+    use crate::accessor::{
+        access::Accessor,
+        entry::handle::{EntryKind, Timestamp},
+        error::AccessorError,
+    };
     use std::{
         fs::{self, File},
         io::{Read, Write},
@@ -663,5 +667,142 @@ mod tests {
             let meta = access.stat_handle(entry.handle.as_file().unwrap()).unwrap();
             assert!(!meta.times.is_empty());
         }
+    }
+
+    #[test]
+    fn test_host_accessor_stat_not_found() {
+        let mut access = Accessor::with_defaults();
+        let err = access.stat("host:/no/such/stat-file").unwrap_err();
+
+        assert!(matches!(err, AccessorError::NotFound { .. }));
+    }
+
+    #[test]
+    fn test_host_accessor_stat_handle() {
+        let dir = setup("test_host_accessor_stat_handle");
+        write_file(&dir, "stat.txt", b"hello");
+        let mut access = Accessor::with_defaults();
+        let matches = access.globfs(&format!("{}/*", dir.display())).unwrap();
+
+        let file = matches
+            .iter()
+            .find(|entry| entry.meta.filename == "stat.txt")
+            .unwrap()
+            .handle
+            .as_file()
+            .unwrap();
+
+        let stat = access.stat_handle(file).unwrap();
+
+        assert_eq!(stat.meta.filename, "stat.txt");
+        assert!(stat.times.len() >= 3);
+    }
+
+    #[test]
+    fn test_host_accessor_source_stat() {
+        let dir = setup("test_host_accessor_source_stat");
+        write_file(&dir, "stat.txt", b"hello");
+        let path = dir.join("stat.txt");
+        let mut access = Accessor::with_defaults();
+
+        let source = access.open_source("host:").unwrap();
+        let stat = access
+            .source_stat(&source, &path.display().to_string())
+            .unwrap();
+
+        assert_eq!(stat.meta.filename, "stat.txt");
+        assert_eq!(stat.meta.kind, EntryKind::File);
+        assert!(
+            stat.times
+                .iter()
+                .any(|time| matches!(time, Timestamp::Modified(_)))
+        );
+
+        let matches = access
+            .source_globfs(&source, &format!("{}/*", dir.display()))
+            .unwrap();
+
+        let file = matches
+            .iter()
+            .find(|entry| entry.meta.filename == "stat.txt")
+            .unwrap()
+            .handle
+            .as_file()
+            .unwrap();
+
+        let handle_stat = access.source_stat_handle(&source, file).unwrap();
+        assert_eq!(handle_stat.meta.filename, "stat.txt");
+
+        let parent = matches
+            .iter()
+            .find(|entry| entry.meta.kind == EntryKind::Directory)
+            .and_then(|entry| entry.handle.as_directory());
+
+        if let Some(dir_handle) = parent {
+            let dir_stat = access.source_stat_dir_handle(&source, dir_handle).unwrap();
+            assert_eq!(dir_stat.meta.kind, EntryKind::Directory);
+        }
+    }
+
+    #[test]
+    fn test_zip_accessor_source_stat() {
+        let mut archive = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        archive.push("tests/test_data/archives/document.odt");
+        let mut access = Accessor::with_defaults();
+
+        let source = access
+            .open_source(&format!("zip:{}", archive.display()))
+            .unwrap();
+
+        let file = access.source_stat(&source, "content.xml").unwrap();
+        assert_eq!(file.meta.filename, "content.xml");
+        assert!(
+            file.times
+                .iter()
+                .any(|time| matches!(time, Timestamp::Modified(_)))
+        );
+
+        let virt = access.source_stat(&source, "META-INF").unwrap();
+        assert_eq!(virt.meta.kind, EntryKind::Directory);
+        assert!(virt.times.is_empty());
+
+        let matches = access.source_globfs(&source, "*").unwrap();
+        let handle = matches
+            .iter()
+            .find(|entry| entry.meta.filename == "content.xml")
+            .unwrap()
+            .handle
+            .as_file()
+            .unwrap();
+
+        let handle_stat = access.source_stat_handle(&source, handle).unwrap();
+        assert_eq!(handle_stat.meta.filename, "content.xml");
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_ntfs_accessor_source_stat() {
+        let mut access = Accessor::with_defaults();
+        let source = access.open_source("ntfs:C").unwrap();
+        let mft = access.source_stat(&source, "$MFT").unwrap();
+
+        assert_eq!(mft.meta.filename, "$MFT");
+        assert!(
+            mft.times
+                .iter()
+                .any(|time| matches!(time, Timestamp::FilenameModified(_)))
+        );
+
+        let entries = access.source_globfs(&source, "*").unwrap();
+        let file = entries
+            .iter()
+            .find(|entry| entry.meta.filename == "$MFT")
+            .unwrap()
+            .handle
+            .as_file()
+            .unwrap();
+
+        let handle_stat = access.source_stat_handle(&source, file).unwrap();
+        assert_eq!(handle_stat.meta.filename, "$MFT");
     }
 }

--- a/forensics/src/accessor/access.rs
+++ b/forensics/src/accessor/access.rs
@@ -217,7 +217,7 @@ impl Accessor {
         Ok(SourceHandle::new(source_id))
     }
 
-    /// Read a file relative to an opened source
+    /// Read a file from an opened source
     pub(crate) fn source_read_file(
         &self,
         source: &SourceHandle,
@@ -227,7 +227,7 @@ impl Accessor {
         read_file_on_source(&self.cache, source.id(), &parse_inner_path(inner)?)
     }
 
-    /// List a directory relative to an opened source
+    /// List a directory from an opened source
     pub(crate) fn source_read_dir(
         &self,
         source: &SourceHandle,
@@ -237,7 +237,7 @@ impl Accessor {
         read_dir_on_source(&self.cache, source.id(), &parse_inner_path(inner)?)
     }
 
-    /// List a directory handle relative to an opened source
+    /// List a directory handle from an opened source
     pub(crate) fn source_read_dir_handle(
         &self,
         source: &SourceHandle,
@@ -253,7 +253,7 @@ impl Accessor {
         read_dir_handle_on_source(&self.cache, source.id(), handle)
     }
 
-    /// Read a file handle relative to an opened source
+    /// Read a file handle from an opened source
     pub(crate) fn source_read_file_handle(
         &self,
         source: &SourceHandle,
@@ -269,7 +269,7 @@ impl Accessor {
         read_file_handle_on_source(&self.cache, source.id(), handle)
     }
 
-    /// Glob relative to an opened source directory
+    /// Glob from an opened source directory
     pub(crate) fn source_globfs(
         &self,
         source: &SourceHandle,
@@ -289,7 +289,7 @@ impl Accessor {
         )
     }
 
-    /// Open a reader relative to an opened source
+    /// Open a reader from an opened source
     pub(crate) fn source_open_reader(
         &self,
         source: &SourceHandle,
@@ -299,7 +299,7 @@ impl Accessor {
         open_reader_on_source(&self.cache, source.id(), &parse_inner_path(inner)?)
     }
 
-    /// Open a reader for a file handle relative to an opened source
+    /// Open a reader for a file handle from an opened source
     pub(crate) fn source_open_reader_handle(
         &self,
         source: &SourceHandle,
@@ -313,6 +313,48 @@ impl Accessor {
 
         validate_file_handle_for_source(source.id(), &handle.locator)?;
         open_reader_handle_on_source(&self.cache, source.id(), handle)
+    }
+
+    /// Return metadata and timestamps for a path from an opened source
+    pub(crate) fn source_stat(
+        &self,
+        source: &SourceHandle,
+        inner: &str,
+    ) -> AccessorResult<EntryStat> {
+        info!("Reading path {inner} with source {}", source.display());
+        stat_on_source(&self.cache, source.id(), &parse_inner_path(inner)?)
+    }
+
+    /// Return metadata and timestamps for a `FileHandle` from an opened source
+    pub(crate) fn source_stat_handle(
+        &self,
+        source: &SourceHandle,
+        handle: &FileHandle,
+    ) -> AccessorResult<EntryStat> {
+        info!(
+            "Stat file handle {} with source {}",
+            handle.display_path(),
+            source.display()
+        );
+
+        validate_file_handle_for_source(source.id(), &handle.locator)?;
+        stat_handle_on_source(&self.cache, source.id(), handle)
+    }
+
+    /// Return metadata and timestamps for a `DirHandle` from an opened source
+    pub(crate) fn source_stat_dir_handle(
+        &self,
+        source: &SourceHandle,
+        handle: &DirHandle,
+    ) -> AccessorResult<EntryStat> {
+        info!(
+            "Stat directory handle {} with source {}",
+            handle.display_path(),
+            source.display()
+        );
+
+        validate_dir_handle_for_source(source.id(), &handle.locator)?;
+        stat_dir_handle_on_source(&self.cache, source.id(), handle)
     }
 }
 

--- a/forensics/src/accessor/access.rs
+++ b/forensics/src/accessor/access.rs
@@ -1,7 +1,7 @@
 use crate::accessor::{
     cache::SourceCache,
     config::AccessorConfig,
-    entry::handle::{DirEntry, DirHandle, FileHandle, GlobMatch},
+    entry::handle::{DirEntry, DirHandle, EntryStat, FileHandle, GlobMatch},
     error::AccessorResult,
     io::reader::AccessorReader,
     location::loc::Location,
@@ -10,7 +10,7 @@ use crate::accessor::{
             build_source, ensure_source, glob_on_source, open_reader_handle_on_source,
             open_reader_on_source, parse_inner_path, read_dir_handle_on_source, read_dir_on_source,
             read_file_handle_on_source, read_file_on_source, source_id_from_dir_locator,
-            source_id_from_file_locator, validate_dir_handle_for_source,
+            source_id_from_file_locator, stat_on_source, validate_dir_handle_for_source,
             validate_file_handle_for_source,
         },
         handle::SourceHandle,
@@ -155,6 +155,20 @@ impl Accessor {
         );
 
         open_reader_handle_on_source(&self.cache, &source_id, handle)
+    }
+
+    /// Return metadata and timestamps for provided path
+    pub(crate) fn stat(&mut self, location: &str) -> AccessorResult<EntryStat> {
+        let loc = Location::parse(location)?;
+        let source_id = build_source(&loc, &self.config, &mut self.cache)?;
+
+        info!(
+            "Stat file {location} using source '{}'. Scheme: {}",
+            source_id.display(),
+            loc.scheme.as_str()
+        );
+
+        stat_on_source(&self.cache, &source_id, &loc.inner_path)
     }
 
     /// Open a source for repeated reads

--- a/forensics/src/accessor/access.rs
+++ b/forensics/src/accessor/access.rs
@@ -321,7 +321,7 @@ impl Accessor {
         source: &SourceHandle,
         inner: &str,
     ) -> AccessorResult<EntryStat> {
-        info!("Reading path {inner} with source {}", source.display());
+        info!("Stat path {inner} with source {}", source.display());
         stat_on_source(&self.cache, source.id(), &parse_inner_path(inner)?)
     }
 
@@ -456,7 +456,7 @@ mod tests {
         let results = access
             .read_dir(&test_location.display().to_string())
             .unwrap();
-        assert!(!results.is_empty())
+        assert!(!results.is_empty());
     }
 
     #[test]
@@ -627,5 +627,41 @@ mod tests {
             format!("host:{}", test_location.display().to_string())
         );
         assert_eq!(reader.location.filename(), "document.odt");
+    }
+
+    #[test]
+    fn test_stat() {
+        let mut access = Accessor::with_defaults();
+        let mut test_location = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        test_location.push("tests/test_data/archives/document.odt");
+
+        let meta = access.stat(test_location.to_str().unwrap()).unwrap();
+        assert!(!meta.times.is_empty());
+
+        assert_eq!(meta.meta.size, 10493);
+    }
+
+    #[test]
+    fn test_stat_handles() {
+        let test_location = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let mut access = Accessor::with_defaults();
+        let results = access
+            .read_dir(&test_location.display().to_string())
+            .unwrap();
+        assert!(!results.is_empty());
+
+        for entry in results {
+            if entry.is_directory() {
+                let meta = access
+                    .stat_dir_handle(entry.handle.as_directory().unwrap())
+                    .unwrap();
+                assert!(!meta.times.is_empty());
+
+                continue;
+            }
+
+            let meta = access.stat_handle(entry.handle.as_file().unwrap()).unwrap();
+            assert!(!meta.times.is_empty());
+        }
     }
 }

--- a/forensics/src/accessor/access.rs
+++ b/forensics/src/accessor/access.rs
@@ -674,7 +674,7 @@ mod tests {
         let mut access = Accessor::with_defaults();
         let err = access.stat("host:/no/such/stat-file").unwrap_err();
 
-        assert!(matches!(err, AccessorError::NotFound { .. }));
+        assert!(matches!(err, AccessorError::Io { .. }));
     }
 
     #[test]

--- a/forensics/src/accessor/access.rs
+++ b/forensics/src/accessor/access.rs
@@ -163,7 +163,7 @@ impl Accessor {
         let source_id = build_source(&loc, &self.config, &mut self.cache)?;
 
         info!(
-            "Stat file {location} using source '{}'. Scheme: {}",
+            "Stat path {location} using source '{}'. Scheme: {}",
             source_id.display(),
             loc.scheme.as_str()
         );

--- a/forensics/src/accessor/access.rs
+++ b/forensics/src/accessor/access.rs
@@ -10,8 +10,8 @@ use crate::accessor::{
             build_source, ensure_source, glob_on_source, open_reader_handle_on_source,
             open_reader_on_source, parse_inner_path, read_dir_handle_on_source, read_dir_on_source,
             read_file_handle_on_source, read_file_on_source, source_id_from_dir_locator,
-            source_id_from_file_locator, stat_on_source, validate_dir_handle_for_source,
-            validate_file_handle_for_source,
+            source_id_from_file_locator, stat_dir_handle_on_source, stat_handle_on_source,
+            stat_on_source, validate_dir_handle_for_source, validate_file_handle_for_source,
         },
         handle::SourceHandle,
     },
@@ -169,6 +169,34 @@ impl Accessor {
         );
 
         stat_on_source(&self.cache, &source_id, &loc.inner_path)
+    }
+
+    /// Return metadata and timestamps for provided `FileHandle`
+    pub(crate) fn stat_handle(&mut self, handle: &FileHandle) -> AccessorResult<EntryStat> {
+        let source_id = source_id_from_file_locator(&handle.locator)?;
+        ensure_source(&source_id, &self.config, &mut self.cache)?;
+
+        info!(
+            "Stat file {} via handle using source '{}'",
+            handle.display_path(),
+            source_id.display(),
+        );
+
+        stat_handle_on_source(&self.cache, &source_id, handle)
+    }
+
+    /// Return metadata and timestamps for provided `DirHandle`
+    pub(crate) fn stat_dir_handle(&mut self, handle: &DirHandle) -> AccessorResult<EntryStat> {
+        let source_id = source_id_from_dir_locator(&handle.locator)?;
+        ensure_source(&source_id, &self.config, &mut self.cache)?;
+
+        info!(
+            "Stat directory {} via handle using source '{}'",
+            handle.display_path(),
+            source_id.display(),
+        );
+
+        stat_dir_handle_on_source(&self.cache, &source_id, handle)
     }
 
     /// Open a source for repeated reads

--- a/forensics/src/accessor/entry/handle.rs
+++ b/forensics/src/accessor/entry/handle.rs
@@ -295,12 +295,14 @@ impl DirEntry {
     }
 }
 
+#[derive(Debug)]
 pub(crate) struct EntryStat {
     pub(crate) meta: EntryMeta,
     pub(crate) times: Vec<Timestamp>,
 }
 
-enum Timestamp {
+#[derive(Debug)]
+pub(crate) enum Timestamp {
     Created(String),
     Modified(String),
     Accessed(String),

--- a/forensics/src/accessor/entry/handle.rs
+++ b/forensics/src/accessor/entry/handle.rs
@@ -294,3 +294,19 @@ impl DirEntry {
         matches!(self.handle, ItemHandle::File(_))
     }
 }
+
+pub(crate) struct EntryStat {
+    pub(crate) meta: EntryMeta,
+    pub(crate) times: Vec<Timestamp>,
+}
+
+enum Timestamp {
+    Created(String),
+    Modified(String),
+    Accessed(String),
+    Changed(String),
+    FilenameCreated(String),
+    FilenameModified(String),
+    FilenameAccessed(String),
+    FilenameChanged(String),
+}

--- a/forensics/src/accessor/entry/locator.rs
+++ b/forensics/src/accessor/entry/locator.rs
@@ -7,7 +7,7 @@ pub(crate) enum SourceId {
     /// Live OS
     Host,
     /// Raw NTFS filesystem
-    RawNtfs(char),
+    Ntfs(char),
     /// A zip file
     Zip(PathBuf),
 }
@@ -17,7 +17,7 @@ impl SourceId {
     pub(crate) fn display(&self) -> String {
         match self {
             SourceId::Host => String::from("host"),
-            SourceId::RawNtfs(drive) => format!("ntfs:{drive}:"),
+            SourceId::Ntfs(drive) => format!("ntfs:{drive}:"),
             SourceId::Zip(path) => format!("zip:{}", path.display()),
         }
     }

--- a/forensics/src/accessor/filesystem/host.rs
+++ b/forensics/src/accessor/filesystem/host.rs
@@ -1,6 +1,9 @@
 use crate::accessor::{
     entry::{
-        handle::{DirEntry, DirHandle, EntryKind, EntryMeta, FileHandle, GlobMatch, ItemHandle},
+        handle::{
+            DirEntry, DirHandle, EntryKind, EntryMeta, EntryStat, FileHandle, GlobMatch,
+            ItemHandle, Timestamp,
+        },
         locator::{DirLocator, FileLocator},
     },
     error::{AccessorError, AccessorResult},
@@ -13,7 +16,7 @@ use crate::accessor::{
 };
 use glob::Pattern;
 use std::{
-    fs::{self, File, metadata, read},
+    fs::{self, File, Metadata, metadata, read, symlink_metadata},
     path::{Path, PathBuf},
 };
 use tracing::debug;
@@ -210,6 +213,52 @@ impl HostFs {
         }
     }
 
+    /// Return metadata and timestamps for provided path
+    pub(crate) fn stat(inner: &InnerPath) -> AccessorResult<EntryStat> {
+        let path = HostFs::resolve_host_path(inner);
+        if !path.exists() {
+            return Err(AccessorError::not_found(HostFs::display_path(&path)));
+        }
+
+        // We will not follow symbolic links
+        let meta = symlink_metadata(&path).map_err(|err| AccessorError::io_path(&path, err))?;
+
+        let kind = if meta.is_dir() {
+            EntryKind::Directory
+        } else if meta.is_file() {
+            EntryKind::File
+        } else {
+            EntryKind::Unsupported
+        };
+
+        Ok(EntryStat {
+            meta: EntryMeta::new(kind, meta.len(), HostFs::display_path(&path)),
+            times: HostFs::host_times(&meta),
+        })
+    }
+
+    /// Return metadata and timestamps for a `FileHandle`
+    pub(crate) fn stat_handle(handle: &FileHandle) -> AccessorResult<EntryStat> {
+        match &handle.locator {
+            FileLocator::Host { path } => HostFs::stat(&InnerPath::new(path.clone())),
+            _ => Err(AccessorError::invalid_handle(format!(
+                "host source cannot stat file handle for {}",
+                handle.display_path()
+            ))),
+        }
+    }
+
+    /// Return metadata and timestamps for a `DirHandle`
+    pub(crate) fn stat_dir_handle(handle: &DirHandle) -> AccessorResult<EntryStat> {
+        match &handle.locator {
+            DirLocator::Host { path } => HostFs::stat(&InnerPath::new(path.clone())),
+            _ => Err(AccessorError::invalid_handle(format!(
+                "host source cannot stat directory handle for {}",
+                handle.display_path()
+            ))),
+        }
+    }
+
     /// Return `PathBuf` from `InnerPath`
     fn resolve_host_path(inner: &InnerPath) -> PathBuf {
         if inner.is_empty() {
@@ -280,12 +329,115 @@ impl HostFs {
 
         Ok(())
     }
+
+    /// Return timestamps for a live host system
+    fn host_times(meta: &Metadata) -> Vec<Timestamp> {
+        let mut times = Vec::new();
+
+        // Rust cannot get Windows Changed timestamps :(
+        #[cfg(target_os = "windows")]
+        {
+            use crate::utils::time::filetime_to_iso;
+            use std::os::windows::fs::MetadataExt;
+
+            if meta.creation_time() != 0 {
+                times.push(Timestamp::Created(filetime_to_iso(meta.creation_time())));
+            }
+
+            if meta.last_write_time() != 0 {
+                times.push(Timestamp::Modified(filetime_to_iso(meta.last_write_time())));
+            }
+
+            if meta.last_access_time() != 0 {
+                times.push(Timestamp::Accessed(filetime_to_iso(
+                    meta.last_access_time(),
+                )));
+            }
+        }
+
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        {
+            use crate::utils::time::unixepoch_to_iso_with_nano;
+
+            #[cfg(target_os = "linux")]
+            use std::os::linux::fs::MetadataExt;
+
+            #[cfg(target_os = "macos")]
+            use std::os::macos::fs::MetadataExt;
+
+            times.push(Timestamp::Modified(unixepoch_to_iso_with_nano(
+                meta.st_mtime(),
+                meta.st_mtime_nsec(),
+            )));
+            times.push(Timestamp::Accessed(unixepoch_to_iso_with_nano(
+                meta.st_atime(),
+                meta.st_atime_nsec(),
+            )));
+            times.push(Timestamp::Changed(unixepoch_to_iso_with_nano(
+                meta.st_ctime(),
+                meta.st_ctime_nsec(),
+            )));
+        }
+
+        #[cfg(target_os = "linux")]
+        if let Ok(created) = meta.created() {
+            use crate::utils::time::unixepoch_microseconds_to_iso;
+            use std::time::UNIX_EPOCH;
+
+            if created > UNIX_EPOCH {
+                let micros = created
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_micros();
+
+                times.push(Timestamp::Created(unixepoch_microseconds_to_iso(
+                    micros as i64,
+                )));
+            }
+        }
+
+        #[cfg(target_os = "macos")]
+        {
+            use crate::utils::time::unixepoch_to_iso_with_nano;
+            times.push(Timestamp::Created(unixepoch_to_iso_with_nano(
+                meta.st_birthtime(),
+                meta.st_birthtime_nsec(),
+            )));
+        }
+
+        #[cfg(any(target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))]
+        use std::os::unix::fs::MetadataExt;
+
+        #[cfg(any(target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))]
+        {
+            use crate::utils::time::unixepoch_to_iso_with_nano;
+
+            times.push(Timestamp::Accessed(unixepoch_to_iso_with_nano(
+                meta.atime(),
+                meta.atime_nsec(),
+            )));
+
+            times.push(Timestamp::Modified(unixepoch_to_iso_with_nano(
+                meta.mtime(),
+                meta.mtime_nsec(),
+            )));
+
+            times.push(Timestamp::Changed(unixepoch_to_iso_with_nano(
+                meta.ctime(),
+                meta.ctime_nsec(),
+            )));
+        }
+
+        times
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::accessor::{
-        entry::handle::FileHandle, error::AccessorError, filesystem::host::HostFs,
+        entry::handle::{DirHandle, EntryKind, FileHandle},
+        error::AccessorError,
+        filesystem::host::HostFs,
         location::path::InnerPath,
     };
     use std::{
@@ -410,5 +562,42 @@ mod tests {
         assert_eq!(reader.location.full_path(), path.display().to_string());
         assert_eq!(reader.location.filename(), "syslog");
         assert!(reader.location.display_path().starts_with("host:"));
+    }
+
+    #[test]
+    fn test_hostfs_stat() {
+        let mut test_location = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        test_location.push("tests");
+        let results = HostFs::stat(&inner(&test_location, "")).unwrap();
+
+        assert!(results.times.len() >= 3);
+        assert_eq!(results.meta.kind, EntryKind::Directory);
+    }
+
+    #[test]
+    fn test_hostfs_stat_file_handle() {
+        let dir = setup("test_hostfs_reader_handle");
+        write_file(&dir, "stat.bin", &[1, 2, 3, 4, 5]);
+
+        let inner = inner(&dir, "stat.bin");
+        let handle = FileHandle::host(inner.as_path().to_path_buf());
+
+        let results = HostFs::stat_handle(&handle).unwrap();
+
+        assert!(results.times.len() >= 3);
+        assert_eq!(results.meta.kind, EntryKind::File);
+    }
+
+    #[test]
+    fn test_hostfs_stat_dir_handle() {
+        let dir = setup("test_hostfs_reader_handle");
+
+        let inner = inner(&dir, "");
+        let handle = DirHandle::host(inner.as_path().to_path_buf());
+
+        let results = HostFs::stat_dir_handle(&handle).unwrap();
+
+        assert!(results.times.len() >= 3);
+        assert_eq!(results.meta.kind, EntryKind::Directory);
     }
 }

--- a/forensics/src/accessor/filesystem/host.rs
+++ b/forensics/src/accessor/filesystem/host.rs
@@ -14,6 +14,7 @@ use crate::accessor::{
     io::reader::{AccessorReader, ReaderLocation},
     location::{path::InnerPath, scheme::Scheme},
 };
+use crate::utils::time::unixepoch_to_iso_with_nano;
 use glob::Pattern;
 use std::{
     fs::{self, File, Metadata, metadata, read, symlink_metadata},
@@ -216,9 +217,6 @@ impl HostFs {
     /// Return metadata and timestamps for provided path
     pub(crate) fn stat(inner: &InnerPath) -> AccessorResult<EntryStat> {
         let path = HostFs::resolve_host_path(inner);
-        if !path.exists() {
-            return Err(AccessorError::not_found(HostFs::display_path(&path)));
-        }
 
         // We will not follow symbolic links
         let meta = symlink_metadata(&path).map_err(|err| AccessorError::io_path(&path, err))?;
@@ -355,16 +353,14 @@ impl HostFs {
             }
         }
 
+        #[cfg(target_os = "linux")]
+        use std::os::linux::fs::MetadataExt;
+
+        #[cfg(target_os = "macos")]
+        use std::os::macos::fs::MetadataExt;
+
         #[cfg(any(target_os = "linux", target_os = "macos"))]
         {
-            use crate::utils::time::unixepoch_to_iso_with_nano;
-
-            #[cfg(target_os = "linux")]
-            use std::os::linux::fs::MetadataExt;
-
-            #[cfg(target_os = "macos")]
-            use std::os::macos::fs::MetadataExt;
-
             times.push(Timestamp::Modified(unixepoch_to_iso_with_nano(
                 meta.st_mtime(),
                 meta.st_mtime_nsec(),
@@ -398,7 +394,6 @@ impl HostFs {
 
         #[cfg(target_os = "macos")]
         {
-            use crate::utils::time::unixepoch_to_iso_with_nano;
             times.push(Timestamp::Created(unixepoch_to_iso_with_nano(
                 meta.st_birthtime(),
                 meta.st_birthtime_nsec(),
@@ -410,8 +405,6 @@ impl HostFs {
 
         #[cfg(any(target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))]
         {
-            use crate::utils::time::unixepoch_to_iso_with_nano;
-
             times.push(Timestamp::Accessed(unixepoch_to_iso_with_nano(
                 meta.atime(),
                 meta.atime_nsec(),

--- a/forensics/src/accessor/filesystem/host.rs
+++ b/forensics/src/accessor/filesystem/host.rs
@@ -576,7 +576,7 @@ mod tests {
 
     #[test]
     fn test_hostfs_stat_file_handle() {
-        let dir = setup("test_hostfs_reader_handle");
+        let dir = setup("test_hostfs_stat_handle");
         write_file(&dir, "stat.bin", &[1, 2, 3, 4, 5]);
 
         let inner = inner(&dir, "stat.bin");
@@ -590,7 +590,7 @@ mod tests {
 
     #[test]
     fn test_hostfs_stat_dir_handle() {
-        let dir = setup("test_hostfs_reader_handle");
+        let dir = setup("test_hostfs_stat_dir_handle");
 
         let inner = inner(&dir, "");
         let handle = DirHandle::host(inner.as_path().to_path_buf());

--- a/forensics/src/accessor/filesystem/ntfs/data.rs
+++ b/forensics/src/accessor/filesystem/ntfs/data.rs
@@ -341,7 +341,7 @@ fn ntfs_times<R: Read + Seek>(
     Ok(times)
 }
 
-/// Extract the Filetime for the NTFS entry
+/// Extract the FILENAME timestamp for the NTFS entry
 fn first_non_dos_filename<R: Read + Seek>(
     reader: &mut R,
     file: &NtfsFile<'_>,
@@ -370,6 +370,8 @@ fn first_non_dos_filename<R: Read + Seek>(
 }
 
 /// Convert Windows Filetime to RFC 3339
+///
+/// `kind` a function constructor that returns enum `Timestamp`
 fn push_filetime(times: &mut Vec<Timestamp>, kind: fn(String) -> Timestamp, filetime: u64) {
     times.push(kind(filetime_to_iso(filetime)))
 }
@@ -1153,7 +1155,6 @@ mod tests {
     fn test_ntfs_stat() {
         let fs = test_fs();
         let stat = fs.stat(&hello_path()).unwrap();
-        println!("{stat:?}");
 
         assert_eq!(stat.meta.filename, "hello world.txt");
         assert_eq!(stat.meta.kind, EntryKind::File);

--- a/forensics/src/accessor/filesystem/ntfs/data.rs
+++ b/forensics/src/accessor/filesystem/ntfs/data.rs
@@ -196,7 +196,7 @@ impl<T: Read + Seek + Send + 'static> NtfsFs<T> {
         self.volume.with_reader(|ntfs, reader| {
             let file = resolve_entry(ntfs, reader, &inner_path)?;
 
-            self.stat_from_file(reader, ntfs, &file, &path)
+            stat_from_file(reader, ntfs, &file, &path)
         })
     }
 
@@ -217,7 +217,7 @@ impl<T: Read + Seek + Send + 'static> NtfsFs<T> {
 
                 self.volume.with_reader(|ntfs, reader| {
                     let file = open_by_ref(ntfs, reader, file_ref)?;
-                    self.stat_from_file(reader, ntfs, &file, display_path)
+                    stat_from_file(reader, ntfs, &file, display_path)
                 })
             }
             _ => Err(AccessorError::invalid_handle(format!(
@@ -243,7 +243,7 @@ impl<T: Read + Seek + Send + 'static> NtfsFs<T> {
                 }
                 self.volume.with_reader(|ntfs, reader| {
                     let file = open_by_ref(ntfs, reader, dir_ref)?;
-                    self.stat_from_file(reader, ntfs, &file, display_path)
+                    stat_from_file(reader, ntfs, &file, display_path)
                 })
             }
             _ => Err(AccessorError::invalid_handle(format!(
@@ -252,32 +252,31 @@ impl<T: Read + Seek + Send + 'static> NtfsFs<T> {
             ))),
         }
     }
+}
 
-    /// Return metadata and timetamps for a NTFS entry
-    fn stat_from_file<R: Read + Seek>(
-        &self,
-        reader: &mut R,
-        ntfs: &ntfs::Ntfs,
-        file: &NtfsFile<'_>,
-        display_path: &str,
-    ) -> AccessorResult<EntryStat> {
-        let kind = if file.is_directory() {
-            EntryKind::Directory
-        } else {
-            EntryKind::File
-        };
+/// Return metadata and timetamps for a NTFS entry
+fn stat_from_file<R: Read + Seek>(
+    reader: &mut R,
+    ntfs: &ntfs::Ntfs,
+    file: &NtfsFile<'_>,
+    display_path: &str,
+) -> AccessorResult<EntryStat> {
+    let kind = if file.is_directory() {
+        EntryKind::Directory
+    } else {
+        EntryKind::File
+    };
 
-        let size = if kind == EntryKind::File {
-            get_file_size(ntfs, reader, file.file_record_number())?
-        } else {
-            0
-        };
+    let size = if kind == EntryKind::File {
+        get_file_size(ntfs, reader, file.file_record_number())?
+    } else {
+        0
+    };
 
-        Ok(EntryStat {
-            meta: EntryMeta::new(kind, size, format!("ntfs:{display_path}")),
-            times: ntfs_times(reader, file)?,
-        })
-    }
+    Ok(EntryStat {
+        meta: EntryMeta::new(kind, size, format!("ntfs:{display_path}")),
+        times: ntfs_times(reader, file)?,
+    })
 }
 
 /// Extract all 8 timestamps for a NTFS entry
@@ -373,7 +372,7 @@ fn first_non_dos_filename<R: Read + Seek>(
 ///
 /// `kind` a function constructor that returns enum `Timestamp`
 fn push_filetime(times: &mut Vec<Timestamp>, kind: fn(String) -> Timestamp, filetime: u64) {
-    times.push(kind(filetime_to_iso(filetime)))
+    times.push(kind(filetime_to_iso(filetime)));
 }
 
 /// Create a reader to stream large files by accessing the raw NTFS filesystem
@@ -1162,6 +1161,42 @@ mod tests {
             stat.times
                 .iter()
                 .any(|time| matches!(time, Timestamp::Accessed(_)))
+        );
+
+        assert!(
+            stat.times
+                .iter()
+                .any(|time| matches!(time, Timestamp::Modified(_)))
+        );
+
+        assert!(
+            stat.times
+                .iter()
+                .any(|time| matches!(time, Timestamp::Created(_)))
+        );
+
+        assert!(
+            stat.times
+                .iter()
+                .any(|time| matches!(time, Timestamp::Changed(_)))
+        );
+
+        assert!(
+            stat.times
+                .iter()
+                .any(|time| matches!(time, Timestamp::FilenameAccessed(_)))
+        );
+
+        assert!(
+            stat.times
+                .iter()
+                .any(|time| matches!(time, Timestamp::FilenameCreated(_)))
+        );
+
+        assert!(
+            stat.times
+                .iter()
+                .any(|time| matches!(time, Timestamp::FilenameChanged(_)))
         );
 
         assert!(

--- a/forensics/src/accessor/filesystem/ntfs/data.rs
+++ b/forensics/src/accessor/filesystem/ntfs/data.rs
@@ -1,21 +1,30 @@
-use crate::accessor::{
-    entry::{
-        handle::{DirEntry, DirHandle, FileHandle},
-        locator::{DirLocator, FileLocator},
-    },
-    error::{AccessorError, AccessorResult},
-    filesystem::ntfs::{
-        attributes::read_named_data,
-        volume::NtfsVolume,
-        walk::{
-            get_file_size, list_children, list_children_handle, ntfs_err, open_by_ref, resolve_file,
+use crate::{
+    accessor::{
+        entry::{
+            handle::{DirEntry, DirHandle, EntryKind, EntryMeta, EntryStat, FileHandle, Timestamp},
+            locator::{DirLocator, FileLocator},
         },
-        wof::{decompress_wof, is_wof_file},
+        error::{AccessorError, AccessorResult},
+        filesystem::ntfs::{
+            attributes::read_named_data,
+            volume::NtfsVolume,
+            walk::{
+                get_file_size, list_children, list_children_handle, ntfs_err, open_by_ref,
+                resolve_entry, resolve_file,
+            },
+            wof::{decompress_wof, is_wof_file},
+        },
+        io::reader::{AccessorReader, ReaderLocation},
+        location::{path::InnerPath, scheme::Scheme},
     },
-    io::reader::{AccessorReader, ReaderLocation},
-    location::{path::InnerPath, scheme::Scheme},
+    utils::time::filetime_to_iso,
 };
-use ntfs::{NtfsFile, NtfsReadSeek, attribute_value::NtfsAttributeValue};
+use ntfs::{
+    NtfsAttributeType::FileName,
+    NtfsFile, NtfsReadSeek,
+    attribute_value::NtfsAttributeValue,
+    structured_values::{NtfsFileName, NtfsFileNamespace},
+};
 use std::{cmp::Ordering, fmt, mem};
 use std::{
     io::{self, Read, Seek, SeekFrom},
@@ -172,6 +181,197 @@ impl<T: Read + Seek + Send + 'static> NtfsFs<T> {
             ))),
         }
     }
+
+    /// Return metadata and timetamps for a NTFS path
+    pub(crate) fn stat(&self, inner: &InnerPath) -> AccessorResult<EntryStat> {
+        let (inner_path, attribute_name) = inner_to_ntfs_path(inner, self.drive);
+        let display_path = display_ntfs_path(self.drive, &inner_path);
+
+        let path = if attribute_name.is_empty() {
+            display_path
+        } else {
+            format!("{display_path}:{attribute_name}")
+        };
+
+        self.volume.with_reader(|ntfs, reader| {
+            let file = resolve_entry(ntfs, reader, &inner_path)?;
+
+            self.stat_from_file(reader, ntfs, &file, &path)
+        })
+    }
+
+    /// Return metadata and timetamps for a file handle
+    pub(crate) fn stat_handle(&self, handle: &FileHandle) -> AccessorResult<EntryStat> {
+        match &handle.locator {
+            FileLocator::Ntfs {
+                drive,
+                file_ref,
+                display_path,
+            } => {
+                if *drive != self.drive {
+                    return Err(AccessorError::invalid_handle(format!(
+                        "ntfs source cannot stat file handle for {}",
+                        handle.display_path()
+                    )));
+                }
+
+                self.volume.with_reader(|ntfs, reader| {
+                    let file = open_by_ref(ntfs, reader, file_ref)?;
+                    self.stat_from_file(reader, ntfs, &file, display_path)
+                })
+            }
+            _ => Err(AccessorError::invalid_handle(format!(
+                "ntfs source cannot stat file handle for {}",
+                handle.display_path()
+            ))),
+        }
+    }
+
+    /// Return metadata and timetamps for a directory handle
+    pub(crate) fn stat_dir_handle(&self, handle: &DirHandle) -> AccessorResult<EntryStat> {
+        match &handle.locator {
+            DirLocator::Ntfs {
+                drive,
+                dir_ref,
+                display_path,
+            } => {
+                if *drive != self.drive {
+                    return Err(AccessorError::invalid_handle(format!(
+                        "ntfs source cannot stat directory handle for {}",
+                        handle.display_path()
+                    )));
+                }
+                self.volume.with_reader(|ntfs, reader| {
+                    let file = open_by_ref(ntfs, reader, dir_ref)?;
+                    self.stat_from_file(reader, ntfs, &file, display_path)
+                })
+            }
+            _ => Err(AccessorError::invalid_handle(format!(
+                "ntfs source cannot stat directory handle for {}",
+                handle.display_path()
+            ))),
+        }
+    }
+
+    /// Return metadata and timetamps for a NTFS entry
+    fn stat_from_file<R: Read + Seek>(
+        &self,
+        reader: &mut R,
+        ntfs: &ntfs::Ntfs,
+        file: &NtfsFile<'_>,
+        display_path: &str,
+    ) -> AccessorResult<EntryStat> {
+        let kind = if file.is_directory() {
+            EntryKind::Directory
+        } else {
+            EntryKind::File
+        };
+
+        let size = if kind == EntryKind::File {
+            get_file_size(ntfs, reader, file.file_record_number())?
+        } else {
+            0
+        };
+
+        Ok(EntryStat {
+            meta: EntryMeta::new(kind, size, format!("ntfs:{display_path}")),
+            times: ntfs_times(reader, file)?,
+        })
+    }
+}
+
+/// Extract all 8 timestamps for a NTFS entry
+fn ntfs_times<R: Read + Seek>(
+    reader: &mut R,
+    file: &NtfsFile<'_>,
+) -> AccessorResult<Vec<Timestamp>> {
+    let info = file.info().map_err(ntfs_err)?;
+    let mut times = Vec::new();
+
+    push_filetime(
+        &mut times,
+        Timestamp::Created,
+        info.creation_time().nt_timestamp(),
+    );
+
+    push_filetime(
+        &mut times,
+        Timestamp::Modified,
+        info.modification_time().nt_timestamp(),
+    );
+
+    push_filetime(
+        &mut times,
+        Timestamp::Accessed,
+        info.access_time().nt_timestamp(),
+    );
+
+    push_filetime(
+        &mut times,
+        Timestamp::Changed,
+        info.mft_record_modification_time().nt_timestamp(),
+    );
+
+    if let Some(name) = first_non_dos_filename(reader, file)? {
+        push_filetime(
+            &mut times,
+            Timestamp::FilenameCreated,
+            name.creation_time().nt_timestamp(),
+        );
+
+        push_filetime(
+            &mut times,
+            Timestamp::FilenameModified,
+            name.modification_time().nt_timestamp(),
+        );
+
+        push_filetime(
+            &mut times,
+            Timestamp::FilenameAccessed,
+            name.access_time().nt_timestamp(),
+        );
+
+        push_filetime(
+            &mut times,
+            Timestamp::FilenameChanged,
+            name.mft_record_modification_time().nt_timestamp(),
+        );
+    }
+
+    Ok(times)
+}
+
+/// Extract the Filetime for the NTFS entry
+fn first_non_dos_filename<R: Read + Seek>(
+    reader: &mut R,
+    file: &NtfsFile<'_>,
+) -> AccessorResult<Option<NtfsFileName>> {
+    let mut attrs = file.attributes();
+    while let Some(attr_value) = attrs.next(reader) {
+        let item = attr_value.map_err(ntfs_err)?;
+        let attr = item.to_attribute().map_err(ntfs_err)?;
+
+        if attr.ty().map_err(ntfs_err)? != FileName {
+            continue;
+        }
+
+        let name = attr
+            .structured_value::<_, NtfsFileName>(reader)
+            .map_err(ntfs_err)?;
+
+        if name.namespace() == NtfsFileNamespace::Dos {
+            continue;
+        }
+
+        return Ok(Some(name));
+    }
+
+    Ok(None)
+}
+
+/// Convert Windows Filetime to RFC 3339
+fn push_filetime(times: &mut Vec<Timestamp>, kind: fn(String) -> Timestamp, filetime: u64) {
+    times.push(kind(filetime_to_iso(filetime)))
 }
 
 /// Create a reader to stream large files by accessing the raw NTFS filesystem
@@ -583,7 +783,10 @@ pub(crate) fn display_ntfs_path(drive: char, inner_path: &str) -> String {
 #[cfg(test)]
 mod tests {
     use crate::accessor::{
-        entry::{handle::FileHandle, locator::FileLocator},
+        entry::{
+            handle::{EntryKind, FileHandle, Timestamp},
+            locator::FileLocator,
+        },
         error::AccessorError,
         filesystem::ntfs::{
             data::{NtfsFs, strip_drive_prefix_and_ads},
@@ -605,7 +808,7 @@ mod tests {
     }
 
     fn hello_path() -> InnerPath {
-        InnerPath::new(PathBuf::from("hello/hello world.txt"))
+        InnerPath::new(PathBuf::from("hello\\hello world.txt"))
     }
 
     fn main_ts_path() -> InnerPath {
@@ -720,7 +923,7 @@ mod tests {
     fn test_seek_current_and_end() {
         let fs = test_fs();
         let mut stream = fs.reader(&hello_path()).unwrap();
-        stream.seek(SeekFrom::End(-5)).unwrap(); // "world\n"
+        stream.seek(SeekFrom::End(-5)).unwrap();
         let mut buf = [0u8; 8];
         let size = stream.read(&mut buf).unwrap();
 
@@ -743,6 +946,7 @@ mod tests {
         let mut stream = fs.reader(&hello_path()).unwrap();
         let mut first = [0u8; 12];
         let mut second = [0u8; 12];
+
         stream.read_exact(&mut first).unwrap();
         stream.seek(SeekFrom::Start(0)).unwrap();
         stream.read_exact(&mut second).unwrap();
@@ -943,5 +1147,26 @@ mod tests {
         assert!(reader.location.display_path().starts_with("ntfs:"));
         assert!(reader.location.full_path().contains("hello world.txt"));
         assert_eq!(reader.location.filename(), "hello world.txt");
+    }
+
+    #[test]
+    fn test_ntfs_stat() {
+        let fs = test_fs();
+        let stat = fs.stat(&hello_path()).unwrap();
+        println!("{stat:?}");
+
+        assert_eq!(stat.meta.filename, "hello world.txt");
+        assert_eq!(stat.meta.kind, EntryKind::File);
+        assert!(
+            stat.times
+                .iter()
+                .any(|time| matches!(time, Timestamp::Accessed(_)))
+        );
+
+        assert!(
+            stat.times
+                .iter()
+                .any(|time| matches!(time, Timestamp::FilenameModified(_)))
+        );
     }
 }

--- a/forensics/src/accessor/filesystem/ntfs/walk.rs
+++ b/forensics/src/accessor/filesystem/ntfs/walk.rs
@@ -109,11 +109,21 @@ pub(crate) fn resolve_file<'a, R: Read + Seek>(
     reader: &mut R,
     inner_path: &str,
 ) -> AccessorResult<NtfsFile<'a>> {
-    let components = split_inner_path(inner_path);
-    if components.is_empty() {
+    let entry = resolve_entry(ntfs, reader, inner_path)?;
+    if entry.is_directory() {
         return Err(AccessorError::not_a_file(inner_path));
     }
 
+    Ok(entry)
+}
+
+/// Return a `NtfsFile` for a file or directory
+pub(crate) fn resolve_entry<'a, R: Read + Seek>(
+    ntfs: &'a Ntfs,
+    reader: &mut R,
+    inner_path: &str,
+) -> AccessorResult<NtfsFile<'a>> {
+    let components = split_inner_path(inner_path);
     let mut current = ntfs.root_directory(reader).map_err(ntfs_err)?;
 
     for (component_index, component) in components.iter().enumerate() {
@@ -134,10 +144,6 @@ pub(crate) fn resolve_file<'a, R: Read + Seek>(
         };
 
         current = entry.to_file(ntfs, reader).map_err(ntfs_err)?;
-    }
-
-    if current.is_directory() {
-        return Err(AccessorError::not_a_file(inner_path));
     }
 
     Ok(current)

--- a/forensics/src/accessor/filesystem/zip.rs
+++ b/forensics/src/accessor/filesystem/zip.rs
@@ -1,6 +1,9 @@
 use crate::accessor::{
     entry::{
-        handle::{DirEntry, DirHandle, EntryKind, EntryMeta, FileHandle, GlobMatch, ItemHandle},
+        handle::{
+            DirEntry, DirHandle, EntryKind, EntryMeta, EntryStat, FileHandle, GlobMatch,
+            ItemHandle, Timestamp,
+        },
         locator::{DirLocator, FileLocator},
     },
     error::{AccessorError, AccessorResult},
@@ -11,9 +14,10 @@ use crate::accessor::{
     io::reader::{AccessorReader, ReaderLocation},
     location::path::InnerPath,
 };
+use chrono::{NaiveDate, NaiveTime, SecondsFormat, TimeZone, Utc};
 use glob::Pattern;
 use std::{collections::BTreeMap, fs::File, io::Read, path::PathBuf, sync::Mutex};
-use zip::ZipArchive;
+use zip::{DateTime, ZipArchive};
 
 /// A record representing a zip content entry
 #[derive(Debug, Clone)]
@@ -26,6 +30,8 @@ struct ZipEntryRecord {
     is_dir: bool,
     /// Decompressed size
     size: u64,
+    /// Last modified timestamp of zip entry (DOS timestamp)
+    modified: Option<String>,
 }
 
 /// Represents our zip archive file
@@ -72,9 +78,8 @@ impl ZipIndex {
                 .map_err(|err| AccessorError::zip(archive_path.clone(), err.to_string()))?;
 
             let path = ZipFs::normalize_zip_path(entry.name());
-            let is_dir = entry.is_dir();
-            let size = entry.size();
 
+            let is_dir = entry.is_dir();
             if !is_dir && !path.is_empty() {
                 // If a zip file contains duplicate path. Something could be wrong with the zip file, ex: corruption
                 if file_paths.contains_key(&path) {
@@ -85,12 +90,15 @@ impl ZipIndex {
                 }
                 file_paths.insert(path.clone(), entries.len());
             }
+            let size = entry.size();
+            let modified = entry.last_modified().and_then(zip_datetime_to_iso);
 
             entries.push(ZipEntryRecord {
                 index,
                 path,
                 is_dir,
                 size,
+                modified,
             });
         }
 
@@ -106,6 +114,12 @@ impl ZipIndex {
         self.file_paths
             .get(path)
             .and_then(|position| self.entries.get(*position))
+    }
+
+    /// Return the `ZipEntryRecord` associated with file or directory in the zip file
+    fn record_for_path(&self, path: &str) -> Option<&ZipEntryRecord> {
+        self.record_at(path)
+            .or_else(|| self.entries.iter().find(|entry| entry.path == path))
     }
 
     /// Return the Directory index for path
@@ -311,34 +325,6 @@ impl ZipFs {
         Ok(matches)
     }
 
-    /// Return a zip entry match for our glob
-    fn zip_child_to_glob_match(&self, child: ZipChild) -> GlobMatch {
-        let (handle, kind, size, display_path) = match child {
-            ZipChild::File { record, .. } => (
-                ItemHandle::File(FileHandle::new(FileLocator::Zip {
-                    archive: self.index.archive_path.clone(),
-                    entry_index: record.index as u32,
-                    entry: record.path.clone(),
-                })),
-                EntryKind::File,
-                record.size,
-                self.display_entry_path(&record.path),
-            ),
-            ZipChild::Directory { prefix, .. } => (
-                ItemHandle::Directory(DirHandle::new(DirLocator::Zip {
-                    archive: self.index.archive_path.clone(),
-                    entry_index: self.index.dir_entry_index(&prefix),
-                    prefix: prefix.clone(),
-                })),
-                EntryKind::Directory,
-                0,
-                self.display_entry_path(&prefix),
-            ),
-        };
-
-        GlobMatch::new(handle, EntryMeta::new(kind, size, display_path))
-    }
-
     /// Open a `AccessorReader` to the provided `InnerPath`
     ///
     /// Due to the zip file crate limitations this reader reads the file into memory
@@ -368,6 +354,136 @@ impl ZipFs {
             bytes,
             ReaderLocation::from_display(handle.display_path()),
         ))
+    }
+
+    /// Return metadata and timestamp for provided `InnerPath`
+    pub(crate) fn stat(&self, inner: &InnerPath) -> AccessorResult<EntryStat> {
+        let path = Self::inner_to_prefix(inner);
+
+        if let Some(record) = self.index.record_for_path(&path) {
+            return Ok(self.stat_from_record(record));
+        }
+
+        if path.is_empty() || !self.list_children(&path)?.is_empty() {
+            return Ok(self.stat_virtual_dir(&path));
+        }
+
+        Err(AccessorError::not_found(self.display_entry_path(&path)))
+    }
+
+    /// Return metadata and timestamp for zip file handle
+    pub(crate) fn stat_handle(&self, handle: &FileHandle) -> AccessorResult<EntryStat> {
+        match &handle.locator {
+            FileLocator::Zip {
+                archive,
+                entry_index,
+                entry,
+            } => {
+                if archive != &self.index.archive_path {
+                    return Err(AccessorError::invalid_handle(format!(
+                        "zip source cannot stat file handle for {}",
+                        handle.display_path()
+                    )));
+                }
+
+                let record = self
+                    .index
+                    .entries
+                    .iter()
+                    .find(|record| record.index == *entry_index as usize)
+                    .ok_or_else(|| AccessorError::not_found(handle.display_path()))?;
+
+                if record.path != *entry {
+                    return Err(AccessorError::invalid_handle(format!(
+                        "zip entry path mismatch for {}",
+                        handle.display_path()
+                    )));
+                }
+
+                Ok(self.stat_from_record(record))
+            }
+            _ => Err(AccessorError::invalid_handle(format!(
+                "zip source cannot stat file handle for {}",
+                handle.display_path()
+            ))),
+        }
+    }
+
+    /// Return metadata and timestamp for zip directory handle
+    pub(crate) fn stat_dir_handle(&self, handle: &DirHandle) -> AccessorResult<EntryStat> {
+        match &handle.locator {
+            DirLocator::Zip {
+                archive, prefix, ..
+            } => {
+                if archive != &self.index.archive_path {
+                    return Err(AccessorError::invalid_handle(format!(
+                        "zip source cannot stat directory handle for {}",
+                        handle.display_path()
+                    )));
+                }
+
+                self.stat(&InnerPath::new(PathBuf::from(prefix.clone())))
+            }
+            _ => Err(AccessorError::invalid_handle(format!(
+                "zip source cannot stat directory handle for {}",
+                handle.display_path()
+            ))),
+        }
+    }
+
+    /// Return metadata and timestamp for zip record
+    fn stat_from_record(&self, record: &ZipEntryRecord) -> EntryStat {
+        let kind = if record.is_dir {
+            EntryKind::Directory
+        } else {
+            EntryKind::File
+        };
+
+        let mut times = Vec::new();
+        if let Some(modified) = &record.modified {
+            times.push(Timestamp::Modified(modified.clone()));
+        }
+
+        EntryStat {
+            meta: EntryMeta::new(kind, record.size, self.display_entry_path(&record.path)),
+            times,
+        }
+    }
+
+    /// Return metadata and timestamp for zip directory
+    fn stat_virtual_dir(&self, prefix: &str) -> EntryStat {
+        EntryStat {
+            meta: EntryMeta::new(EntryKind::Directory, 0, self.display_entry_path(prefix)),
+            times: Vec::new(),
+        }
+    }
+
+    /// Return a zip entry match for our glob
+    fn zip_child_to_glob_match(&self, child: ZipChild) -> GlobMatch {
+        let (handle, kind, size, display_path) = match child {
+            ZipChild::File { record, .. } => (
+                ItemHandle::File(FileHandle::new(FileLocator::Zip {
+                    archive: self.index.archive_path.clone(),
+                    entry_index: record.index as u32,
+                    entry: record.path.clone(),
+                })),
+                EntryKind::File,
+                record.size,
+                self.display_entry_path(&record.path),
+            ),
+            ZipChild::Directory { prefix, .. } => (
+                ItemHandle::Directory(DirHandle::new(DirLocator::Zip {
+                    archive: self.index.archive_path.clone(),
+                    entry_index: self.index.dir_entry_index(&prefix),
+                    prefix: prefix.clone(),
+                })),
+                EntryKind::Directory,
+                0,
+                self.display_entry_path(&prefix),
+            ),
+        };
+
+        GlobMatch::new(handle, EntryMeta::new(kind, size, display_path))
     }
 
     /// Helper to convert `InnerPath` to String for zip content file access
@@ -574,6 +690,26 @@ fn glob_path_pattern(
     Ok(())
 }
 
+/// Convert the ZIP DOS timestamp to ISO RFC 3389 format
+fn zip_datetime_to_iso(datetime: DateTime) -> Option<String> {
+    let date = NaiveDate::from_ymd_opt(
+        i32::from(datetime.year()),
+        u32::from(datetime.month()),
+        u32::from(datetime.day()),
+    )?;
+
+    let time = NaiveTime::from_hms_opt(
+        u32::from(datetime.hour()),
+        u32::from(datetime.minute()),
+        u32::from(datetime.second()),
+    )?;
+
+    Some(
+        Utc.from_utc_datetime(&date.and_time(time))
+            .to_rfc3339_opts(SecondsFormat::Millis, true),
+    )
+}
+
 /// Structure to represent zip entries
 #[derive(Debug, Clone)]
 enum ZipChild {
@@ -608,7 +744,7 @@ impl ZipChild {
 mod tests {
     use crate::accessor::{
         entry::{
-            handle::{EntryKind, FileHandle},
+            handle::{EntryKind, FileHandle, Timestamp},
             locator::FileLocator,
         },
         error::AccessorError,
@@ -802,5 +938,27 @@ mod tests {
         );
 
         assert_eq!(reader.location.filename(), "tex.txt");
+    }
+
+    #[test]
+    fn test_zipfs_stat() {
+        let dir = setup("test_zipfs_stat");
+        let archive = dir.join("archive.zip");
+        write_zip(&archive, &[("home/test.txt", b"zip payload")]);
+
+        let zipfs = ZipFs::new(archive).unwrap();
+        let file = zipfs.stat(&inner("home/test.txt")).unwrap();
+
+        assert_eq!(file.meta.filename, "test.txt");
+        assert_eq!(file.meta.kind, EntryKind::File);
+        assert!(
+            file.times
+                .iter()
+                .any(|time| matches!(time, Timestamp::Modified(_)))
+        );
+
+        let virt = zipfs.stat(&inner("home")).unwrap();
+        assert_eq!(virt.meta.kind, EntryKind::Directory);
+        assert!(virt.times.is_empty());
     }
 }

--- a/forensics/src/accessor/filesystem/zip.rs
+++ b/forensics/src/accessor/filesystem/zip.rs
@@ -690,7 +690,7 @@ fn glob_path_pattern(
     Ok(())
 }
 
-/// Convert the ZIP DOS timestamp to ISO RFC 3389 format
+/// Convert the ZIP DOS timestamp to ISO RFC RFC 3339 format
 fn zip_datetime_to_iso(datetime: DateTime) -> Option<String> {
     let date = NaiveDate::from_ymd_opt(
         i32::from(datetime.year()),

--- a/forensics/src/accessor/source/backend.rs
+++ b/forensics/src/accessor/source/backend.rs
@@ -38,4 +38,6 @@ pub(crate) trait SourceBackend {
     fn open_reader_handle(&self, handle: &FileHandle) -> AccessorResult<AccessorReader>;
 
     fn stat(&self, inner: &InnerPath) -> AccessorResult<EntryStat>;
+
+    fn stat_handle(&self, handle: &FileHandle) -> AccessorResult<EntryStat>;
 }

--- a/forensics/src/accessor/source/backend.rs
+++ b/forensics/src/accessor/source/backend.rs
@@ -37,7 +37,12 @@ pub(crate) trait SourceBackend {
     /// Create a `AccessorReader` for provided `FileHandle`. Allows `Read+Seek` for provided file
     fn open_reader_handle(&self, handle: &FileHandle) -> AccessorResult<AccessorReader>;
 
+    /// Return metadata and timestamps for provided path
     fn stat(&self, inner: &InnerPath) -> AccessorResult<EntryStat>;
 
+    /// Return metadata and timestamps for provided `FileHandle`
     fn stat_handle(&self, handle: &FileHandle) -> AccessorResult<EntryStat>;
+
+    /// Return metadata and timestamps for provided `DirHandle`
+    fn stat_dir_handle(&self, handle: &DirHandle) -> AccessorResult<EntryStat>;
 }

--- a/forensics/src/accessor/source/backend.rs
+++ b/forensics/src/accessor/source/backend.rs
@@ -1,6 +1,6 @@
 use crate::accessor::{
     entry::{
-        handle::{DirEntry, DirHandle, FileHandle, GlobMatch},
+        handle::{DirEntry, DirHandle, EntryStat, FileHandle, GlobMatch},
         locator::SourceId,
     },
     error::AccessorResult,
@@ -36,4 +36,6 @@ pub(crate) trait SourceBackend {
 
     /// Create a `AccessorReader` for provided `FileHandle`. Allows `Read+Seek` for provided file
     fn open_reader_handle(&self, handle: &FileHandle) -> AccessorResult<AccessorReader>;
+
+    fn stat(&self, inner: &InnerPath) -> AccessorResult<EntryStat>;
 }

--- a/forensics/src/accessor/source/dispatch.rs
+++ b/forensics/src/accessor/source/dispatch.rs
@@ -17,7 +17,7 @@ pub(crate) enum Source {
     /// Use a zip file as the source
     Zip(ZipSource),
     /// Use raw NTFS Windows drive as the source
-    RawNtfs(NtfsSource),
+    Ntfs(NtfsSource),
 }
 
 impl Source {
@@ -26,7 +26,7 @@ impl Source {
         match self {
             Self::Host(source) => source.read_file(inner),
             Self::Zip(source) => source.read_file(inner),
-            Self::RawNtfs(source) => source.read_file(inner),
+            Self::Ntfs(source) => source.read_file(inner),
         }
     }
 
@@ -35,7 +35,7 @@ impl Source {
         match self {
             Self::Host(source) => source.read_dir(inner),
             Self::Zip(source) => source.read_dir(inner),
-            Self::RawNtfs(source) => source.read_dir(inner),
+            Self::Ntfs(source) => source.read_dir(inner),
         }
     }
 
@@ -43,7 +43,7 @@ impl Source {
         match self {
             Self::Host(source) => source.read_dir_handle(handle),
             Self::Zip(source) => source.read_dir_handle(handle),
-            Self::RawNtfs(source) => source.read_dir_handle(handle),
+            Self::Ntfs(source) => source.read_dir_handle(handle),
         }
     }
 
@@ -52,7 +52,7 @@ impl Source {
         match self {
             Self::Host(source) => source.globfs(dir, pattern),
             Self::Zip(source) => source.globfs(dir, pattern),
-            Self::RawNtfs(source) => source.globfs(dir, pattern),
+            Self::Ntfs(source) => source.globfs(dir, pattern),
         }
     }
 
@@ -61,7 +61,7 @@ impl Source {
         match self {
             Self::Host(source) => source.read_file_handle(handle),
             Self::Zip(source) => source.read_file_handle(handle),
-            Self::RawNtfs(source) => source.read_file_handle(handle),
+            Self::Ntfs(source) => source.read_file_handle(handle),
         }
     }
 
@@ -70,7 +70,7 @@ impl Source {
         match self {
             Self::Host(source) => source.open_reader_handle(handle),
             Self::Zip(source) => source.open_reader_handle(handle),
-            Self::RawNtfs(source) => source.open_reader_handle(handle),
+            Self::Ntfs(source) => source.open_reader_handle(handle),
         }
     }
 
@@ -79,7 +79,7 @@ impl Source {
         match self {
             Self::Host(source) => source.open_reader(inner),
             Self::Zip(source) => source.open_reader(inner),
-            Self::RawNtfs(source) => source.open_reader(inner),
+            Self::Ntfs(source) => source.open_reader(inner),
         }
     }
 
@@ -88,7 +88,15 @@ impl Source {
         match self {
             Source::Host(source) => source.stat(inner),
             Source::Zip(source) => source.stat(inner),
-            Source::RawNtfs(source) => source.stat(inner),
+            Source::Ntfs(source) => source.stat(inner),
+        }
+    }
+
+    pub(crate) fn stat_handle(&self, handle: &FileHandle) -> AccessorResult<EntryStat> {
+        match self {
+            Source::Host(source) => source.stat_handle(handle),
+            Source::Zip(source) => source.stat_handle(handle),
+            Source::Ntfs(source) => source.stat_handle(handle),
         }
     }
 }

--- a/forensics/src/accessor/source/dispatch.rs
+++ b/forensics/src/accessor/source/dispatch.rs
@@ -92,11 +92,21 @@ impl Source {
         }
     }
 
+    /// Stat and return metadata and timestamps for provided `FileHandle`
     pub(crate) fn stat_handle(&self, handle: &FileHandle) -> AccessorResult<EntryStat> {
         match self {
             Source::Host(source) => source.stat_handle(handle),
             Source::Zip(source) => source.stat_handle(handle),
             Source::Ntfs(source) => source.stat_handle(handle),
+        }
+    }
+
+    /// Stat and return metadata and timestamps for provided `DirHandle`
+    pub(crate) fn stat_dir_handle(&self, handle: &DirHandle) -> AccessorResult<EntryStat> {
+        match self {
+            Source::Host(source) => source.stat_dir_handle(handle),
+            Source::Zip(source) => source.stat_dir_handle(handle),
+            Source::Ntfs(source) => source.stat_dir_handle(handle),
         }
     }
 }

--- a/forensics/src/accessor/source/dispatch.rs
+++ b/forensics/src/accessor/source/dispatch.rs
@@ -1,5 +1,5 @@
 use crate::accessor::{
-    entry::handle::{DirEntry, DirHandle, FileHandle, GlobMatch},
+    entry::handle::{DirEntry, DirHandle, EntryStat, FileHandle, GlobMatch},
     error::AccessorResult,
     io::reader::AccessorReader,
     location::path::InnerPath,
@@ -80,6 +80,15 @@ impl Source {
             Self::Host(source) => source.open_reader(inner),
             Self::Zip(source) => source.open_reader(inner),
             Self::RawNtfs(source) => source.open_reader(inner),
+        }
+    }
+
+    /// Stat and return metadata and timestamps for provided path
+    pub(crate) fn stat(&self, inner: &InnerPath) -> AccessorResult<EntryStat> {
+        match self {
+            Source::Host(source) => source.stat(inner),
+            Source::Zip(source) => source.stat(inner),
+            Source::RawNtfs(source) => source.stat(inner),
         }
     }
 }

--- a/forensics/src/accessor/source/factory.rs
+++ b/forensics/src/accessor/source/factory.rs
@@ -184,7 +184,7 @@ pub(crate) fn stat_handle_on_source(
     source_from_cache(cache, source_id)?.stat_handle(handle)
 }
 
-/// Stat a file using a `DirHandle`, without reparsing the location
+/// Stat a directory using a `DirHandle`, without reparsing the location
 pub(crate) fn stat_dir_handle_on_source(
     cache: &SourceCache,
     source_id: &SourceId,

--- a/forensics/src/accessor/source/factory.rs
+++ b/forensics/src/accessor/source/factory.rs
@@ -39,7 +39,7 @@ pub(crate) fn ensure_source(
 
     let source = match source_id {
         SourceId::Host => Source::Host(HostSource::new(config)),
-        SourceId::RawNtfs(drive) => Source::RawNtfs(NtfsSource::new(config, *drive)?),
+        SourceId::Ntfs(drive) => Source::Ntfs(NtfsSource::new(config, *drive)?),
         SourceId::Zip(path) => Source::Zip(ZipSource::new(config, path.clone())?),
     };
 
@@ -47,11 +47,11 @@ pub(crate) fn ensure_source(
     Ok(())
 }
 
-/// Derive the cache key from a parsed [`Location`] scheme and source fields
+/// Derive the cache key from a parsed `Location` scheme and source fields
 ///
-/// - `Host` → [`SourceId::Host`]
-/// - `Zip` → [`SourceId::Zip`]
-/// - `RawNtfs` → [`SourceId::RawNtfs`]
+/// - `Host` → `SourceId::Host`
+/// - `Zip` → `SourceId::Zip`
+/// - `Ntfs` → `SourceId::Ntfs`
 pub(crate) fn source_id_from_location(location: &Location) -> AccessorResult<SourceId> {
     match location.scheme {
         Scheme::Host => Ok(SourceId::Host),
@@ -64,7 +64,7 @@ pub(crate) fn source_id_from_location(location: &Location) -> AccessorResult<Sou
                 source.display().chars().next().ok_or_else(|| {
                     AccessorError::location("", "ntfs source missing drive letter")
                 })?;
-            Ok(SourceId::RawNtfs(drive))
+            Ok(SourceId::Ntfs(drive))
         }
         Scheme::Zip => {
             let source = location
@@ -76,19 +76,19 @@ pub(crate) fn source_id_from_location(location: &Location) -> AccessorResult<Sou
     }
 }
 
-/// Derive [`SourceId`] from a handle produced by listing or glob
+/// Derive `SourceId` from a handle produced by listing or glob
 ///
 /// Allows `read_file_handle` or `read_dir_handle` to open the correct cached source
 /// without walking the filesystem again
 pub(crate) fn source_id_from_file_locator(locator: &FileLocator) -> AccessorResult<SourceId> {
     match locator {
         FileLocator::Host { .. } => Ok(SourceId::Host),
-        FileLocator::Ntfs { drive, .. } => Ok(SourceId::RawNtfs(*drive)),
+        FileLocator::Ntfs { drive, .. } => Ok(SourceId::Ntfs(*drive)),
         FileLocator::Zip { archive, .. } => Ok(SourceId::Zip(archive.clone())),
     }
 }
 
-/// Look up an opened source or return [`AccessorError::SourceNotOpen`]
+/// Look up an opened source or return `AccessorError::SourceNotOpen`
 ///
 /// Two-step callers must call `open` first
 fn source_from_cache<'a>(
@@ -190,7 +190,7 @@ pub(crate) fn validate_file_handle_for_source(
     match (source_id, locator) {
         (SourceId::Host, FileLocator::Host { .. }) => Ok(()),
         (
-            SourceId::RawNtfs(drive),
+            SourceId::Ntfs(drive),
             FileLocator::Ntfs {
                 drive: handle_drive,
                 ..
@@ -214,7 +214,7 @@ pub(crate) fn validate_file_handle_for_source(
 pub(crate) fn source_id_from_dir_locator(locator: &DirLocator) -> AccessorResult<SourceId> {
     match locator {
         DirLocator::Host { .. } => Ok(SourceId::Host),
-        DirLocator::Ntfs { drive, .. } => Ok(SourceId::RawNtfs(*drive)),
+        DirLocator::Ntfs { drive, .. } => Ok(SourceId::Ntfs(*drive)),
         DirLocator::Zip { archive, .. } => Ok(SourceId::Zip(archive.clone())),
     }
 }
@@ -239,7 +239,7 @@ pub(crate) fn validate_dir_handle_for_source(
     match (source_id, locator) {
         (SourceId::Host, DirLocator::Host { .. }) => Ok(()),
         (
-            SourceId::RawNtfs(drive),
+            SourceId::Ntfs(drive),
             DirLocator::Ntfs {
                 drive: handle_drive,
                 ..

--- a/forensics/src/accessor/source/factory.rs
+++ b/forensics/src/accessor/source/factory.rs
@@ -130,13 +130,22 @@ pub(crate) fn glob_on_source(
     source_from_cache(cache, source_id)?.globfs(directory, pattern)
 }
 
-/// Read a file using a handle, without reparsing a location string
+/// Read a file using a `FileHandle`, without reparsing a location string
 pub(crate) fn read_file_handle_on_source(
     cache: &SourceCache,
     source_id: &SourceId,
     handle: &FileHandle,
 ) -> AccessorResult<Vec<u8>> {
     source_from_cache(cache, source_id)?.read_file_handle(handle)
+}
+
+/// Read a directory using a handle, without reparsing a location string
+pub(crate) fn read_dir_handle_on_source(
+    cache: &SourceCache,
+    source_id: &SourceId,
+    handle: &DirHandle,
+) -> AccessorResult<Vec<DirEntry>> {
+    source_from_cache(cache, source_id)?.read_dir_handle(handle)
 }
 
 /// Open a seekable reader using a handle, without reparsing a location string
@@ -157,6 +166,7 @@ pub(crate) fn open_reader_on_source(
     source_from_cache(cache, source_id)?.open_reader(inner)
 }
 
+/// Stat a path relative to an already-open source using an inner path
 pub(crate) fn stat_on_source(
     cache: &SourceCache,
     source_id: &SourceId,
@@ -165,6 +175,23 @@ pub(crate) fn stat_on_source(
     source_from_cache(cache, source_id)?.stat(inner)
 }
 
+/// Stat a file using a `FileHandle`, without reparsing the location
+pub(crate) fn stat_handle_on_source(
+    cache: &SourceCache,
+    source_id: &SourceId,
+    handle: &FileHandle,
+) -> AccessorResult<EntryStat> {
+    source_from_cache(cache, source_id)?.stat_handle(handle)
+}
+
+/// Stat a file using a `DirHandle`, without reparsing the location
+pub(crate) fn stat_dir_handle_on_source(
+    cache: &SourceCache,
+    source_id: &SourceId,
+    handle: &DirHandle,
+) -> AccessorResult<EntryStat> {
+    source_from_cache(cache, source_id)?.stat_dir_handle(handle)
+}
 /// Parse a relative inner path
 ///
 /// Used after `open("host:")` or `open("zip:/path/archive.zip")`
@@ -217,15 +244,6 @@ pub(crate) fn source_id_from_dir_locator(locator: &DirLocator) -> AccessorResult
         DirLocator::Ntfs { drive, .. } => Ok(SourceId::Ntfs(*drive)),
         DirLocator::Zip { archive, .. } => Ok(SourceId::Zip(archive.clone())),
     }
-}
-
-/// Read a directory using a handle, without reparsing a location string
-pub(crate) fn read_dir_handle_on_source(
-    cache: &SourceCache,
-    source_id: &SourceId,
-    handle: &DirHandle,
-) -> AccessorResult<Vec<DirEntry>> {
-    source_from_cache(cache, source_id)?.read_dir_handle(handle)
 }
 
 /// Ensure a handle's locator matches the currently open source

--- a/forensics/src/accessor/source/factory.rs
+++ b/forensics/src/accessor/source/factory.rs
@@ -2,7 +2,7 @@ use crate::accessor::{
     cache::SourceCache,
     config::AccessorConfig,
     entry::{
-        handle::{DirEntry, DirHandle, FileHandle, GlobMatch},
+        handle::{DirEntry, DirHandle, EntryStat, FileHandle, GlobMatch},
         locator::{DirLocator, FileLocator, SourceId},
     },
     error::{AccessorError, AccessorResult},
@@ -155,6 +155,14 @@ pub(crate) fn open_reader_on_source(
     inner: &InnerPath,
 ) -> AccessorResult<AccessorReader> {
     source_from_cache(cache, source_id)?.open_reader(inner)
+}
+
+pub(crate) fn stat_on_source(
+    cache: &SourceCache,
+    source_id: &SourceId,
+    inner: &InnerPath,
+) -> AccessorResult<EntryStat> {
+    source_from_cache(cache, source_id)?.stat(inner)
 }
 
 /// Parse a relative inner path

--- a/forensics/src/accessor/source/host.rs
+++ b/forensics/src/accessor/source/host.rs
@@ -61,6 +61,10 @@ impl SourceBackend for HostSource {
     fn stat(&self, inner: &InnerPath) -> AccessorResult<EntryStat> {
         HostFs::stat(inner)
     }
+
+    fn stat_handle(&self, handle: &FileHandle) -> AccessorResult<EntryStat> {
+        HostFs::stat_handle(handle)
+    }
 }
 
 #[cfg(test)]

--- a/forensics/src/accessor/source/host.rs
+++ b/forensics/src/accessor/source/host.rs
@@ -1,7 +1,7 @@
 use crate::accessor::{
     config::AccessorConfig,
     entry::{
-        handle::{DirEntry, DirHandle, FileHandle, GlobMatch},
+        handle::{DirEntry, DirHandle, EntryStat, FileHandle, GlobMatch},
         locator::SourceId,
     },
     error::AccessorResult,
@@ -56,6 +56,10 @@ impl SourceBackend for HostSource {
 
     fn read_dir_handle(&self, handle: &DirHandle) -> AccessorResult<Vec<DirEntry>> {
         HostFs::read_dir_handle(handle)
+    }
+
+    fn stat(&self, inner: &InnerPath) -> AccessorResult<EntryStat> {
+        HostFs::stat(inner)
     }
 }
 

--- a/forensics/src/accessor/source/host.rs
+++ b/forensics/src/accessor/source/host.rs
@@ -65,6 +65,10 @@ impl SourceBackend for HostSource {
     fn stat_handle(&self, handle: &FileHandle) -> AccessorResult<EntryStat> {
         HostFs::stat_handle(handle)
     }
+
+    fn stat_dir_handle(&self, handle: &DirHandle) -> AccessorResult<EntryStat> {
+        HostFs::stat_dir_handle(handle)
+    }
 }
 
 #[cfg(test)]

--- a/forensics/src/accessor/source/ntfs.rs
+++ b/forensics/src/accessor/source/ntfs.rs
@@ -49,6 +49,8 @@ trait NtfsFsBackend: Send {
     fn stat(&self, inner: &InnerPath) -> AccessorResult<EntryStat>;
     /// Return metadata and timestamps for provided `FileHandle`
     fn stat_handle(&self, handle: &FileHandle) -> AccessorResult<EntryStat>;
+    /// Return metadata and timestamps for provided `DirHandle`
+    fn stat_dir_handle(&self, handle: &DirHandle) -> AccessorResult<EntryStat>;
 }
 
 impl<T> NtfsFsBackend for NtfsFs<T>
@@ -93,6 +95,10 @@ where
 
     fn stat_handle(&self, handle: &FileHandle) -> AccessorResult<EntryStat> {
         self.stat_handle(handle)
+    }
+
+    fn stat_dir_handle(&self, handle: &DirHandle) -> AccessorResult<EntryStat> {
+        self.stat_dir_handle(handle)
     }
 }
 
@@ -163,6 +169,10 @@ impl SourceBackend for NtfsSource {
 
     fn stat_handle(&self, handle: &FileHandle) -> AccessorResult<EntryStat> {
         self.fs.stat_handle(handle)
+    }
+
+    fn stat_dir_handle(&self, handle: &DirHandle) -> AccessorResult<EntryStat> {
+        self.fs.stat_dir_handle(handle)
     }
 }
 

--- a/forensics/src/accessor/source/ntfs.rs
+++ b/forensics/src/accessor/source/ntfs.rs
@@ -1,7 +1,7 @@
 use crate::accessor::{
     config::AccessorConfig,
     entry::{
-        handle::{DirEntry, DirHandle, FileHandle, GlobMatch},
+        handle::{DirEntry, DirHandle, EntryStat, FileHandle, GlobMatch},
         locator::SourceId,
     },
     error::{AccessorError, AccessorResult},
@@ -45,6 +45,7 @@ trait NtfsFsBackend: Send {
     fn reader(&self, inner: &InnerPath) -> AccessorResult<AccessorReader>;
     /// Open a file for streaming via ntfs disk access by file reference
     fn reader_handle(&self, handle: &FileHandle) -> AccessorResult<AccessorReader>;
+    fn stat(&self, inner: &InnerPath) -> AccessorResult<EntryStat>;
 }
 
 impl<T> NtfsFsBackend for NtfsFs<T>
@@ -81,6 +82,10 @@ where
 
     fn reader_handle(&self, handle: &FileHandle) -> AccessorResult<AccessorReader> {
         self.reader_handle(handle)
+    }
+
+    fn stat(&self, inner: &InnerPath) -> AccessorResult<EntryStat> {
+        self.stat(inner)
     }
 }
 
@@ -143,6 +148,10 @@ impl SourceBackend for NtfsSource {
 
     fn open_reader_handle(&self, handle: &FileHandle) -> AccessorResult<AccessorReader> {
         self.fs.reader_handle(handle)
+    }
+
+    fn stat(&self, inner: &InnerPath) -> AccessorResult<EntryStat> {
+        self.fs.stat(inner)
     }
 }
 

--- a/forensics/src/accessor/source/ntfs.rs
+++ b/forensics/src/accessor/source/ntfs.rs
@@ -45,7 +45,10 @@ trait NtfsFsBackend: Send {
     fn reader(&self, inner: &InnerPath) -> AccessorResult<AccessorReader>;
     /// Open a file for streaming via ntfs disk access by file reference
     fn reader_handle(&self, handle: &FileHandle) -> AccessorResult<AccessorReader>;
+    /// Return metadata and timestamps for provided path
     fn stat(&self, inner: &InnerPath) -> AccessorResult<EntryStat>;
+    /// Return metadata and timestamps for provided `FileHandle`
+    fn stat_handle(&self, handle: &FileHandle) -> AccessorResult<EntryStat>;
 }
 
 impl<T> NtfsFsBackend for NtfsFs<T>
@@ -87,6 +90,10 @@ where
     fn stat(&self, inner: &InnerPath) -> AccessorResult<EntryStat> {
         self.stat(inner)
     }
+
+    fn stat_handle(&self, handle: &FileHandle) -> AccessorResult<EntryStat> {
+        self.stat_handle(handle)
+    }
 }
 
 impl NtfsSource {
@@ -119,7 +126,7 @@ impl NtfsSource {
 
 impl SourceBackend for NtfsSource {
     fn source_id(&self) -> SourceId {
-        SourceId::RawNtfs(self.drive)
+        SourceId::Ntfs(self.drive)
     }
 
     fn read_file(&self, inner: &InnerPath) -> AccessorResult<Vec<u8>> {
@@ -152,6 +159,10 @@ impl SourceBackend for NtfsSource {
 
     fn stat(&self, inner: &InnerPath) -> AccessorResult<EntryStat> {
         self.fs.stat(inner)
+    }
+
+    fn stat_handle(&self, handle: &FileHandle) -> AccessorResult<EntryStat> {
+        self.fs.stat_handle(handle)
     }
 }
 

--- a/forensics/src/accessor/source/zip.rs
+++ b/forensics/src/accessor/source/zip.rs
@@ -1,7 +1,7 @@
 use crate::accessor::{
     config::AccessorConfig,
     entry::{
-        handle::{DirEntry, DirHandle, FileHandle, GlobMatch},
+        handle::{DirEntry, DirHandle, EntryStat, FileHandle, GlobMatch},
         locator::SourceId,
     },
     error::AccessorResult,
@@ -64,6 +64,10 @@ impl SourceBackend for ZipSource {
 
     fn open_reader_handle(&self, handle: &FileHandle) -> AccessorResult<AccessorReader> {
         self.fs.reader_handle(handle, self.max_read_size)
+    }
+
+    fn stat(&self, inner: &InnerPath) -> AccessorResult<EntryStat> {
+        self.fs.stat(inner)
     }
 }
 

--- a/forensics/src/accessor/source/zip.rs
+++ b/forensics/src/accessor/source/zip.rs
@@ -221,7 +221,7 @@ mod tests {
 
     #[test]
     fn test_zip_stat() {
-        let dir = setup("test_zip_source_read_file");
+        let dir = setup("test_zip_source_stat");
         let archive = dir.join("archive.zip");
         write_zip(&archive, &[("inner.txt", b"zip source payload")]);
         let source = ZipSource::new(&AccessorConfig::default(), archive).unwrap();

--- a/forensics/src/accessor/source/zip.rs
+++ b/forensics/src/accessor/source/zip.rs
@@ -73,6 +73,10 @@ impl SourceBackend for ZipSource {
     fn stat_handle(&self, handle: &FileHandle) -> AccessorResult<EntryStat> {
         self.fs.stat_handle(handle)
     }
+
+    fn stat_dir_handle(&self, handle: &DirHandle) -> AccessorResult<EntryStat> {
+        self.fs.stat_dir_handle(handle)
+    }
 }
 
 #[cfg(test)]

--- a/forensics/src/accessor/source/zip.rs
+++ b/forensics/src/accessor/source/zip.rs
@@ -218,4 +218,18 @@ mod tests {
             .unwrap();
         assert_eq!(bytes.len(), 974);
     }
+
+    #[test]
+    fn test_zip_stat() {
+        let dir = setup("test_zip_source_read_file");
+        let archive = dir.join("archive.zip");
+        write_zip(&archive, &[("inner.txt", b"zip source payload")]);
+        let source = ZipSource::new(&AccessorConfig::default(), archive).unwrap();
+
+        let meta = source
+            .stat(&InnerPath::new(PathBuf::from("inner.txt")))
+            .unwrap();
+
+        assert!(!meta.times.is_empty());
+    }
 }

--- a/forensics/src/accessor/source/zip.rs
+++ b/forensics/src/accessor/source/zip.rs
@@ -69,6 +69,10 @@ impl SourceBackend for ZipSource {
     fn stat(&self, inner: &InnerPath) -> AccessorResult<EntryStat> {
         self.fs.stat(inner)
     }
+
+    fn stat_handle(&self, handle: &FileHandle) -> AccessorResult<EntryStat> {
+        self.fs.stat_handle(handle)
+    }
 }
 
 #[cfg(test)]

--- a/forensics/src/artifacts/os/files/filelisting.rs
+++ b/forensics/src/artifacts/os/files/filelisting.rs
@@ -203,7 +203,7 @@ fn file_metadata(
         // Always make sure we tell the `Accessor` to use the `Host Accessor`
         // Should prevent confusion when paths contain `zip:/file.zip/ntfs:files.txt`
         file_entry.binary_info =
-            executable_metadata(&format!("host:{}", &entry.path().display()), plat)
+            executable_metadata(&format!("host:{}", entry.path().display()), plat)
                 .unwrap_or_default();
     }
 

--- a/forensics/src/artifacts/os/windows/eventlogs/formatters.rs
+++ b/forensics/src/artifacts/os/windows/eventlogs/formatters.rs
@@ -130,7 +130,6 @@ fn format_message(
     let mut plus_option = String::new();
     let mut width_value = 0;
     let mut precision_value = 0;
-    let message;
 
     if options
         .flags
@@ -153,30 +152,28 @@ fn format_message(
         .as_ref()
         .is_some_and(|f| f.contains(&Flags::AlignLeft) && f.contains(&Flags::Spaces))
     {
-        message = format!(
+        format!(
             "{plus_symbol}{:<width$.precision$}",
             serde_json::from_value(data.clone()).unwrap_or(data.to_string()),
             width = width_value as usize,
             precision = precision_value as usize,
             plus_symbol = plus_option
-        );
+        )
     } else if options
         .flags
         .as_ref()
         .is_some_and(|f| f.contains(&Flags::AlignLeft) && f.contains(&Flags::Zeros))
     {
-        message = format!(
+        format!(
             "{plus_symbol}{:0<width$.precision$}",
             serde_json::from_value(data.clone()).unwrap_or(data.to_string()),
             width = width_value as usize,
             precision = precision_value as usize,
             plus_symbol = plus_option
-        );
+        )
     } else {
-        message = serde_json::from_value(data.clone()).unwrap_or(data.to_string());
+        serde_json::from_value(data.clone()).unwrap_or(data.to_string())
     }
-
-    message
 }
 
 /// Get the %# number from string. Ex: %1!s! returns: (!s!, (%1, 1))

--- a/forensics/src/artifacts/os/windows/shellbags/parser.rs
+++ b/forensics/src/artifacts/os/windows/shellbags/parser.rs
@@ -339,10 +339,9 @@ mod tests {
             registry::helper::get_registry_keys_handle,
             shellbags::parser::{
                 RegInfo, Shellbag, alt_shellbags, extract_registry_shellbags, extract_shellbags,
-                grab_shellbags, parse_shellbags, save_shellbags, update_shellbags,
+                save_shellbags, update_shellbags,
             },
         },
-        structs::artifacts::os::windows::ShellbagsOptions,
         utils::regex_options::create_regex,
     };
     use common::windows::{ShellItem, ShellType};
@@ -351,6 +350,11 @@ mod tests {
     #[test]
     #[cfg(target_os = "windows")]
     fn test_grab_shellbags() {
+        use crate::{
+            artifacts::os::windows::shellbags::parser::grab_shellbags,
+            structs::artifacts::os::windows::ShellbagsOptions,
+        };
+
         let options = ShellbagsOptions {
             resolve_guids: true,
             alt_file: None,

--- a/forensics/src/artifacts/os/windows/shellbags/parser.rs
+++ b/forensics/src/artifacts/os/windows/shellbags/parser.rs
@@ -407,6 +407,8 @@ mod tests {
     #[test]
     #[cfg(target_os = "windows")]
     fn test_parse_shellbags() {
+        use crate::artifacts::os::windows::shellbags::parser::parse_shellbags;
+
         let drive = 'C';
         let _results = parse_shellbags(drive, false).unwrap();
     }

--- a/forensics/src/lib.rs
+++ b/forensics/src/lib.rs
@@ -18,7 +18,6 @@
     clippy::flat_map_option,
     clippy::float_cmp_const,
     clippy::fn_params_excessive_bools,
-    clippy::from_iter_instead_of_collect,
     clippy::if_let_mutex,
     clippy::implicit_clone,
     clippy::imprecise_flops,

--- a/timeline/src/lib.rs
+++ b/timeline/src/lib.rs
@@ -18,7 +18,6 @@
     clippy::flat_map_option,
     clippy::float_cmp_const,
     clippy::fn_params_excessive_bools,
-    clippy::from_iter_instead_of_collect,
     clippy::if_let_mutex,
     clippy::implicit_clone,
     clippy::imprecise_flops,


### PR DESCRIPTION
Stat support for the accessor.

Now you can get timestamps and file/directory metadata when using the accessor

```
let mut accessor = Accessor::with_defaults();
let meta  = accessor.stat("path/to/file");
```