### PR TITLE
Add Accessor filelisting support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,13 +19,13 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aes"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
+checksum = "35f0f96ce78e38c3dc6d8948aa8163d06385be74000f3c7a95bf1eef35d3ea32"
 dependencies = [
  "cipher",
  "cpubits",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
 ]
 
 [[package]]
@@ -255,7 +255,7 @@ dependencies = [
  "atoi",
  "base64 0.22.1",
  "chrono",
- "comfy-table",
+ "comfy-table 7.1.4",
  "half",
  "lexical-core",
  "num-traits",
@@ -382,7 +382,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
- "synstructure",
+ "synstructure 0.13.2",
 ]
 
 [[package]]
@@ -404,6 +404,18 @@ checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -435,7 +447,7 @@ checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -461,9 +473,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.18.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
+checksum = "b281d307588d634de920874890732659e2e7672f72b5e10e81badc1a8a83621e"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -472,9 +484,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.44.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
+checksum = "9bff6c3b54fad79a2e60b8102caf565819711497c1f5f092f49508e2f5c31b27"
 dependencies = [
  "cc",
  "cmake",
@@ -613,27 +625,29 @@ dependencies = [
 
 [[package]]
 name = "boa_ast"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6339a700715bda376f5ea65c76e8fe8fc880930d8b0638cea68e7f3da6538e0a"
+checksum = "9221b0a090572b4a118b46c5874c0781fe4bc9546b85f0a615b8bfb609ca4ed7"
 dependencies = [
  "bitflags 2.13.1",
  "boa_interner",
  "boa_macros",
  "boa_string",
  "indexmap",
- "num-bigint 0.4.8",
+ "num-bigint 0.5.1",
  "rustc-hash 2.1.3",
+ "strum 0.28.0",
 ]
 
 [[package]]
 name = "boa_engine"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1521be326f8a5c8887e95d4ce7f002917a002a23f7b93b9a6a2bf50ed4157824"
+checksum = "5d6aaf7fdc4299df68adb67e1a5440a51d34630a1f5271b9698fd74bc97b60d9"
 dependencies = [
  "aligned-vec",
  "arrayvec",
+ "async-channel",
  "bitflags 2.13.1",
  "boa_ast",
  "boa_gc",
@@ -647,22 +661,21 @@ dependencies = [
  "dashmap",
  "dynify",
  "fast-float2",
- "float16",
- "futures-channel",
  "futures-concurrency",
  "futures-lite",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "icu_normalizer",
  "indexmap",
  "intrusive-collections",
- "itertools 0.14.0",
- "num-bigint 0.4.8",
+ "itertools 0.15.0",
+ "num-bigint 0.5.1",
  "num-integer",
  "num-traits",
  "num_enum",
- "paste",
+ "oneshot",
+ "pastey",
  "portable-atomic",
- "rand 0.9.5",
+ "rand 0.10.2",
  "regress",
  "rustc-hash 2.1.3",
  "ryu-js",
@@ -675,30 +688,30 @@ dependencies = [
  "thin-vec",
  "thiserror 2.0.20",
  "time",
- "xsum",
 ]
 
 [[package]]
 name = "boa_gc"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17323a98cf2e631afacf1a6d659c1212c48a68bacfa85afab0a66ade80582e51"
+checksum = "af82119558ab1002d1978c8459b53a3ebb506177d29a3aca37c07c1777b1d966"
 dependencies = [
+ "arrayvec",
  "boa_macros",
  "boa_string",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "thin-vec",
 ]
 
 [[package]]
 name = "boa_interner"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20510b8b02bcde9b0a01cf34c0c308c56156503d1d91cdab4c8cfbd292b747ea"
+checksum = "317c631e791f5cb7d0017e43c0a758b0eaffd40c34c4c360e2a6be7752b78cd1"
 dependencies = [
  "boa_gc",
  "boa_macros",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap",
  "once_cell",
  "phf",
@@ -708,23 +721,23 @@ dependencies = [
 
 [[package]]
 name = "boa_macros"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5822cb4f146d243060e588bc5a5f2e709683fdad3d7111f42c48e6b5c921d23d"
+checksum = "b882fd440dc0f4b7441367cf89567bb077920356750c9a76a16c002d8ec2fa5c"
 dependencies = [
  "cfg-if",
  "cow-utils",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
- "synstructure",
+ "syn 3.0.5",
+ "synstructure 0.14.0",
 ]
 
 [[package]]
 name = "boa_parser"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd957fa9fa93e3a001a8aba5a5cd40c2bbfde486378be4c4b472fd304aaddb"
+checksum = "641e81b3c8cbb7a2140547fb3ea534e9edf210b4e8c920b5fa864a919e11fbcf"
 dependencies = [
  "bitflags 2.13.1",
  "boa_ast",
@@ -732,7 +745,7 @@ dependencies = [
  "boa_macros",
  "fast-float2",
  "icu_properties",
- "num-bigint 0.4.8",
+ "num-bigint 0.5.1",
  "num-traits",
  "regress",
  "rustc-hash 2.1.3",
@@ -740,12 +753,13 @@ dependencies = [
 
 [[package]]
 name = "boa_runtime"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caa4d5b97ec713cc84c95be6686d82d4ae0090c45954a61d88f901889134eba5"
+checksum = "c4f64cd1483c17ad23f3c9792cc1f949618178b79b0b25d3fee8f07d3019edd5"
 dependencies = [
  "boa_engine",
  "boa_gc",
+ "boa_wintertc",
  "bytemuck",
  "futures",
  "futures-lite",
@@ -754,16 +768,29 @@ dependencies = [
 
 [[package]]
 name = "boa_string"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2da1d7f4a76fd9040788a122f0d807910800a7b86f5952e9244848c36511de"
+checksum = "30bf86c2bcff5bf2547acbfc516c5d3108ca527cb131511d749bf6fbef762c0e"
 dependencies = [
  "fast-float2",
  "itoa",
- "paste",
+ "pastey",
  "rustc-hash 2.1.3",
  "ryu-js",
  "static_assertions",
+]
+
+[[package]]
+name = "boa_wintertc"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66d29a1e767039bfa1981bf149966d4a4d7453190abe13ffccd8aaf95031299"
+dependencies = [
+ "base64 0.23.1",
+ "boa_engine",
+ "boa_gc",
+ "comfy-table 8.0.0",
+ "rustc-hash 2.1.3",
 ]
 
 [[package]]
@@ -786,7 +813,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -832,7 +859,7 @@ checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -910,9 +937,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.4"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
+checksum = "005ec2760ca554fae18df7a11195552ec576cd665632a881bc011d5bb2fd4d80"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -934,12 +961,12 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "rand_core 0.10.1",
 ]
 
@@ -1025,7 +1052,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1086,6 +1113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "comfy-table"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136c8c4c3823846e8ba6d4bda011b4e5d5827b8bb0ac26c31f9ab31abe9f54f2"
+dependencies = [
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "common"
 version = "0.20.0"
 dependencies = [
@@ -1093,6 +1130,15 @@ dependencies = [
  "plist",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1197,9 +1243,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
@@ -1392,9 +1438,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+checksum = "622f3fc73690be383c7214310406f28a90e6edeadc3cea882f9d71e495b9711a"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -1402,18 +1448,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.20"
+version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+checksum = "dc74980687109a3b14c72fd458107bf0baa1da1a1a805e178d15501ba9b86d9d"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.22"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+checksum = "a31eee39dddec8330830986fcd7625edb5a24ec90ea038215273bbc3adb08ac6"
 
 [[package]]
 name = "crossterm"
@@ -1552,7 +1598,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1563,7 +1609,7 @@ checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
 dependencies = [
  "darling_core",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1738,7 +1784,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1765,13 +1811,13 @@ checksum = "970e05eedd3f55c435194d9104f90a9b4a79a80d6e73251bc9ff43e178130c4e"
 dependencies = [
  "arrow",
  "cast",
- "comfy-table",
+ "comfy-table 7.1.4",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink 0.10.0",
  "libduckdb-sys",
  "num-integer",
- "strum",
+ "strum 0.27.2",
 ]
 
 [[package]]
@@ -2109,9 +2155,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
 
 [[package]]
 name = "fixedbitset"
@@ -2121,23 +2167,13 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.8.9",
+ "miniz_oxide",
  "zlib-rs",
-]
-
-[[package]]
-name = "float16"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9442b5e9a7997eace4990debae01c1b69a1a601b9eeef7fada6c3f3edeff4a1"
-dependencies = [
- "cfg-if",
- "rustc_version",
 ]
 
 [[package]]
@@ -2192,14 +2228,14 @@ dependencies = [
  "lz4_flex 0.14.0",
  "macos-unifiedlogs",
  "md-5 0.11.0",
- "miniz_oxide 0.9.1",
+ "miniz_oxide",
  "nom 8.0.0",
  "ntapi",
  "ntfs",
  "parquet",
  "pelite",
  "plist",
- "quick-xml 0.42.0",
+ "quick-xml",
  "regex",
  "reqwest",
  "rusqlite",
@@ -2330,7 +2366,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -2534,8 +2570,6 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.2.0",
  "serde",
  "serde_core",
@@ -2547,6 +2581,8 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
  "serde",
  "serde_core",
@@ -2738,9 +2774,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+checksum = "27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2824,12 +2860,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.0.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -2843,7 +2880,6 @@ checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap",
- "serde",
  "tinystr",
  "writeable",
  "zerovec",
@@ -2851,11 +2887,10 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.0.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b24a59706036ba941c9476a55cd57b82b77f38a3c667d637ee7cabbc85eaedc"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
@@ -2868,31 +2903,30 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.0.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.2"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5a97b8ac6235e69506e8dacfb2adf38461d2ce6d3e9bd9c94c4cbc3cd4400a4"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
 dependencies = [
  "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "potential_utf",
  "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
@@ -2902,8 +2936,6 @@ checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
- "serde",
- "stable_deref_trait",
  "writeable",
  "yoke",
  "zerofrom",
@@ -2936,9 +2968,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -2962,9 +2994,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "cc4e190f5d26ca7051642629da2c52fc03bde85a03197c99408dcd291734c855"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -3002,7 +3034,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -3013,12 +3045,9 @@ checksum = "8eca9188c1b20836bb561bc09bb2f54e9ca99b271031b5f3ff183a00c08c98c8"
 
 [[package]]
 name = "intrusive-collections"
-version = "0.9.7"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "189d0897e4cbe8c75efedf3502c18c887b05046e59d28404d4d8e46cbc4d1e86"
-dependencies = [
- "memoffset",
-]
+checksum = "4275b20e6057cd7733fd8df8a5a31701e4fe44497dad0f3fa0e1c4fb971506be"
 
 [[package]]
 name = "inventory"
@@ -3031,9 +3060,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.1"
+version = "2.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
+checksum = "791930b43c0d5973160d90a8f3894509f2b273430f5c5c73b668636d0287c5c0"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -3189,9 +3218,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.104"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+checksum = "ce57d20d1ea864ce2ac172ab472d409214f4fd359f0b2a2775abdf522e2af99e"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3524,9 +3553,9 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memfd"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
+checksum = "57804b2c9b69967f1536a56f86297e367a33b19e98852ed624b84551cdbc0d90"
 dependencies = [
  "rustix 1.1.4",
 ]
@@ -3573,29 +3602,20 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
- "simd-adler32",
-]
-
-[[package]]
-name = "miniz_oxide"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
 dependencies = [
  "adler2",
  "serde",
+ "simd-adler32",
 ]
 
 [[package]]
 name = "mio"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
 dependencies = [
  "libc",
  "wasi",
@@ -3702,7 +3722,6 @@ checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -3713,6 +3732,7 @@ checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
 dependencies = [
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -3919,6 +3939,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oneshot"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe21416a02c693fb9f980befcb230ecc70b0b3d1cc4abf88b9675c4c1457f0c"
+
+[[package]]
 name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3995,9 +4021,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "59.2.0"
+version = "59.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7065842956a20c2a536924ce8e4d9955f7422451511b9eb7500d7bfe5077e59c"
+checksum = "ff322f54b1a0f9288e614ed1f2d329b380af5476420db19f46ffb865e1163d73"
 dependencies = [
  "ahash",
  "base64 0.23.1",
@@ -4016,10 +4042,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
+name = "pastey"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "path-tree"
@@ -4076,9 +4102,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+checksum = "010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6"
 dependencies = [
  "phf_macros",
  "phf_shared",
@@ -4086,9 +4112,9 @@ dependencies = [
 
 [[package]]
 name = "phf_generator"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+checksum = "aeb62e0959d5a1bebc965f4d15d9e2b7cea002b6b0f5ba8cde6cc26738467100"
 dependencies = [
  "fastrand",
  "phf_shared",
@@ -4096,9 +4122,9 @@ dependencies = [
 
 [[package]]
 name = "phf_macros"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+checksum = "5fa8d0ca26d424d27630da600c6624696e7dec8bf7b3b492b383c5dc49e5e085"
 dependencies = [
  "phf_generator",
  "phf_shared",
@@ -4109,9 +4135,9 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+checksum = "c6fd9027e2d9319be6349febd1db4e8d02aa544921200c9b777720ac34a3aa89"
 dependencies = [
  "siphasher",
 ]
@@ -4171,13 +4197,13 @@ checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "plist"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
+checksum = "2896bade328c13f7042a297ea5ac5b0951f6cf989dea5f32c2fd98da398195cb"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "indexmap",
- "quick-xml 0.41.0",
+ "quick-xml",
  "serde",
  "time",
 ]
@@ -4218,9 +4244,9 @@ checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+checksum = "10ab3eb7f3becc3a1cbc4f2c6f20267996cfc1a6467a873763411b136a122715"
 dependencies = [
  "portable-atomic",
 ]
@@ -4268,7 +4294,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bfe0f4c752e450fc2faf62654f1c134747922825d5b04ca717b8874f41a40c0"
 dependencies = [
  "proc-macro2",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -4335,7 +4361,7 @@ checksum = "1c8d9ca532f185d5d4db7a7c9d51420b452168ea1c2b913953281bd6fe1fcbd0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -4370,15 +4396,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -4489,18 +4506,8 @@ version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
 dependencies = [
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -4525,31 +4532,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -4613,7 +4601,7 @@ checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -4661,11 +4649,10 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "regress"
-version = "0.10.5"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2057b2325e68a893284d1538021ab90279adac1139957ca2a74426c6f118fb48"
+checksum = "32eef8b209c3c1c15dbad02c1f30f9539f00dc7253e0cbcdaae442a50a09d7c1"
 dependencies = [
- "hashbrown 0.16.1",
  "memchr",
 ]
 
@@ -4769,7 +4756,7 @@ checksum = "1c25ef604ac7dd839d44d64648952ea23c97866f124ff671b0ed2cf3ad9bb06e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -4886,7 +4873,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5129,7 +5116,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -5195,7 +5182,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "digest 0.11.3",
 ]
 
@@ -5217,7 +5204,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "digest 0.11.3",
 ]
 
@@ -5334,9 +5321,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.2"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 dependencies = [
  "serde",
 ]
@@ -5458,6 +5445,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5550,9 +5546,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.4"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5577,6 +5573,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "901704edd0dfe137f1987838ee4f259e4e063c31371bdb423f7ae38ec6f77f02"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -5724,7 +5731,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -5794,7 +5801,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
- "serde_core",
  "zerovec",
 ]
 
@@ -5810,9 +5816,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+checksum = "4cf0ded5c4e56918d8f8a339e1bb67d038d3bc6d144ac407904015ba2e4cde9b"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -5848,14 +5854,14 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.4"
+version = "0.26.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+checksum = "b0c85f2c3ef0b1cd58b36682f4b17aaa995f0e5db534d85692b4903abce21f67"
 dependencies = [
  "rustls",
  "tokio",
@@ -5877,9 +5883,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.4+spec-1.1.0"
+version = "1.1.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -6054,9 +6060,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "twox-hash"
-version = "2.1.3"
+version = "2.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9"
+checksum = "5283634e518fe9e82c7b20520bb4bc209009fd16c82077c802f8111ecbb0117a"
 
 [[package]]
 name = "typed-path"
@@ -6114,9 +6120,9 @@ checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
 name = "ureq"
-version = "3.4.0"
+version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
+checksum = "af5546be8f5378d5414f83733f5c9a2526f4645829edbc1c41790aeef1b38e8b"
 dependencies = [
  "base64 0.23.1",
  "log",
@@ -6130,9 +6136,9 @@ dependencies = [
 
 [[package]]
 name = "ureq-proto"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613"
+checksum = "fabc3e92916c89c95b20eef7b06b00b066bc217ef9ea3a4ac9bf1a7e35261e10"
 dependencies = [
  "base64 0.23.1",
  "http",
@@ -6187,9 +6193,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.25.0"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -6309,9 +6315,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
+checksum = "aecb87a33d3b0c5e3b7aa46336eaf486cffafbd281b195e4c8b80d50df2351bf"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6322,9 +6328,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.77"
+version = "0.4.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
+checksum = "6ef4c5d3d2cdf5c54f4231181768f5510842e350db025faf1f7163b1030ed928"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6332,9 +6338,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
+checksum = "a690d511e3c1a8b3a55e33511e3c2c00c78415cd23650f32b808627f5696b9ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6342,22 +6348,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
+checksum = "411e4887f0071ef2d2164a9d5fdf2d20efbef78fccd3a78b0c10a1dc5295e48a"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.5",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.127"
+version = "0.2.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
+checksum = "81941cd78d0c92026c33e5e01312845a4cb1e9af3407f9134b100dd03144103e"
 dependencies = [
  "unicode-ident",
 ]
@@ -6586,9 +6592,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.104"
+version = "0.3.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
+checksum = "9fbddc4a036f00ec4f18c83445bd3115cb306a91da554919a099d9222fe4a7f8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6782,6 +6788,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -6949,12 +6964,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
-name = "xsum"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0637d3a5566a82fa5214bae89087bc8c9fb94cd8e8a3c07feb691bb8d9c632db"
-
-[[package]]
 name = "xz2"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7032,7 +7041,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -7073,7 +7082,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
- "synstructure",
+ "synstructure 0.13.2",
 ]
 
 [[package]]
@@ -7114,7 +7123,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
- "synstructure",
+ "synstructure 0.13.2",
 ]
 
 [[package]]
@@ -7146,7 +7155,6 @@ dependencies = [
  "displaydoc",
  "yoke",
  "zerofrom",
- "zerovec",
 ]
 
 [[package]]
@@ -7155,7 +7163,6 @@ version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
- "serde",
  "yoke",
  "zerofrom",
  "zerovec-derive",
@@ -7169,7 +7176,7 @@ checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,10 +27,10 @@ description = "A cross platform forensic parser"
 serde = { version = "1.0.229", features = ["derive"] }
 tracing = "0.1.44"
 serde_json = "1.0.151"
-toml = "1.1.4"
+toml = "1.1.5"
 base64 = "0.23.1"
 tokio = { version = "1.53.1", features = ["full"] }
-flate2 = "1.1.9"
+flate2 = "1.1.10"
 glob = "0.3.4"
 reqwest = { version = "0.13.4", features = [
     "json",
@@ -39,7 +39,7 @@ reqwest = { version = "0.13.4", features = [
     "form",
 ] }
 sysinfo = "0.39.6"
-uuid = { version = "1.25.0", features = ["v4"] }
+uuid = { version = "1.26.0", features = ["v4"] }
 rusqlite = { version = "0.40.2", features = [
     "bundled",
     "serde_json",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -11,5 +11,5 @@ repository = { workspace = true }
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }
-plist = "1.10.0"
+plist = "1.10.1"
 ext4-fs = "0.2.0"

--- a/forensics/Cargo.toml
+++ b/forensics/Cargo.toml
@@ -50,8 +50,8 @@ ruzstd = "0.9.0"
 lz4_flex = "0.14.0"
 xz2 = { version = "0.1.7", default-features = false, features = ["static"] }
 macos-unifiedlogs = "0.6.0"
-plist = "1.10.0"
-aes = "0.9.2"
+plist = "1.10.1"
+aes = "0.9.3"
 cbc = "0.2.1"
 csv = "1.4.0"
 common = { path = "../common" }
@@ -62,7 +62,7 @@ lumination = "0.2.0"
 snap = "1.1.2"
 ext4-fs = "0.2.0"
 calf = "0.3.0"
-parquet = { version = "59.2.0", default-features = false, features = [
+parquet = { version = "59.3.0", default-features = false, features = [
     "json",
     "snap",
     "simdutf8",
@@ -94,9 +94,9 @@ rusty-s3 = { version = "0.10.2", optional = true }
 jsonwebtoken = { version = "11.0.0", optional = true, features = ["aws_lc_rs"] }
 
 # JS API
-boa_engine = { version = "0.21.1", default-features = false, optional = true }
-boa_gc = { version = "0.21.1", default-features = false, optional = true }
-boa_runtime = { version = "0.21.1", default-features = false, optional = true }
+boa_engine = { version = "0.22.0", default-features = false, optional = true }
+boa_gc = { version = "0.22.0", default-features = false, optional = true }
+boa_runtime = { version = "0.22.0", default-features = false, optional = true }
 futures-concurrency = { version = "7.7.1", default-features = false, optional = true }
 futures-lite = { version = "2.6.1", default-features = false, optional = true }
 

--- a/forensics/src/accessor/access.rs
+++ b/forensics/src/accessor/access.rs
@@ -504,7 +504,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(windows)]
+    #[cfg(target_os = "windows")]
     fn test_ntfs_accessor_read_zip() {
         let mut test_location = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         test_location.push("tests/test_data/archives/document.odt");
@@ -521,7 +521,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(windows)]
+    #[cfg(target_os = "windows")]
     fn test_ntfs_accessor_live() {
         let mut access = Accessor::with_defaults();
         let source = access.open_source(&"ntfs:C").unwrap();
@@ -537,7 +537,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(windows)]
+    #[cfg(target_os = "windows")]
     fn test_ntfs_accessor_live_read_dir_handle() {
         let mut access = Accessor::with_defaults();
         let source = access.open_source(&"ntfs:C").unwrap();
@@ -566,7 +566,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(windows)]
+    #[cfg(target_os = "windows")]
     fn test_ntfs_accessor_mft_reader() {
         use std::io::Read;
 
@@ -582,7 +582,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(windows)]
+    #[cfg(target_os = "windows")]
     fn test_ntfs_glob_recursive() {
         let mut access = Accessor::with_defaults();
         let source = access.open_source(&"ntfs:C").unwrap();
@@ -594,7 +594,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(windows)]
+    #[cfg(target_os = "windows")]
     fn test_windows_globfs() {
         let mut access = Accessor::with_defaults();
         let entries = access.globfs("C:\\Users\\*\\NTUSER*").unwrap();
@@ -780,7 +780,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(windows)]
+    #[cfg(target_os = "windows")]
     fn test_ntfs_accessor_source_stat() {
         let mut access = Accessor::with_defaults();
         let source = access.open_source("ntfs:C").unwrap();

--- a/forensics/src/accessor/filesystem/zip.rs
+++ b/forensics/src/accessor/filesystem/zip.rs
@@ -275,19 +275,7 @@ impl ZipFs {
         // Prefix is home/
         // If the prefix is empty then root directory is the default
         let prefix = Self::inner_to_prefix(directory);
-        if !prefix.is_empty()
-            && !self.index.file_paths.contains_key(&prefix)
-            && !self
-                .index
-                .entries
-                .iter()
-                .any(|entry| entry.is_dir && entry.path == prefix)
-            && self.list_children(&prefix)?.is_empty()
-        {
-            return Err(AccessorError::not_a_directory(
-                self.display_entry_path(&prefix),
-            ));
-        }
+
         // Normalize all pattern separators to forward slash '/'
         let normalized = normalize_glob_pattern(pattern);
 

--- a/forensics/src/accessor/filesystem/zip.rs
+++ b/forensics/src/accessor/filesystem/zip.rs
@@ -538,11 +538,6 @@ impl ZipFs {
         let prefix = Self::inner_to_prefix(inner);
         let children = self.list_children(&prefix)?;
 
-        if !prefix.is_empty() && !self.index.file_paths.contains_key(&prefix) && children.is_empty()
-        {
-            return Err(AccessorError::not_found(self.display_entry_path(&prefix)));
-        }
-
         let mut entries = Vec::with_capacity(children.len());
         for (name, child) in children {
             let (handle, kind, size, display_path) = match child {
@@ -593,6 +588,7 @@ impl ZipFs {
         };
 
         let mut children = BTreeMap::<String, ZipChild>::new();
+        let mut found = prefix.is_empty();
 
         // Go through our parsed zip index records
         for record in &self.index.entries {
@@ -606,9 +602,11 @@ impl ZipFs {
             } else if *entry_path == prefix {
                 // Ignore the prefix directory. Example, if the directory prefix is 'home/' we should skip the entry 'home/'
                 // If we do not have this then the `strip_prefix` function below would match and we would track it
+                found = true;
                 continue;
             } else if let Some(rest) = entry_path.strip_prefix(&prefix_with_slash) {
                 // If we found an zip entry that matches the prefix, we keep it
+                found = true;
                 rest
             } else {
                 continue;
@@ -637,6 +635,10 @@ impl ZipFs {
                     ZipChild::file(record.clone(), remainder.to_string()),
                 );
             }
+        }
+
+        if !found {
+            return Err(AccessorError::not_found(self.display_entry_path(&prefix)));
         }
 
         Ok(children)

--- a/forensics/src/accessor/mod.rs
+++ b/forensics/src/accessor/mod.rs
@@ -7,3 +7,4 @@ mod filesystem;
 pub(crate) mod io;
 pub(crate) mod location;
 pub(crate) mod source;
+pub(crate) mod walk;

--- a/forensics/src/accessor/source/ntfs.rs
+++ b/forensics/src/accessor/source/ntfs.rs
@@ -208,7 +208,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(windows)]
+    #[cfg(target_os = "windows")]
     fn test_ntfs_read_root_dirs() {
         use crate::accessor::entry::handle::EntryKind;
 

--- a/forensics/src/accessor/walk.rs
+++ b/forensics/src/accessor/walk.rs
@@ -1,0 +1,311 @@
+use tracing::error;
+
+use crate::accessor::{
+    access::Accessor,
+    entry::{
+        handle::{DirEntry, DirHandle, EntryKind, FileHandle, ItemHandle},
+        locator::{DirLocator, FileLocator, NtfsEntryRef, SourceId},
+    },
+    error::{AccessorError, AccessorResult},
+    location::path::InnerPath,
+    source::{factory::parse_inner_path, handle::SourceHandle},
+};
+use std::collections::HashSet;
+
+/// A special accessor that be used to recursively iterator through an `Accessor` `Source`
+pub(crate) struct WalkAccessor {
+    /// `Source` we should iterate through
+    source: SourceHandle,
+    /// Start path for the recursion
+    start: InnerPath,
+    /// Max depth we should descend. Default is 1
+    max_depth: u32,
+    started: bool,
+    stack: Vec<WalkStack>,
+    pending_error: Option<AccessorError>,
+    /// Default firmlinks on macOS we ignore
+    firmlinks: HashSet<String>,
+}
+
+struct WalkStack {
+    depth: u32,
+    child: Vec<DirEntry>,
+}
+
+/// Entry returned by `WalkAccessor`
+pub(crate) struct WalkEntry {
+    entry: DirEntry,
+    depth: u32,
+}
+
+impl WalkEntry {
+    pub(crate) fn depth(&self) -> u32 {
+        self.depth
+    }
+
+    pub(crate) fn filename(&self) -> &str {
+        &self.entry.meta.filename
+    }
+
+    pub(crate) fn full_path(&self) -> &str {
+        &self.entry.meta.full_path
+    }
+
+    pub(crate) fn display_path(&self) -> &str {
+        &self.entry.meta.display_path
+    }
+
+    pub(crate) fn is_file(&self) -> bool {
+        self.entry.is_file()
+    }
+
+    pub(crate) fn is_directory(&self) -> bool {
+        self.entry.is_directory()
+    }
+
+    pub(crate) fn as_file(&self) -> Option<&FileHandle> {
+        self.entry.handle.as_file()
+    }
+
+    pub(crate) fn as_directory(&self) -> Option<&DirHandle> {
+        self.entry.handle.as_directory()
+    }
+
+    pub(crate) fn handle(&self) -> &ItemHandle {
+        &self.entry.handle
+    }
+
+    pub(crate) fn entry(&self) -> &DirEntry {
+        &self.entry
+    }
+}
+
+impl WalkAccessor {
+    /// Return a `WalkAccessor` to iterate the `SourceHandle`
+    ///
+    /// Default **depth** is 1
+    pub(crate) fn new(source: &SourceHandle, inner: &str) -> AccessorResult<Self> {
+        Ok(Self {
+            source: source.clone(),
+            start: parse_inner_path(inner)?,
+            max_depth: 1,
+            started: false,
+            stack: Vec::new(),
+            pending_error: None,
+            firmlinks: HashSet::new(),
+        })
+    }
+
+    pub(crate) fn max_depth(mut self, depth: u32) -> Self {
+        self.max_depth = depth;
+        self
+    }
+
+    pub(crate) fn next(&mut self, accessor: &Accessor) -> Option<AccessorResult<WalkEntry>> {
+        if let Some(err) = self.pending_error.take() {
+            return Some(Err(err));
+        }
+
+        if !self.started {
+            self.started = true;
+            self.load_firmlinks(accessor);
+
+            return self.yield_root(accessor);
+        }
+
+        loop {
+            let walk_stack = self.stack.last_mut()?;
+            if walk_stack.child.is_empty() {
+                self.stack.pop();
+                continue;
+            }
+
+            let child = walk_stack.child.pop()?;
+            let depth = walk_stack.depth + 1;
+
+            if self.is_firmlink(&child.meta.full_path) {
+                continue;
+            }
+
+            self.queue_descend(accessor, &child, depth);
+            return Some(Ok(WalkEntry {
+                entry: child,
+                depth,
+            }));
+        }
+    }
+
+    fn yield_root(&mut self, accessor: &Accessor) -> Option<AccessorResult<WalkEntry>> {
+        let stat = match accessor.source_stat(&self.source, &self.start.display()) {
+            Ok(stat) => stat,
+            Err(err) => {
+                error!(
+                    "Could not get start path '{}': {err:?}",
+                    &self.start.display()
+                );
+                return Some(Err(err));
+            }
+        };
+
+        let handle = root_handle(&self.source, &self.start, &stat.meta.kind);
+        let entry = DirEntry::new(stat.meta.filename.clone(), handle, stat.meta);
+
+        self.queue_descend(accessor, &entry, 0);
+
+        Some(Ok(WalkEntry { entry, depth: 0 }))
+    }
+
+    fn queue_descend(&mut self, accessor: &Accessor, entry: &DirEntry, depth: u32) {
+        if !entry.is_directory() || depth >= self.max_depth {
+            return;
+        }
+
+        match self.list_children(accessor, entry, depth) {
+            Ok(mut child) => {
+                child.reverse();
+                self.stack.push(WalkStack { depth, child })
+            }
+            Err(err) => {
+                error!(
+                    "Failed to descend filelisting at '{}': {err:?}",
+                    entry.meta.full_path
+                );
+                self.pending_error = Some(err);
+            }
+        }
+    }
+
+    fn list_children(
+        &self,
+        accessor: &Accessor,
+        entry: &DirEntry,
+        depth: u32,
+    ) -> AccessorResult<Vec<DirEntry>> {
+        if depth == 0 {
+            return accessor.source_read_dir(&self.source, &self.start.display());
+        }
+
+        let Some(handle) = entry.handle.as_directory() else {
+            error!("Cannot list files for '{}'", entry.meta.full_path);
+            return Err(AccessorError::NotADirectory {
+                path: entry.meta.full_path.clone(),
+            });
+        };
+
+        accessor.source_read_dir_handle(&self.source, handle)
+    }
+
+    fn load_firmlinks(&mut self, accessor: &Accessor) {
+        if !cfg!(target_os = "macos") || self.source.id() != &SourceId::Host {
+            return;
+        }
+
+        let firmlinks = "/usr/share/firmlinks";
+        let bytes = match accessor.source_read_file(&self.source, firmlinks) {
+            Ok(results) => results,
+            Err(err) => {
+                error!("Could not read '{firmlinks}' on macOS: {err:?}");
+                return;
+            }
+        };
+
+        for line in String::from_utf8_lossy(&bytes).lines() {
+            if let Some(path) = line.split_whitespace().next() {
+                if !path.is_empty() {
+                    self.firmlinks.insert(path.to_string());
+                }
+            }
+        }
+    }
+
+    fn is_firmlink(&self, full_path: &str) -> bool {
+        self.firmlinks.contains(full_path)
+    }
+}
+
+fn root_handle(source: &SourceHandle, start: &InnerPath, kind: &EntryKind) -> ItemHandle {
+    let path = start.as_path().to_path_buf();
+
+    match (source.id(), kind) {
+        (SourceId::Host, EntryKind::Directory) => ItemHandle::Directory(DirHandle::host(path)),
+        (SourceId::Host, EntryKind::File) => ItemHandle::File(FileHandle::host(path)),
+        (SourceId::Host, EntryKind::Unsupported) => ItemHandle::Unsupported(FileHandle::host(path)),
+        (SourceId::Zip(archive), EntryKind::Directory) => {
+            ItemHandle::Directory(DirHandle::new(DirLocator::Zip {
+                archive: archive.clone(),
+                entry_index: 0,
+                prefix: start.display(),
+            }))
+        }
+        (SourceId::Zip(archive), _) => ItemHandle::File(FileHandle::new(FileLocator::Zip {
+            archive: archive.clone(),
+            entry_index: 0,
+            entry: start.display(),
+        })),
+        (SourceId::Ntfs(drive), EntryKind::Directory) => {
+            ItemHandle::Directory(DirHandle::new(DirLocator::Ntfs {
+                drive: *drive,
+                dir_ref: NtfsEntryRef {
+                    file_record_number: 0,
+                    sequence_number: 0,
+                },
+                display_path: start.display(),
+            }))
+        }
+        (SourceId::Ntfs(drive), _) => ItemHandle::File(FileHandle::new(FileLocator::Ntfs {
+            drive: *drive,
+            file_ref: NtfsEntryRef {
+                file_record_number: 0,
+                sequence_number: 0,
+            },
+            display_path: start.display(),
+        })),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::accessor::{access::Accessor, walk::WalkAccessor};
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_walk_accessor() {
+        let test_location = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let mut accessor = Accessor::with_defaults();
+        let source = accessor.open_source("host:").unwrap();
+
+        let mut walk = WalkAccessor::new(&source, test_location.to_str().unwrap())
+            .unwrap()
+            .max_depth(5);
+
+        let mut count = 0;
+        while let Some(Ok(entry)) = walk.next(&accessor) {
+            count += 1;
+            assert!(!entry.full_path().is_empty());
+        }
+
+        assert!(count > 10);
+    }
+
+    #[test]
+    fn test_walk_accessor_zip() {
+        let mut test_location = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        test_location.push("tests/test_data/archives/document.odt");
+
+        let mut accessor = Accessor::with_defaults();
+        let source = accessor
+            .open_source(&format!("zip:{}", test_location.display()))
+            .unwrap();
+
+        let mut walk = WalkAccessor::new(&source, "/").unwrap().max_depth(5);
+
+        let mut count = 0;
+        while let Some(Ok(entry)) = walk.next(&accessor) {
+            println!("{}", entry.full_path());
+            count += 1;
+            assert!(!entry.full_path().is_empty());
+        }
+
+        assert!(count > 10, "{}", count);
+    }
+}

--- a/forensics/src/accessor/walk.rs
+++ b/forensics/src/accessor/walk.rs
@@ -286,7 +286,8 @@ mod tests {
             .max_depth(2)
             .exclude("/bin")
             .exclude("/lost+found")
-            .exclude("/root");
+            .exclude("/root")
+            .exclude("/proc");
 
         let mut count = 0;
         while let Some(item) = walk.next(&accessor) {

--- a/forensics/src/accessor/walk.rs
+++ b/forensics/src/accessor/walk.rs
@@ -99,15 +99,11 @@ impl WalkAccessor {
             let child = walk_stack.child.pop()?;
             let depth = walk_stack.depth + 1;
 
-            // Skip excluded paths
-            if !self.exclude.is_empty()
-                && self.source.id() == &SourceId::Host
-                && self.is_exclude(&child.meta.full_path)
-            {
-                continue;
+            // Only descend into paths we do not want to exclude
+            if self.exclude.is_empty() || !self.is_exclude(&child.meta.full_path) {
+                self.queue_descend(accessor, &child, depth);
             }
 
-            self.queue_descend(accessor, &child, depth);
             return Some(Ok(WalkEntry {
                 entry: child,
                 depth,
@@ -297,7 +293,7 @@ mod tests {
             let entry = item.unwrap();
             count += 1;
             assert!(!entry.entry.meta.full_path.is_empty());
-            assert!(!entry.entry.meta.full_path.contains("/bin/"));
+            assert!(!entry.entry.meta.full_path.starts_with("/bin/"));
         }
 
         assert!(count > 10, "{}", count);
@@ -453,7 +449,7 @@ mod tests {
         assert!(names.contains(&"keep".to_string()));
         assert!(names.contains(&"a.txt".to_string()));
         assert!(names.contains(&"other.txt".to_string()));
-        assert!(!names.contains(&"dev".to_string()));
+        assert!(!names.contains(&"dev/".to_string()));
         assert!(!names.contains(&"secret.txt".to_string()));
     }
 

--- a/forensics/src/accessor/walk.rs
+++ b/forensics/src/accessor/walk.rs
@@ -110,7 +110,9 @@ impl WalkAccessor {
             self.started = true;
             self.load_firmlinks(accessor);
 
-            return self.yield_root(accessor);
+            if let Err(err) = self.start_walk(accessor) {
+                return Some(Err(err));
+            }
         }
 
         loop {
@@ -135,24 +137,13 @@ impl WalkAccessor {
         }
     }
 
-    fn yield_root(&mut self, accessor: &Accessor) -> Option<AccessorResult<WalkEntry>> {
-        let stat = match accessor.source_stat(&self.source, &self.start.display()) {
-            Ok(stat) => stat,
-            Err(err) => {
-                error!(
-                    "Could not get start path '{}': {err:?}",
-                    &self.start.display()
-                );
-                return Some(Err(err));
-            }
-        };
+    fn start_walk(&mut self, accessor: &Accessor) -> AccessorResult<()> {
+        let mut child = accessor.source_read_dir(&self.source, &self.start.display())?;
+        child.reverse();
 
-        let handle = root_handle(&self.source, &self.start, &stat.meta.kind);
-        let entry = DirEntry::new(stat.meta.filename.clone(), handle, stat.meta);
+        self.stack.push(WalkStack { depth: 0, child });
 
-        self.queue_descend(accessor, &entry, 0);
-
-        Some(Ok(WalkEntry { entry, depth: 0 }))
+        Ok(())
     }
 
     fn queue_descend(&mut self, accessor: &Accessor, entry: &DirEntry, depth: u32) {
@@ -160,7 +151,15 @@ impl WalkAccessor {
             return;
         }
 
-        match self.list_children(accessor, entry, depth) {
+        let Some(handle) = entry.handle.as_directory() else {
+            error!("Cannot list files for '{}'", entry.meta.full_path);
+            self.pending_error = Some(AccessorError::NotADirectory {
+                path: entry.meta.full_path.clone(),
+            });
+            return;
+        };
+
+        match accessor.source_read_dir_handle(&self.source, handle) {
             Ok(mut child) => {
                 child.reverse();
                 self.stack.push(WalkStack { depth, child })
@@ -173,26 +172,6 @@ impl WalkAccessor {
                 self.pending_error = Some(err);
             }
         }
-    }
-
-    fn list_children(
-        &self,
-        accessor: &Accessor,
-        entry: &DirEntry,
-        depth: u32,
-    ) -> AccessorResult<Vec<DirEntry>> {
-        if depth == 0 {
-            return accessor.source_read_dir(&self.source, &self.start.display());
-        }
-
-        let Some(handle) = entry.handle.as_directory() else {
-            error!("Cannot list files for '{}'", entry.meta.full_path);
-            return Err(AccessorError::NotADirectory {
-                path: entry.meta.full_path.clone(),
-            });
-        };
-
-        accessor.source_read_dir_handle(&self.source, handle)
     }
 
     fn load_firmlinks(&mut self, accessor: &Accessor) {
@@ -223,46 +202,6 @@ impl WalkAccessor {
     }
 }
 
-fn root_handle(source: &SourceHandle, start: &InnerPath, kind: &EntryKind) -> ItemHandle {
-    let path = start.as_path().to_path_buf();
-
-    match (source.id(), kind) {
-        (SourceId::Host, EntryKind::Directory) => ItemHandle::Directory(DirHandle::host(path)),
-        (SourceId::Host, EntryKind::File) => ItemHandle::File(FileHandle::host(path)),
-        (SourceId::Host, EntryKind::Unsupported) => ItemHandle::Unsupported(FileHandle::host(path)),
-        (SourceId::Zip(archive), EntryKind::Directory) => {
-            ItemHandle::Directory(DirHandle::new(DirLocator::Zip {
-                archive: archive.clone(),
-                entry_index: 0,
-                prefix: start.display(),
-            }))
-        }
-        (SourceId::Zip(archive), _) => ItemHandle::File(FileHandle::new(FileLocator::Zip {
-            archive: archive.clone(),
-            entry_index: 0,
-            entry: start.display(),
-        })),
-        (SourceId::Ntfs(drive), EntryKind::Directory) => {
-            ItemHandle::Directory(DirHandle::new(DirLocator::Ntfs {
-                drive: *drive,
-                dir_ref: NtfsEntryRef {
-                    file_record_number: 0,
-                    sequence_number: 0,
-                },
-                display_path: start.display(),
-            }))
-        }
-        (SourceId::Ntfs(drive), _) => ItemHandle::File(FileHandle::new(FileLocator::Ntfs {
-            drive: *drive,
-            file_ref: NtfsEntryRef {
-                file_record_number: 0,
-                sequence_number: 0,
-            },
-            display_path: start.display(),
-        })),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use crate::accessor::{access::Accessor, walk::WalkAccessor};
@@ -279,8 +218,10 @@ mod tests {
             .max_depth(5);
 
         let mut count = 0;
-        while let Some(Ok(entry)) = walk.next(&accessor) {
+        while let Some(item) = walk.next(&accessor) {
+            let entry = item.unwrap();
             count += 1;
+
             assert!(!entry.full_path().is_empty());
         }
 
@@ -297,11 +238,11 @@ mod tests {
             .open_source(&format!("zip:{}", test_location.display()))
             .unwrap();
 
-        let mut walk = WalkAccessor::new(&source, "/").unwrap().max_depth(5);
+        let mut walk = WalkAccessor::new(&source, "").unwrap().max_depth(5);
 
         let mut count = 0;
-        while let Some(Ok(entry)) = walk.next(&accessor) {
-            println!("{}", entry.full_path());
+        while let Some(item) = walk.next(&accessor) {
+            let entry = item.unwrap();
             count += 1;
             assert!(!entry.full_path().is_empty());
         }

--- a/forensics/src/accessor/walk.rs
+++ b/forensics/src/accessor/walk.rs
@@ -417,7 +417,7 @@ mod tests {
             .map(|(_, name)| name)
             .collect();
 
-        assert!(!paths.iter().any(|name| name == "Users"));
+        assert!(paths.iter().any(|name| name == "Users"));
         let mut walk = WalkAccessor::new(&source, "/Users").unwrap().max_depth(1);
         let users = collect(&mut walk, &accessor);
 
@@ -449,7 +449,7 @@ mod tests {
         assert!(names.contains(&"keep".to_string()));
         assert!(names.contains(&"a.txt".to_string()));
         assert!(names.contains(&"other.txt".to_string()));
-        assert!(!names.contains(&"dev/".to_string()));
+        assert!(names.contains(&"dev".to_string()));
         assert!(!names.contains(&"secret.txt".to_string()));
     }
 

--- a/forensics/src/accessor/walk.rs
+++ b/forensics/src/accessor/walk.rs
@@ -23,8 +23,10 @@ pub(crate) struct WalkAccessor {
     stack: Vec<WalkStack>,
     /// Error we may encounter while iterating
     pending_error: Option<AccessorError>,
-    /// Default firmlinks on macOS we ignore
-    firmlinks: HashSet<String>,
+    /// Directories we should skip
+    ///
+    /// On macOS we always skip firmlinks
+    exclude: HashSet<String>,
 }
 
 /// Track files and directories we walk
@@ -56,13 +58,18 @@ impl WalkAccessor {
             started: false,
             stack: Vec::new(),
             pending_error: None,
-            firmlinks: HashSet::new(),
+            exclude: HashSet::new(),
         })
     }
 
     /// Max depth we should descend to
     pub(crate) fn max_depth(mut self, depth: u32) -> Self {
         self.max_depth = depth;
+        self
+    }
+
+    pub(crate) fn exclude(mut self, path: impl Into<String>) -> Self {
+        self.exclude.insert(path.into());
         self
     }
 
@@ -92,8 +99,11 @@ impl WalkAccessor {
             let child = walk_stack.child.pop()?;
             let depth = walk_stack.depth + 1;
 
-            // On macOS systems we always ignore firmlink paths
-            if self.is_firmlink(&child.meta.full_path) {
+            // Skip excluded paths
+            if !self.exclude.is_empty()
+                && self.source.id() == &SourceId::Host
+                && self.is_exclude(&child.meta.full_path)
+            {
                 continue;
             }
 
@@ -166,14 +176,14 @@ impl WalkAccessor {
             if let Some(path) = line.split_whitespace().next()
                 && !path.is_empty()
             {
-                self.firmlinks.insert(path.to_string());
+                self.exclude.insert(path.to_string());
             }
         }
     }
 
-    /// Check if path is a firmlink
-    fn is_firmlink(&self, full_path: &str) -> bool {
-        self.firmlinks.contains(full_path)
+    /// Check if we should skip path
+    fn is_exclude(&self, full_path: &str) -> bool {
+        self.exclude.contains(full_path)
     }
 }
 
@@ -204,9 +214,7 @@ mod tests {
     fn collect(walk: &mut WalkAccessor, accessor: &Accessor) -> Vec<(u32, String)> {
         let mut out = Vec::new();
         while let Some(item) = walk.next(accessor) {
-            let Ok(entry) = item else {
-                continue;
-            };
+            let entry = item.unwrap();
             out.push((entry.depth, entry.entry.meta.filename.clone()));
         }
         out
@@ -267,6 +275,29 @@ mod tests {
             let entry = item.unwrap();
             count += 1;
             assert!(!entry.entry.meta.full_path.is_empty());
+        }
+
+        assert!(count > 10, "{}", count);
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_walk_accessor_skip_bin() {
+        let mut accessor = Accessor::with_defaults();
+        let source = accessor.open_source(&"host:").unwrap();
+        let mut walk = WalkAccessor::new(&source, "/")
+            .unwrap()
+            .max_depth(2)
+            .exclude("/bin")
+            .exclude("/lost+found")
+            .exclude("/root");
+
+        let mut count = 0;
+        while let Some(item) = walk.next(&accessor) {
+            let entry = item.unwrap();
+            count += 1;
+            assert!(!entry.entry.meta.full_path.is_empty());
+            assert!(!entry.entry.meta.full_path.contains("/bin/"));
         }
 
         assert!(count > 10, "{}", count);
@@ -395,5 +426,55 @@ mod tests {
         let users = collect(&mut walk, &accessor);
 
         assert!(!users.is_empty());
+    }
+
+    #[test]
+    fn test_walk_exclude_directory() {
+        let dir = setup("exclude_dir");
+        write_file(&dir, "keep/a.txt", b"a");
+        write_file(&dir, "dev/secret.txt", b"secret");
+        write_file(&dir, "other.txt", b"o");
+
+        let mut accessor = Accessor::with_defaults();
+        let source = accessor.open_source("host:").unwrap();
+        let start = dir.display().to_string();
+        let skip = dir.join("dev").display().to_string();
+
+        let mut walk = WalkAccessor::new(&source, &start)
+            .unwrap()
+            .max_depth(3)
+            .exclude(skip);
+
+        let names: Vec<String> = collect(&mut walk, &accessor)
+            .into_iter()
+            .map(|(_, name)| name)
+            .collect();
+
+        assert!(names.contains(&"keep".to_string()));
+        assert!(names.contains(&"a.txt".to_string()));
+        assert!(names.contains(&"other.txt".to_string()));
+        assert!(!names.contains(&"dev".to_string()));
+        assert!(!names.contains(&"secret.txt".to_string()));
+    }
+
+    #[test]
+    fn test_walk_exclude_does_not_skip_start() {
+        let dir = setup("exclude_start");
+        write_file(&dir, "child.txt", b"c");
+
+        let mut accessor = Accessor::with_defaults();
+        let source = accessor.open_source("host:").unwrap();
+        let start = dir.display().to_string();
+
+        let mut walk = WalkAccessor::new(&source, &start)
+            .unwrap()
+            .max_depth(1)
+            .exclude(start.clone());
+
+        let names: Vec<String> = collect(&mut walk, &accessor)
+            .into_iter()
+            .map(|(_, name)| name)
+            .collect();
+        assert!(names.contains(&"child.txt".to_string()));
     }
 }

--- a/forensics/src/accessor/walk.rs
+++ b/forensics/src/accessor/walk.rs
@@ -2,10 +2,7 @@ use tracing::error;
 
 use crate::accessor::{
     access::Accessor,
-    entry::{
-        handle::{DirEntry, EntryKind, FileHandle, ItemHandle},
-        locator::{DirLocator, FileLocator, NtfsEntryRef, SourceId},
-    },
+    entry::{handle::DirEntry, locator::SourceId},
     error::{AccessorError, AccessorResult},
     location::path::InnerPath,
     source::{factory::parse_inner_path, handle::SourceHandle},
@@ -32,13 +29,14 @@ pub(crate) struct WalkAccessor {
 
 /// Track files and directories we walk
 struct WalkStack {
-    /// Current depht
+    /// Current depth
     depth: u32,
     /// Array of children from current path in the iterator
     child: Vec<DirEntry>,
 }
 
 /// Entry returned by `WalkAccessor`
+#[derive(Debug)]
 pub(crate) struct WalkEntry {
     /// A File or Directory return by the iterator
     pub(crate) entry: DirEntry,
@@ -68,7 +66,7 @@ impl WalkAccessor {
         self
     }
 
-    /// Iterator to walk the filesytem
+    /// Iterator to walk the filesystem
     pub(crate) fn next(&mut self, accessor: &Accessor) -> Option<AccessorResult<WalkEntry>> {
         if let Some(err) = self.pending_error.take() {
             return Some(Err(err));
@@ -135,7 +133,7 @@ impl WalkAccessor {
         match accessor.source_read_dir_handle(&self.source, handle) {
             Ok(mut child) => {
                 child.reverse();
-                self.stack.push(WalkStack { depth, child })
+                self.stack.push(WalkStack { depth, child });
             }
             Err(err) => {
                 error!(
@@ -165,10 +163,10 @@ impl WalkAccessor {
         };
 
         for line in String::from_utf8_lossy(&bytes).lines() {
-            if let Some(path) = line.split_whitespace().next() {
-                if !path.is_empty() {
-                    self.firmlinks.insert(path.to_string());
-                }
+            if let Some(path) = line.split_whitespace().next()
+                && !path.is_empty()
+            {
+                self.firmlinks.insert(path.to_string());
             }
         }
     }
@@ -181,8 +179,38 @@ impl WalkAccessor {
 
 #[cfg(test)]
 mod tests {
-    use crate::accessor::{access::Accessor, walk::WalkAccessor};
-    use std::path::PathBuf;
+    use crate::accessor::{access::Accessor, error::AccessorError, walk::WalkAccessor};
+    use std::{
+        fs::{self, File},
+        io::Write,
+        path::PathBuf,
+    };
+
+    fn setup(name: &str) -> PathBuf {
+        let dir = PathBuf::from("./tmp/walk").join(name);
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn write_file(dir: &PathBuf, name: &str, contents: &[u8]) {
+        let path = dir.join(name);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        File::create(path).unwrap().write_all(contents).unwrap();
+    }
+
+    fn collect(walk: &mut WalkAccessor, accessor: &Accessor) -> Vec<(u32, String)> {
+        let mut out = Vec::new();
+        while let Some(item) = walk.next(accessor) {
+            let Ok(entry) = item else {
+                continue;
+            };
+            out.push((entry.depth, entry.entry.meta.filename.clone()));
+        }
+        out
+    }
 
     #[test]
     fn test_walk_accessor() {
@@ -232,7 +260,7 @@ mod tests {
     fn test_walk_accessor_ntfs() {
         let mut accessor = Accessor::with_defaults();
         let source = accessor.open_source(&"ntfs:C").unwrap();
-        let mut walk = WalkAccessor::new(&source, "").unwrap().max_depth(5);
+        let mut walk = WalkAccessor::new(&source, "").unwrap().max_depth(2);
 
         let mut count = 0;
         while let Some(item) = walk.next(&accessor) {
@@ -242,5 +270,130 @@ mod tests {
         }
 
         assert!(count > 10, "{}", count);
+    }
+
+    #[test]
+    fn test_walk_max_depth() {
+        let dir = setup("max_depth");
+        write_file(&dir, "a.txt", b"a");
+        write_file(&dir, "nested/b.txt", b"b");
+        write_file(&dir, "nested/deep/c.txt", b"c");
+
+        let mut accessor = Accessor::with_defaults();
+        let source = accessor.open_source("host:").unwrap();
+        let start = dir.display().to_string();
+        let mut walk = WalkAccessor::new(&source, &start).unwrap().max_depth(1);
+        let names: Vec<String> = collect(&mut walk, &accessor)
+            .into_iter()
+            .map(|(_, name)| name)
+            .collect();
+
+        assert!(names.contains(&"a.txt".to_string()));
+        assert!(names.contains(&"nested".to_string()));
+        assert!(!names.contains(&"b.txt".to_string()));
+        assert!(!names.contains(&"c.txt".to_string()));
+
+        let mut walk = WalkAccessor::new(&source, &start).unwrap().max_depth(2);
+        let names: Vec<String> = collect(&mut walk, &accessor)
+            .into_iter()
+            .map(|(_, name)| name)
+            .collect();
+
+        assert!(names.contains(&"b.txt".to_string()));
+        assert!(!names.contains(&"c.txt".to_string()));
+    }
+
+    #[test]
+    fn test_walk_stat_during_iteration() {
+        let dir = setup("stat_during");
+        write_file(&dir, "file.txt", b"hello");
+
+        let mut accessor = Accessor::with_defaults();
+        let source = accessor.open_source("host:").unwrap();
+        let mut walk = WalkAccessor::new(&source, &dir.display().to_string())
+            .unwrap()
+            .max_depth(1);
+
+        let mut saw_file = false;
+
+        while let Some(item) = walk.next(&accessor) {
+            let entry = item.unwrap();
+            if let Some(file) = entry.entry.handle.as_file() {
+                let stat = accessor.source_stat_handle(&source, file).unwrap();
+                assert_eq!(stat.meta.filename, "file.txt");
+                assert_eq!(stat.meta.size, 5);
+                saw_file = true;
+            }
+
+            if let Some(dir_handle) = entry.entry.handle.as_directory() {
+                let stat = accessor
+                    .source_stat_dir_handle(&source, dir_handle)
+                    .unwrap();
+                assert_eq!(
+                    stat.meta.kind,
+                    crate::accessor::entry::handle::EntryKind::Directory
+                );
+            }
+        }
+
+        assert!(saw_file);
+    }
+
+    #[test]
+    fn test_walk_zip_nested_and_empty_dir() {
+        let mut archive = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        archive.push("tests/test_data/archives/document.odt");
+
+        let mut accessor = Accessor::with_defaults();
+        let source = accessor
+            .open_source(&format!("zip:{}", archive.display()))
+            .unwrap();
+
+        let mut walk = WalkAccessor::new(&source, "").unwrap().max_depth(5);
+        let names: Vec<String> = collect(&mut walk, &accessor)
+            .into_iter()
+            .map(|(_, name)| name)
+            .collect();
+
+        assert!(names.contains(&"content.xml".to_string()));
+        assert!(names.contains(&"Configurations2".to_string()));
+        assert!(names.contains(&"thumbnail.png".to_string()));
+        assert!(names.contains(&"manifest.xml".to_string()));
+    }
+
+    #[test]
+    fn test_walk_zip_missing_prefix() {
+        let mut archive = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        archive.push("tests/test_data/archives/document.odt");
+
+        let mut accessor = Accessor::with_defaults();
+        let source = accessor
+            .open_source(&format!("zip:{}", archive.display()))
+            .unwrap();
+
+        let mut walk = WalkAccessor::new(&source, "no/such/dir").unwrap();
+        let err = walk.next(&accessor).unwrap().unwrap_err();
+
+        assert!(matches!(err, AccessorError::NotFound { .. }));
+        assert!(walk.next(&accessor).is_none());
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn test_walk_skips_firmlinks_but_not_start() {
+        let mut accessor = Accessor::with_defaults();
+        let source = accessor.open_source("host:").unwrap();
+
+        let mut walk = WalkAccessor::new(&source, "/").unwrap().max_depth(2);
+        let paths: Vec<String> = collect(&mut walk, &accessor)
+            .into_iter()
+            .map(|(_, name)| name)
+            .collect();
+
+        assert!(!paths.iter().any(|name| name == "Users"));
+        let mut walk = WalkAccessor::new(&source, "/Users").unwrap().max_depth(1);
+        let users = collect(&mut walk, &accessor);
+
+        assert!(!users.is_empty());
     }
 }

--- a/forensics/src/accessor/walk.rs
+++ b/forensics/src/accessor/walk.rs
@@ -3,7 +3,7 @@ use tracing::error;
 use crate::accessor::{
     access::Accessor,
     entry::{
-        handle::{DirEntry, DirHandle, EntryKind, FileHandle, ItemHandle},
+        handle::{DirEntry, EntryKind, FileHandle, ItemHandle},
         locator::{DirLocator, FileLocator, NtfsEntryRef, SourceId},
     },
     error::{AccessorError, AccessorResult},
@@ -20,64 +20,30 @@ pub(crate) struct WalkAccessor {
     start: InnerPath,
     /// Max depth we should descend. Default is 1
     max_depth: u32,
+    /// Flag to determine if we need to start at provided start path
     started: bool,
+    /// Current iterator stack
     stack: Vec<WalkStack>,
+    /// Error we may encounter while iterating
     pending_error: Option<AccessorError>,
     /// Default firmlinks on macOS we ignore
     firmlinks: HashSet<String>,
 }
 
+/// Track files and directories we walk
 struct WalkStack {
+    /// Current depht
     depth: u32,
+    /// Array of children from current path in the iterator
     child: Vec<DirEntry>,
 }
 
 /// Entry returned by `WalkAccessor`
 pub(crate) struct WalkEntry {
-    entry: DirEntry,
-    depth: u32,
-}
-
-impl WalkEntry {
-    pub(crate) fn depth(&self) -> u32 {
-        self.depth
-    }
-
-    pub(crate) fn filename(&self) -> &str {
-        &self.entry.meta.filename
-    }
-
-    pub(crate) fn full_path(&self) -> &str {
-        &self.entry.meta.full_path
-    }
-
-    pub(crate) fn display_path(&self) -> &str {
-        &self.entry.meta.display_path
-    }
-
-    pub(crate) fn is_file(&self) -> bool {
-        self.entry.is_file()
-    }
-
-    pub(crate) fn is_directory(&self) -> bool {
-        self.entry.is_directory()
-    }
-
-    pub(crate) fn as_file(&self) -> Option<&FileHandle> {
-        self.entry.handle.as_file()
-    }
-
-    pub(crate) fn as_directory(&self) -> Option<&DirHandle> {
-        self.entry.handle.as_directory()
-    }
-
-    pub(crate) fn handle(&self) -> &ItemHandle {
-        &self.entry.handle
-    }
-
-    pub(crate) fn entry(&self) -> &DirEntry {
-        &self.entry
-    }
+    /// A File or Directory return by the iterator
+    pub(crate) entry: DirEntry,
+    /// Current depth
+    pub(crate) depth: u32,
 }
 
 impl WalkAccessor {
@@ -96,16 +62,19 @@ impl WalkAccessor {
         })
     }
 
+    /// Max depth we should descend to
     pub(crate) fn max_depth(mut self, depth: u32) -> Self {
         self.max_depth = depth;
         self
     }
 
+    /// Iterator to walk the filesytem
     pub(crate) fn next(&mut self, accessor: &Accessor) -> Option<AccessorResult<WalkEntry>> {
         if let Some(err) = self.pending_error.take() {
             return Some(Err(err));
         }
 
+        // Determine if we need to start the walk
         if !self.started {
             self.started = true;
             self.load_firmlinks(accessor);
@@ -125,6 +94,7 @@ impl WalkAccessor {
             let child = walk_stack.child.pop()?;
             let depth = walk_stack.depth + 1;
 
+            // On macOS systems we always ignore firmlink paths
             if self.is_firmlink(&child.meta.full_path) {
                 continue;
             }
@@ -137,6 +107,7 @@ impl WalkAccessor {
         }
     }
 
+    /// Start the iterator by reading the provided start path
     fn start_walk(&mut self, accessor: &Accessor) -> AccessorResult<()> {
         let mut child = accessor.source_read_dir(&self.source, &self.start.display())?;
         child.reverse();
@@ -146,6 +117,7 @@ impl WalkAccessor {
         Ok(())
     }
 
+    /// Track paths we need to descend
     fn queue_descend(&mut self, accessor: &Accessor, entry: &DirEntry, depth: u32) {
         if !entry.is_directory() || depth >= self.max_depth {
             return;
@@ -159,6 +131,7 @@ impl WalkAccessor {
             return;
         };
 
+        // We always read directories by `DirHandle`
         match accessor.source_read_dir_handle(&self.source, handle) {
             Ok(mut child) => {
                 child.reverse();
@@ -174,12 +147,15 @@ impl WalkAccessor {
         }
     }
 
+    /// On macOS read the default firmlink paths
     fn load_firmlinks(&mut self, accessor: &Accessor) {
         if !cfg!(target_os = "macos") || self.source.id() != &SourceId::Host {
             return;
         }
 
         let firmlinks = "/usr/share/firmlinks";
+        // Firmlinks appear as normal directories in Rust
+        // So we have to skip them otherwise our filelisting doubles in size
         let bytes = match accessor.source_read_file(&self.source, firmlinks) {
             Ok(results) => results,
             Err(err) => {
@@ -197,6 +173,7 @@ impl WalkAccessor {
         }
     }
 
+    /// Check if path is a firmlink
     fn is_firmlink(&self, full_path: &str) -> bool {
         self.firmlinks.contains(full_path)
     }
@@ -222,7 +199,7 @@ mod tests {
             let entry = item.unwrap();
             count += 1;
 
-            assert!(!entry.full_path().is_empty());
+            assert!(!entry.entry.meta.full_path.is_empty());
         }
 
         assert!(count > 10);
@@ -244,7 +221,24 @@ mod tests {
         while let Some(item) = walk.next(&accessor) {
             let entry = item.unwrap();
             count += 1;
-            assert!(!entry.full_path().is_empty());
+            assert!(!entry.entry.meta.full_path.is_empty());
+        }
+
+        assert!(count > 10, "{}", count);
+    }
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn test_walk_accessor_ntfs() {
+        let mut accessor = Accessor::with_defaults();
+        let source = accessor.open_source(&"ntfs:C").unwrap();
+        let mut walk = WalkAccessor::new(&source, "").unwrap().max_depth(5);
+
+        let mut count = 0;
+        while let Some(item) = walk.next(&accessor) {
+            let entry = item.unwrap();
+            count += 1;
+            assert!(!entry.entry.meta.full_path.is_empty());
         }
 
         assert!(count > 10, "{}", count);

--- a/forensics/src/artifacts/os/files/filelisting.rs
+++ b/forensics/src/artifacts/os/files/filelisting.rs
@@ -52,7 +52,7 @@ pub(crate) fn get_filelist(
         let firmlink_paths_data = read_firmlinks();
         match firmlink_paths_data {
             Ok(mut firmlinks) => firmlink_paths.append(&mut firmlinks),
-            Err(err) => warn!("[files] Failed to read firmlinks file on macOS: {err:?}"),
+            Err(err) => warn!("Failed to read firmlinks file on macOS: {err:?}"),
         }
     }
 
@@ -71,7 +71,7 @@ pub(crate) fn get_filelist(
         rule = match extract_rule(options.yara.as_ref().unwrap()) {
             Ok(result) => result,
             Err(err) => {
-                error!("[files] Bad yara rule {err:?}");
+                error!("Bad yara rule {err:?}");
                 return Err(FileError::Filelisting);
             }
         };
@@ -84,7 +84,7 @@ pub(crate) fn get_filelist(
         let entry = match entries {
             Ok(result) => result,
             Err(err) => {
-                warn!("[files] Failed to get file info: {err:?}");
+                warn!("Failed to get file info: {err:?}");
                 continue;
             }
         };
@@ -111,7 +111,7 @@ pub(crate) fn get_filelist(
             scan = match scan_result {
                 Ok(result) => result,
                 Err(err) => {
-                    warn!("[files] Failed to scan with yara: {err:?}");
+                    warn!("Failed to scan with yara: {err:?}");
                     continue;
                 }
             };
@@ -125,10 +125,7 @@ pub(crate) fn get_filelist(
         let mut file_entry = match file_entry_result {
             Ok(result) => result,
             Err(err) => {
-                warn!(
-                    "[files] Failed to get file {:?} entry data: {err:?}",
-                    entry.path()
-                );
+                warn!("Failed to get file {:?} entry data: {err:?}", entry.path());
                 continue;
             }
         };
@@ -226,7 +223,7 @@ fn file_metadata(
         file_entry.directory = parent.display().to_string();
     } else {
         info!(
-            "[files] Did not get parent directory for filename at: {:?}",
+            "Did not get parent directory for filename at: {:?}",
             entry.path()
         );
     }
@@ -234,7 +231,7 @@ fn file_metadata(
     if let Some(filename) = entry.file_name().to_str() {
         file_entry.filename = filename.to_string();
     } else {
-        warn!("[files] Failed to get filename for: {:?}", entry.path());
+        warn!("Failed to get filename for: {:?}", entry.path());
     }
     Ok(file_entry)
 }
@@ -277,7 +274,7 @@ fn executable_metadata(path: &str, plat: &PlatformType) -> Result<Value, FileErr
                 Ok(result) => result,
                 Err(err) => {
                     if !err.to_string().contains("Magic Bytes") {
-                        error!("[files] Could not parse ELF file {path} error: {err:?}");
+                        error!("Could not parse ELF file {path} error: {err:?}");
                     }
                     return Err(FileError::ParseFile);
                 }
@@ -289,7 +286,7 @@ fn executable_metadata(path: &str, plat: &PlatformType) -> Result<Value, FileErr
                 Ok(results) => results,
                 Err(err) => {
                     if err != MachoError::Buffer && err != MachoError::Magic {
-                        error!("[files] Failed to parse executable binary {path}, error: {err:?}");
+                        error!("Failed to parse executable binary {path}, error: {err:?}");
                     }
                     return Err(FileError::ParseFile);
                 }
@@ -301,7 +298,7 @@ fn executable_metadata(path: &str, plat: &PlatformType) -> Result<Value, FileErr
                 Ok(result) => result,
                 Err(err) => {
                     if err != pelite::Error::Invalid && err != pelite::Error::BadMagic {
-                        warn!("[files] Could not parse PE file {path}: {err:?}");
+                        warn!("Could not parse PE file {path}: {err:?}");
                     }
                     return Err(FileError::ParseFile);
                 }
@@ -320,7 +317,7 @@ fn user_regex(input: &str) -> Result<Regex, FileError> {
     match reg_result {
         Ok(result) => Ok(result),
         Err(err) => {
-            error!("[files] Bad regex: {input}, error: {err:?}");
+            error!("Bad regex: {input}, error: {err:?}");
             Err(FileError::Regex)
         }
     }

--- a/forensics/src/runtime/filesystem/directory.rs
+++ b/forensics/src/runtime/filesystem/directory.rs
@@ -61,7 +61,7 @@ pub(crate) fn js_read_dir(
         ),
         None,
         context,
-    );
+    )?;
 
     // Return a promise and let setup.rs handle the results
     Ok(promise.into())

--- a/forensics/src/runtime/http/client.rs
+++ b/forensics/src/runtime/http/client.rs
@@ -115,7 +115,7 @@ pub(crate) fn js_request(
         ),
         None,
         context,
-    );
+    )?;
 
     Ok(promise.into())
 }


### PR DESCRIPTION
This PR adds a `WalkAccessor` which builds on `Accessor` it allows artifacts to do a recursive filelisting using the accessors

This can be useful for the filelisting and the triage artifacts which require recursive filelisting support